### PR TITLE
Add X recovery backend and DB-backed claim rounds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 DEPLOYER_PRIVATE_KEY=
 
-# X API bearer token used by scripts/export-x-followers.js
+# X API bearer token used by backend/export-x-followers.js
 X-BEARER-TOKEN=
 X_API_KEY=
 X_API_SECRET=
@@ -10,8 +10,12 @@ X_FRONTEND_RETURN_URLS=http://127.0.0.1:5502/frontend/
 X_AUTH_ALLOWED_ORIGINS=http://127.0.0.1:5502
 X_AUTH_COOKIE_SECURE=auto
 X_AUTH_TRUST_PROXY=false
+LIBERDUS_DB_PATH=data/liberdus.sqlite
+# Import source for follower snapshots. Runtime follower matching now reads from SQLite.
 X_FOLLOWER_SNAPSHOT_FILE=cache/x/liberdus-followers.json
+# Import source for recovery candidates. Supports the processed CSV format and the legacy JSON list.
 X_RECOVERY_CANDIDATES_FILE=cache/x/missing-address-usernames.json
+# Legacy import source for pre-SQLite recovery submissions. New submissions are stored in SQLite.
 X_RECOVERY_STORE_FILE=cache/x/recovery-links.json
 
 # Recommended: use your own RPC provider URLs.

--- a/.env.example
+++ b/.env.example
@@ -1,39 +1,84 @@
+# -----------------------------------------------------------------------------
+# Contract deployment and verification
+# Used by:
+# - hardhat.config.js
+# - scripts/deploy-airdrop.js
+# - scripts/verify-airdrop.js
+# -----------------------------------------------------------------------------
+
 DEPLOYER_PRIVATE_KEY=
 
-# X API bearer token used by backend/export-x-followers.js
-X-BEARER-TOKEN=
-X_API_KEY=
-X_API_SECRET=
-X_OAUTH1_CALLBACK_URL=http://127.0.0.1:8787/api/x/callback
-X_FRONTEND_RETURN_URL=http://127.0.0.1:5502/frontend/
-X_FRONTEND_RETURN_URLS=http://127.0.0.1:5502/frontend/
+# RPCs used for contract deployment/verification.
+BSC_TESTNET_RPC_URL=https://data-seed-prebsc-1-s1.bnbchain.org:8545
+BSC_MAINNET_RPC_URL=https://bsc-dataseed.bnbchain.org
+
+# ERC20 token addresses that EpochMerkleAirdrop should distribute.
+BSC_TESTNET_TOKEN_ADDRESS=
+BSC_MAINNET_TOKEN_ADDRESS=
+
+# Used for BscScan verification.
+BSCSCAN_API_KEY=
+
+# Optional: number of confirmations to wait before verification.
+DEPLOY_CONFIRMATIONS=5
+
+
+# -----------------------------------------------------------------------------
+# Backend server runtime
+# Used by:
+# - backend/server.js
+# - backend/lib/app-config.js
+# -----------------------------------------------------------------------------
+
+# Backend listener
+X_AUTH_HOST=127.0.0.1
+X_AUTH_PORT=8787
+
+# Browser/frontend integration
 X_AUTH_ALLOWED_ORIGINS=http://127.0.0.1:5502
 X_AUTH_COOKIE_SECURE=auto
 X_AUTH_TRUST_PROXY=false
+
+# X OAuth 1.0a app credentials
+X_API_KEY=
+X_API_SECRET=
+X_OAUTH1_CALLBACK_URL=http://127.0.0.1:8787/api/x/callback
+
+# Frontend URLs users return to after X sign-in
+X_FRONTEND_RETURN_URL=http://127.0.0.1:5502/frontend/
+X_FRONTEND_RETURN_URLS=http://127.0.0.1:5502/frontend/
+
+# SQLite + airdrop backend config
 LIBERDUS_DB_PATH=data/liberdus.sqlite
 LIBERDUS_CHAIN_ID=1337
 LIBERDUS_RPC_URL=http://127.0.0.1:8545
 LIBERDUS_AIRDROP_ADDRESS=
 LIBERDUS_DEPLOYMENT_KEY=
-LIBERDUS_CLAIMS_MANIFEST=frontend/claims/generated/index.json
 LIBERDUS_TOKEN_DECIMALS=18
-# Import source for follower snapshots. Runtime follower matching now reads from SQLite.
+
+# Optional backend config overrides
+LIBERDUS_TOKEN_ADDRESS=
+LIBERDUS_API_BASE_URL=
+LIBERDUS_FRONTEND_CONFIG=
+
+
+# -----------------------------------------------------------------------------
+# Optional import/export helper inputs
+# Used by:
+# - backend/import-claim-rounds.js
+# - backend/import-x-followers.js
+# - backend/import-recovery-candidates.js
+# - backend/import-recovery-submissions.js
+# - backend/export-x-followers.js
+# -----------------------------------------------------------------------------
+
+# Optional claim manifest path for one-time claim round import
+LIBERDUS_CLAIMS_MANIFEST=frontend/claims/generated/index.json
+
+# X API bearer token used only by backend/export-x-followers.js
+X-BEARER-TOKEN=
+
+# Optional default import sources
 X_FOLLOWER_SNAPSHOT_FILE=cache/x/liberdus-followers.json
-# Import source for recovery candidates. Supports the processed CSV format and the legacy JSON list.
 X_RECOVERY_CANDIDATES_FILE=cache/x/missing-address-usernames.json
-# Legacy import source for pre-SQLite recovery submissions. New submissions are stored in SQLite.
 X_RECOVERY_STORE_FILE=cache/x/recovery-links.json
-
-# Recommended: use your own RPC provider URLs.
-BSC_TESTNET_RPC_URL=https://data-seed-prebsc-1-s1.bnbchain.org:8545
-BSC_MAINNET_RPC_URL=https://bsc-dataseed.bnbchain.org
-
-# The ERC20 token address that EpochMerkleAirdrop should distribute on each network.
-BSC_TESTNET_TOKEN_ADDRESS=0x48463C89254d001Bdc6B5d2af92d531E60FB4f72
-BSC_MAINNET_TOKEN_ADDRESS=0x5AfdCC93D794762C785Ec14Fb2a24c4aBDbB8aaa
-
-# Used for both BSC testnet and BSC mainnet verification.
-BSCSCAN_API_KEY=
-
-# Optional: number of confirmations to wait before verification.
-DEPLOY_CONFIRMATIONS=5

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ X_AUTH_ALLOWED_ORIGINS=http://127.0.0.1:5502
 X_AUTH_COOKIE_SECURE=auto
 X_AUTH_TRUST_PROXY=false
 LIBERDUS_DB_PATH=data/liberdus.sqlite
+LIBERDUS_CHAIN_ID=1337
+LIBERDUS_RPC_URL=http://127.0.0.1:8545
+LIBERDUS_AIRDROP_ADDRESS=
+LIBERDUS_DEPLOYMENT_KEY=
+LIBERDUS_CLAIMS_MANIFEST=frontend/claims/generated/index.json
+LIBERDUS_TOKEN_DECIMALS=18
 # Import source for follower snapshots. Runtime follower matching now reads from SQLite.
 X_FOLLOWER_SNAPSHOT_FILE=cache/x/liberdus-followers.json
 # Import source for recovery candidates. Supports the processed CSV format and the legacy JSON list.

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,19 @@
 DEPLOYER_PRIVATE_KEY=
 
+# X API bearer token used by scripts/export-x-followers.js
+X-BEARER-TOKEN=
+X_API_KEY=
+X_API_SECRET=
+X_OAUTH1_CALLBACK_URL=http://127.0.0.1:8787/api/x/callback
+X_FRONTEND_RETURN_URL=http://127.0.0.1:5502/frontend/
+X_FRONTEND_RETURN_URLS=http://127.0.0.1:5502/frontend/
+X_AUTH_ALLOWED_ORIGINS=http://127.0.0.1:5502
+X_AUTH_COOKIE_SECURE=auto
+X_AUTH_TRUST_PROXY=false
+X_FOLLOWER_SNAPSHOT_FILE=cache/x/liberdus-followers.json
+X_RECOVERY_CANDIDATES_FILE=cache/x/missing-address-usernames.json
+X_RECOVERY_STORE_FILE=cache/x/recovery-links.json
+
 # Recommended: use your own RPC provider URLs.
 BSC_TESTNET_RPC_URL=https://data-seed-prebsc-1-s1.bnbchain.org:8545
 BSC_MAINNET_RPC_URL=https://bsc-dataseed.bnbchain.org

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 artifacts/
 cache/
+data/
 coverage/
 .vscode/
 .env

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npm run fund:owner:local
 ```
 
 `npm run deploy:local` writes `frontend/config.local.json` with the current local deployment addresses used by the frontend.
+It also writes a fresh `deploymentKey` each time so local Hardhat resets and redeploys do not collide with older airdrop rounds stored in SQLite.
 
 For hosted deployments, the frontend reads `frontend/config.json`. Publish the right config file before deploying:
 
@@ -90,12 +91,13 @@ Serve the repo with any static file server, then open:
 - `/frontend/index.html` for the claimant page
 - `/frontend/admin.html` for the owner-only admin page
 
-Hosted claim rounds are listed in `frontend/claims/index.json`. Each entry points at the raw claims JSON for one epoch. The claimant page loads those raw files, computes the Merkle tree in the browser, and generates proofs client-side.
+Claim rounds now live in the backend SQLite database. The claim page reads wallet-specific proofs from the backend, and the admin page saves newly started rounds into that database after the `startNewAirdrop` transaction confirms on chain.
 
 The claimant page also supports X sign-in through the `xAuth` block in each frontend config file:
 
 ```json
 {
+  "apiBaseUrl": "https://your-backend.example",
   "xAuth": {
     "enabled": true,
     "redirectUri": "https://your-site.example/frontend/index.html",
@@ -133,6 +135,12 @@ X_AUTH_ALLOWED_ORIGINS=http://127.0.0.1:5502
 X_AUTH_COOKIE_SECURE=auto
 X_AUTH_TRUST_PROXY=false
 LIBERDUS_DB_PATH=data/liberdus.sqlite
+LIBERDUS_CHAIN_ID=1337
+LIBERDUS_RPC_URL=http://127.0.0.1:8545
+LIBERDUS_AIRDROP_ADDRESS=
+LIBERDUS_DEPLOYMENT_KEY=
+LIBERDUS_CLAIMS_MANIFEST=frontend/claims/generated/index.json
+LIBERDUS_TOKEN_DECIMALS=18
 X_FOLLOWER_SNAPSHOT_FILE=cache/x/liberdus-followers.json
 X_RECOVERY_CANDIDATES_FILE=cache/x/missing-address-usernames.json
 # Legacy import source for pre-SQLite recovery submissions.
@@ -143,6 +151,8 @@ Then set local frontend config like:
 
 ```json
 {
+  "apiBaseUrl": "http://127.0.0.1:8787",
+  "deploymentKey": "local:your-current-deploy-id",
   "xAuth": {
     "enabled": true,
     "redirectUri": "http://127.0.0.1:5502/frontend/",
@@ -177,6 +187,20 @@ npm run recovery-submissions:import
 
 That command reads `X_RECOVERY_STORE_FILE` as a legacy import source and writes those rows into `recovery_submissions`.
 
+To seed the DB with the existing file-backed claim rounds once, run:
+
+```bash
+npm run claim-rounds:import
+```
+
+That command reads `LIBERDUS_CLAIMS_MANIFEST`, rebuilds each round server-side, and stores finalized proofs in `airdrop_rounds` / `airdrop_claims`. If the imported root matches the live on-chain epoch, the importer also stores the current deadline from chain.
+
+Round identity is now namespaced by `deploymentKey`. The backend stores rounds under `(deploymentKey, epoch)`, so:
+
+- production/test deployments can keep a stable key, such as `chainId:contractAddress`
+- local deployments should use a fresh key every time `npm run deploy:local` runs
+- old rounds and claims can stay in SQLite for history, but they will not leak into the current deployment once the key changes
+
 The local auth server:
 
 - starts the OAuth 1.0a request-token flow server-side
@@ -193,6 +217,7 @@ The local auth server:
 - reads follower matches from the `x_accounts` table in `LIBERDUS_DB_PATH`
 - reads recovery-candidate flags from the `x_accounts` table in `LIBERDUS_DB_PATH`
 - stores recovery proof submissions in the `recovery_submissions` table in `LIBERDUS_DB_PATH`
+- stores finalized airdrop rounds in `airdrop_rounds` / `airdrop_claims` in `LIBERDUS_DB_PATH`
 - flags whether the username matched:
   - the imported follower snapshot data in `LIBERDUS_DB_PATH`
   - the latest imported recovery-candidate set in `LIBERDUS_DB_PATH`

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ For local development:
 npm run xauth:local
 ```
 
+The local backend now lives under `backend/`.
+
 The local auth server reads these environment variables from `.env`:
 
 ```dotenv
@@ -130,8 +132,10 @@ X_FRONTEND_RETURN_URLS=http://127.0.0.1:5502/frontend/
 X_AUTH_ALLOWED_ORIGINS=http://127.0.0.1:5502
 X_AUTH_COOKIE_SECURE=auto
 X_AUTH_TRUST_PROXY=false
+LIBERDUS_DB_PATH=data/liberdus.sqlite
 X_FOLLOWER_SNAPSHOT_FILE=cache/x/liberdus-followers.json
 X_RECOVERY_CANDIDATES_FILE=cache/x/missing-address-usernames.json
+# Legacy import source for pre-SQLite recovery submissions.
 X_RECOVERY_STORE_FILE=cache/x/recovery-links.json
 ```
 
@@ -149,6 +153,30 @@ Then set local frontend config like:
 
 For production, set `X_AUTH_COOKIE_SECURE=true` behind HTTPS and configure `X_AUTH_TRUST_PROXY=true` only if the server is behind a trusted reverse proxy that sets `X-Forwarded-For`.
 
+Follower matching now reads from SQLite, not directly from the raw follower export JSON. Import the latest snapshot into the DB before running the auth server:
+
+```bash
+npm run followers:import
+```
+
+That command reads `X_FOLLOWER_SNAPSHOT_FILE`, upserts the latest follower state into `x_accounts`, and updates per-account snapshot rollups in `LIBERDUS_DB_PATH` so you can track how many snapshots an account has appeared in and when it was first or last seen.
+
+Recovery-candidate matching also reads from SQLite. Import the latest processed candidate list before running the auth server:
+
+```bash
+npm run recovery-candidates:import -- --file "C:\path\to\api_followers_not_seen_in_airdrop_rewards_....csv"
+```
+
+That command reads `X_RECOVERY_CANDIDATES_FILE` by default, supports both the processed CSV format and the legacy JSON username list, and marks the latest recovery-candidate set on `x_accounts` in `LIBERDUS_DB_PATH`.
+
+If you want to pull old JSON submissions into SQLite once, run:
+
+```bash
+npm run recovery-submissions:import
+```
+
+That command reads `X_RECOVERY_STORE_FILE` as a legacy import source and writes those rows into `recovery_submissions`.
+
 The local auth server:
 
 - starts the OAuth 1.0a request-token flow server-side
@@ -162,10 +190,12 @@ The local auth server:
 - rate limits the auth, challenge, and save endpoints
 - issues a wallet-signature challenge tied to the signed-in X account
 - verifies the wallet signature on the backend
-- stores the resulting wallet/X pair in `X_RECOVERY_STORE_FILE`
+- reads follower matches from the `x_accounts` table in `LIBERDUS_DB_PATH`
+- reads recovery-candidate flags from the `x_accounts` table in `LIBERDUS_DB_PATH`
+- stores recovery proof submissions in the `recovery_submissions` table in `LIBERDUS_DB_PATH`
 - flags whether the username matched:
-  - the follower snapshot in `X_FOLLOWER_SNAPSHOT_FILE`
-  - the optional recovery candidate list in `X_RECOVERY_CANDIDATES_FILE`
+  - the imported follower snapshot data in `LIBERDUS_DB_PATH`
+  - the latest imported recovery-candidate set in `LIBERDUS_DB_PATH`
 
 `X_RECOVERY_CANDIDATES_FILE` is optional. If present, it can be either:
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,95 @@ Serve the repo with any static file server, then open:
 
 Hosted claim rounds are listed in `frontend/claims/index.json`. Each entry points at the raw claims JSON for one epoch. The claimant page loads those raw files, computes the Merkle tree in the browser, and generates proofs client-side.
 
+The claimant page also supports X sign-in through the `xAuth` block in each frontend config file:
+
+```json
+{
+  "xAuth": {
+    "enabled": true,
+    "redirectUri": "https://your-site.example/frontend/index.html",
+    "backendUrl": "https://your-auth-server.example"
+  }
+}
+```
+
+This repo now uses X OAuth 1.0a for the recovery flow. The frontend `redirectUri` is the page users should return to after the backend finishes the X callback. The actual callback registered in the X app settings must point at your backend callback endpoint, not the frontend page.
+
+On the claim page, the X recovery flow is shown only when:
+
+- a wallet is connected
+- that wallet has no claim entries across the loaded rounds
+
+After the user signs in with X, the page requests a wallet signature and submits the signed wallet/X pairing to the backend for storage.
+
+For local development:
+
+```bash
+npm run xauth:local
+```
+
+The local auth server reads these environment variables from `.env`:
+
+```dotenv
+X_API_KEY=
+X_API_SECRET=
+X_OAUTH1_CALLBACK_URL=http://127.0.0.1:8787/api/x/callback
+X_FRONTEND_RETURN_URL=http://127.0.0.1:5502/frontend/
+X_FRONTEND_RETURN_URLS=http://127.0.0.1:5502/frontend/
+X_AUTH_ALLOWED_ORIGINS=http://127.0.0.1:5502
+X_AUTH_COOKIE_SECURE=auto
+X_AUTH_TRUST_PROXY=false
+X_FOLLOWER_SNAPSHOT_FILE=cache/x/liberdus-followers.json
+X_RECOVERY_CANDIDATES_FILE=cache/x/missing-address-usernames.json
+X_RECOVERY_STORE_FILE=cache/x/recovery-links.json
+```
+
+Then set local frontend config like:
+
+```json
+{
+  "xAuth": {
+    "enabled": true,
+    "redirectUri": "http://127.0.0.1:5502/frontend/",
+    "backendUrl": "http://127.0.0.1:8787"
+  }
+}
+```
+
+For production, set `X_AUTH_COOKIE_SECURE=true` behind HTTPS and configure `X_AUTH_TRUST_PROXY=true` only if the server is behind a trusted reverse proxy that sets `X-Forwarded-For`.
+
+The local auth server:
+
+- starts the OAuth 1.0a request-token flow server-side
+- receives the X callback at `X_OAUTH1_CALLBACK_URL`
+- exchanges the request token for an access token and token secret
+- uses the username returned by X when available, and falls back to `account/verify_credentials` only if needed
+- keeps a short-lived X session in memory using an HttpOnly cookie
+- allows only exact frontend return URLs listed in `X_FRONTEND_RETURN_URLS`
+- binds the login handoff to the initiating browser before accepting the X callback
+- requires allowed browser origins plus a CSRF token on state-changing requests
+- rate limits the auth, challenge, and save endpoints
+- issues a wallet-signature challenge tied to the signed-in X account
+- verifies the wallet signature on the backend
+- stores the resulting wallet/X pair in `X_RECOVERY_STORE_FILE`
+- flags whether the username matched:
+  - the follower snapshot in `X_FOLLOWER_SNAPSHOT_FILE`
+  - the optional recovery candidate list in `X_RECOVERY_CANDIDATES_FILE`
+
+`X_RECOVERY_CANDIDATES_FILE` is optional. If present, it can be either:
+
+```json
+["alice", "bob", "charlie"]
+```
+
+or:
+
+```json
+{
+  "usernames": ["alice", "bob", "charlie"]
+}
+```
+
 ## Merkle CLI
 
 Use the CLI to validate an offline claims file and print the Merkle root and total amount:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ npm run verify:airdrop:bsc:mainnet
 
 The frontend lives in `frontend/` and is served without any frontend framework or build step.
 
+For server deployment, PM2, and SQLite account import instructions, see [SERVER_DEPLOYMENT.md](</C:/Users/Chris/Documents/Code/liberdus/follower-campaign/liberdus-airdrop/SERVER_DEPLOYMENT.md>).
+
 ```bash
 npm run node
 npm run deploy:local

--- a/SERVER_DEPLOYMENT.md
+++ b/SERVER_DEPLOYMENT.md
@@ -1,0 +1,325 @@
+# Server Deployment
+
+This document covers:
+
+- running the backend with PM2
+- hosting both test and prod on the same server
+- loading the X account / wallet data into SQLite
+
+This repo is designed to work well with one backend process per environment. If you run both test and prod on the same server, keep them in separate directories with separate `.env` files, separate PM2 app names, separate backend ports, and separate SQLite files.
+
+## Recommended Layout
+
+Example:
+
+```text
+/srv/liberdus-airdrop-prod
+/srv/liberdus-airdrop-test
+```
+
+Each directory should contain its own checkout of this repo.
+
+Recommended per-environment separation:
+
+- prod backend port: `8787`
+- test backend port: `8788`
+- prod PM2 app name: `liberdus-airdrop-prod`
+- test PM2 app name: `liberdus-airdrop-test`
+- prod DB path: `data/liberdus.sqlite` inside the prod checkout
+- test DB path: `data/liberdus.sqlite` inside the test checkout
+
+Because the checkouts are separate, the default `data/liberdus.sqlite` path is already isolated. You only need to override `LIBERDUS_DB_PATH` if you want the DB somewhere else.
+
+## 1. Install
+
+Run this once in each directory:
+
+```bash
+npm ci
+```
+
+## 2. Configure `.env`
+
+Create `.env` in each directory from `.env.example`.
+
+Minimum backend fields:
+
+```dotenv
+X_AUTH_HOST=127.0.0.1
+X_AUTH_PORT=8787
+X_AUTH_ALLOWED_ORIGINS=https://airdrop.example.com
+X_AUTH_COOKIE_SECURE=true
+X_AUTH_TRUST_PROXY=true
+
+X_API_KEY=
+X_API_SECRET=
+X_OAUTH1_CALLBACK_URL=https://airdrop.example.com/api/x/callback
+X_FRONTEND_RETURN_URL=https://airdrop.example.com/
+X_FRONTEND_RETURN_URLS=https://airdrop.example.com/
+
+LIBERDUS_DB_PATH=data/liberdus.sqlite
+LIBERDUS_CHAIN_ID=56
+LIBERDUS_RPC_URL=https://your-rpc.example
+LIBERDUS_AIRDROP_ADDRESS=0x...
+LIBERDUS_DEPLOYMENT_KEY=56:0x...
+LIBERDUS_TOKEN_DECIMALS=18
+```
+
+For test, use the test domain, test port, test chain ID, test contract address, and a different `LIBERDUS_DEPLOYMENT_KEY`.
+
+Notes:
+
+- `LIBERDUS_DEPLOYMENT_KEY` is the namespace for stored airdrop rounds. Keep it stable for a real deployment.
+- `X_OAUTH1_CALLBACK_URL` must be the backend callback URL.
+- `X_FRONTEND_RETURN_URL` and `X_FRONTEND_RETURN_URLS` must exactly match the claim page URL users return to after X sign-in.
+- `X_AUTH_ALLOWED_ORIGINS` must match the frontend origin exactly.
+
+## 3. Configure the Frontend
+
+This repo expects the frontend to load `frontend/config.json`.
+
+For prod:
+
+```bash
+cp frontend/config.prod.json frontend/config.json
+```
+
+For test:
+
+```bash
+cp frontend/config.test.json frontend/config.json
+```
+
+Then edit `frontend/config.json` for that environment.
+
+Important fields:
+
+```json
+{
+  "chainId": 56,
+  "rpcUrl": "https://your-rpc.example",
+  "tokenAddress": "0x...",
+  "airdropAddress": "0x...",
+  "apiBaseUrl": "https://airdrop.example.com",
+  "deploymentKey": "56:0x...",
+  "xAuth": {
+    "enabled": true,
+    "redirectUri": "https://airdrop.example.com/",
+    "backendUrl": "https://airdrop.example.com"
+  }
+}
+```
+
+Notes:
+
+- `apiBaseUrl` is the backend base URL, not `/api`.
+- `xAuth.backendUrl` should normally match `apiBaseUrl`.
+- `deploymentKey` must match `LIBERDUS_DEPLOYMENT_KEY` in `.env`.
+
+## 4. Load Account Data Into SQLite
+
+The backend creates the SQLite file automatically the first time you run an importer or the server.
+
+The simplest path is the combined accounts importer:
+
+```bash
+npm run accounts:import -- --file /absolute/path/to/combined_followers_and_responses_latest_api_only.csv
+```
+
+### Supported Combined CSV Headers
+
+The importer in [backend/import-accounts.js](</C:/Users/Chris/Documents/Code/liberdus/follower-campaign/liberdus-airdrop/backend/import-accounts.js>) understands these columns:
+
+```csv
+x_username,wallet_address,x_user_id,x_account_created_at,is_follower,needs_recovery,first_seen_following_at,last_seen_following_at,snapshots_seen_count,latest_snapshot_captured_at
+```
+
+What they mean:
+
+- `x_username`: X username, with or without `@`
+- `wallet_address`: wallet from the form, if known
+- `x_user_id`: stable X user ID, if known
+- `x_account_created_at`: X account creation timestamp, if known
+- `is_follower`: `true` / `false`
+- `needs_recovery`: `true` / `false`
+- `first_seen_following_at`: earliest snapshot timestamp where the account was seen
+- `last_seen_following_at`: most recent snapshot timestamp where the account was seen
+- `snapshots_seen_count`: number of snapshots the account appeared in
+- `latest_snapshot_captured_at`: timestamp of the latest snapshot used for that row
+
+Practical minimum:
+
+```csv
+x_username,wallet_address,x_user_id,is_follower,needs_recovery
+```
+
+Behavior:
+
+- rows are keyed by `x_user_id` when present, otherwise lowercase username
+- existing `wallet_address` values are not overwritten
+- `wallet_source` is set to `form` when `wallet_address` is provided by this importer
+
+### Raw Imports If You Need Them
+
+If you want to import from the raw sources instead of a combined CSV:
+
+```bash
+npm run followers:import -- --file /absolute/path/to/followers.json
+npm run recovery-candidates:import -- --file /absolute/path/to/recovery-candidates.csv
+npm run recovery-submissions:import -- --file /absolute/path/to/recovery-links.json
+```
+
+## 5. Optional: Seed Old Claim Rounds
+
+If you need to load existing file-backed claims into SQLite once:
+
+```bash
+npm run claim-rounds:import
+```
+
+That reads `LIBERDUS_CLAIMS_MANIFEST` and stores rounds in:
+
+- `airdrop_rounds`
+- `airdrop_claims`
+
+Those rows are namespaced by `deployment_key`.
+
+## 6. Run the Backend With PM2
+
+This repo includes [backend/pm2.config.cjs](</C:/Users/Chris/Documents/Code/liberdus/follower-campaign/liberdus-airdrop/backend/pm2.config.cjs>) and these package scripts:
+
+```bash
+npm run pm2:start
+npm run pm2:restart
+npm run pm2:stop
+npm run pm2:delete
+npm run pm2:status
+```
+
+For same-server test and prod, set a different PM2 app name in each directory when starting:
+
+Prod:
+
+```bash
+PM2_APP_NAME=liberdus-airdrop-prod npm run pm2:start
+```
+
+Test:
+
+```bash
+PM2_APP_NAME=liberdus-airdrop-test npm run pm2:start
+```
+
+After the first successful start:
+
+```bash
+npx pm2 save
+npx pm2 startup
+```
+
+Useful commands:
+
+```bash
+PM2_APP_NAME=liberdus-airdrop-prod npm run pm2:restart
+PM2_APP_NAME=liberdus-airdrop-test npm run pm2:restart
+pm2 logs liberdus-airdrop-prod
+pm2 logs liberdus-airdrop-test
+pm2 status
+```
+
+## 7. Recommended Nginx Layout
+
+A practical setup is:
+
+- serve the static frontend from `frontend/`
+- proxy `/api/` to the local backend port
+
+Example prod server block:
+
+```nginx
+server {
+    server_name airdrop.example.com;
+
+    root /srv/liberdus-airdrop-prod/frontend;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8787/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Example test server block:
+
+```nginx
+server {
+    server_name test-airdrop.example.com;
+
+    root /srv/liberdus-airdrop-test/frontend;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8788/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+If you serve the frontend from site root like this, use:
+
+- `https://airdrop.example.com/` as the X return URL
+- `https://airdrop.example.com/api/x/callback` as the X callback URL
+
+If you instead serve it at `/frontend/`, then use `/frontend/` everywhere consistently. Exact match matters.
+
+## 8. Deploy / Update Flow
+
+For each environment:
+
+```bash
+git pull
+npm ci
+cp frontend/config.prod.json frontend/config.json   # or config.test.json
+# update frontend/config.json if needed
+# update .env if needed
+npm run accounts:import -- --file /absolute/path/to/latest-combined.csv
+PM2_APP_NAME=liberdus-airdrop-prod npm run pm2:restart
+```
+
+Use the matching PM2 app name for test.
+
+## 9. Sanity Checks
+
+Check backend health locally on the server:
+
+```bash
+curl http://127.0.0.1:8787/health
+```
+
+Check PM2:
+
+```bash
+pm2 status
+pm2 logs liberdus-airdrop-prod
+```
+
+Check that the frontend config and backend `.env` agree on:
+
+- chain ID
+- airdrop contract address
+- deployment key
+- backend base URL
+- X callback / return URLs

--- a/backend/export-x-followers.js
+++ b/backend/export-x-followers.js
@@ -1,0 +1,473 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const dotenv = require("dotenv");
+
+const API_BASE_URL = "https://api.x.com/2";
+const DEFAULT_USERNAME = "liberdus";
+const DEFAULT_OUTPUT_PATH = path.join("cache", "x", `${DEFAULT_USERNAME}-followers.json`);
+const DEFAULT_MAX_RESULTS = 1000;
+const MAX_ATTEMPTS = 6;
+const REQUEST_TIMEOUT_MS = 30_000;
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+const USER_CONTEXT_ONLY_USER_FIELDS = [
+  {
+    field: "confirmed_email",
+    reason: "Requires the users.email scope and only applies to the authenticated user.",
+  },
+  {
+    field: "connection_status",
+    reason: "Depends on the relationship between the authenticating user and the looked-up user.",
+  },
+  {
+    field: "receives_your_dm",
+    reason: "Depends on the relationship between the authenticating user and the looked-up user.",
+  },
+  {
+    field: "subscription",
+    reason: "Describes whether the looked-up user is subscribed to the authenticated user.",
+  },
+  {
+    field: "subscription_type",
+    reason: "Describes the authenticated user's own Premium subscription tier.",
+  },
+];
+const USER_FIELDS = [
+  "affiliation",
+  "created_at",
+  "description",
+  "entities",
+  "id",
+  "is_identity_verified",
+  "location",
+  "most_recent_tweet_id",
+  "name",
+  "parody",
+  "pinned_tweet_id",
+  "profile_banner_url",
+  "profile_image_url",
+  "protected",
+  "public_metrics",
+  "url",
+  "username",
+  "verified",
+  "verified_followers_count",
+  "verified_type",
+  "withheld",
+];
+
+function usage() {
+  console.error(
+    [
+      "Usage:",
+      "  node backend/export-x-followers.js [--username <handle>] [--out <output.json>] [--max-results <1-1000>] [--force]",
+      "",
+      "Defaults:",
+      `  username: ${DEFAULT_USERNAME}`,
+      `  out: ${DEFAULT_OUTPUT_PATH}`,
+      `  max-results: ${DEFAULT_MAX_RESULTS}`,
+      "",
+      "Behavior:",
+      "  - reads X-BEARER-TOKEN from .env",
+      `  - requests all app-only user fields X exposes for public lookups (${USER_FIELDS.length} fields)`,
+      "  - checkpoints progress after every page to a .partial.json file",
+      "  - refuses to overwrite an existing completed snapshot unless --force is passed",
+    ].join("\n"),
+  );
+}
+
+function parseArgs(argv) {
+  const options = {
+    username: DEFAULT_USERNAME,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    maxResults: DEFAULT_MAX_RESULTS,
+    force: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--username") {
+      options.username = (argv[++index] || "").trim();
+      continue;
+    }
+
+    if (arg === "--out") {
+      options.outputPath = (argv[++index] || "").trim();
+      continue;
+    }
+
+    if (arg === "--max-results") {
+      options.maxResults = Number(argv[++index]);
+      continue;
+    }
+
+    if (arg === "--force") {
+      options.force = true;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!options.username) {
+    throw new Error("`--username` is required.");
+  }
+
+  if (!options.outputPath) {
+    throw new Error("`--out` is required.");
+  }
+
+  if (!Number.isInteger(options.maxResults) || options.maxResults < 1 || options.maxResults > 1000) {
+    throw new Error("`--max-results` must be an integer between 1 and 1000.");
+  }
+
+  return options;
+}
+
+function resolvePaths(outputPath) {
+  const repoRoot = path.resolve(__dirname, "..");
+  const resolvedOutputPath = path.resolve(repoRoot, outputPath);
+  const partialPath = resolvedOutputPath.endsWith(".json")
+    ? resolvedOutputPath.replace(/\.json$/i, ".partial.json")
+    : `${resolvedOutputPath}.partial.json`;
+
+  return {
+    repoRoot,
+    outputPath: resolvedOutputPath,
+    partialPath,
+  };
+}
+
+function loadBearerToken(repoRoot) {
+  dotenv.config({ path: path.join(repoRoot, ".env"), quiet: true });
+
+  const token = process.env["X-BEARER-TOKEN"];
+  if (!token || !token.trim()) {
+    throw new Error("Missing `X-BEARER-TOKEN` in .env.");
+  }
+
+  return token.trim();
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function describeRetryDelayMs(response, attempt) {
+  const retryAfterHeader = response.headers.get("retry-after");
+  if (retryAfterHeader) {
+    const retryAfterSeconds = Number(retryAfterHeader);
+    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+      return retryAfterSeconds * 1000;
+    }
+  }
+
+  const resetHeader = response.headers.get("x-rate-limit-reset");
+  if (resetHeader) {
+    const resetAtMs = Number(resetHeader) * 1000;
+    if (Number.isFinite(resetAtMs)) {
+      return Math.max(resetAtMs - Date.now() + 1_000, 1_000);
+    }
+  }
+
+  return Math.min(60_000, 2_000 * (2 ** (attempt - 1)));
+}
+
+function isRetryableError(error) {
+  return (
+    error &&
+    typeof error === "object" &&
+    (
+      error.name === "AbortError" ||
+      error.code === "ECONNRESET" ||
+      error.code === "ETIMEDOUT" ||
+      error.code === "UND_ERR_CONNECT_TIMEOUT" ||
+      error.code === "UND_ERR_HEADERS_TIMEOUT"
+    )
+  );
+}
+
+async function parseJsonResponse(response) {
+  const text = await response.text();
+  if (!text) return {};
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}
+
+async function fetchJson(url, bearerToken, label, attempt = 1) {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${bearerToken}`,
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    const payload = await parseJsonResponse(response);
+
+    if (response.ok) {
+      return payload;
+    }
+
+    if (RETRYABLE_STATUS_CODES.has(response.status) && attempt < MAX_ATTEMPTS) {
+      const delayMs = describeRetryDelayMs(response, attempt);
+      console.error(
+        `${label} returned HTTP ${response.status}; retrying in ${Math.ceil(delayMs / 1000)}s (attempt ${attempt}/${MAX_ATTEMPTS})`,
+      );
+      await sleep(delayMs);
+      return fetchJson(url, bearerToken, label, attempt + 1);
+    }
+
+    const detail = typeof payload === "object" ? JSON.stringify(payload) : String(payload);
+    throw new Error(`${label} failed with HTTP ${response.status}: ${detail}`);
+  } catch (error) {
+    if (attempt < MAX_ATTEMPTS && isRetryableError(error)) {
+      const delayMs = Math.min(60_000, 2_000 * (2 ** (attempt - 1)));
+      console.error(
+        `${label} failed with ${error.name || "network error"}; retrying in ${Math.ceil(delayMs / 1000)}s (attempt ${attempt}/${MAX_ATTEMPTS})`,
+      );
+      await sleep(delayMs);
+      return fetchJson(url, bearerToken, label, attempt + 1);
+    }
+
+    throw error;
+  }
+}
+
+function ensureDirectory(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function writeJson(filePath, value) {
+  ensureDirectory(filePath);
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function removeFileIfExists(filePath) {
+  if (fs.existsSync(filePath)) {
+    fs.rmSync(filePath);
+  }
+}
+
+async function lookupUser(username, bearerToken) {
+  const url = new URL(`${API_BASE_URL}/users/by/username/${encodeURIComponent(username)}`);
+  url.searchParams.set("user.fields", USER_FIELDS.join(","));
+
+  const response = await fetchJson(url, bearerToken, `lookup @${username}`);
+  if (!response || !response.data || !response.data.id) {
+    throw new Error(`Could not resolve @${username} to a user ID.`);
+  }
+
+  return response.data;
+}
+
+function createInitialState(options, sourceUser) {
+  const startedAt = new Date().toISOString();
+
+  return {
+    version: 1,
+    complete: false,
+    startedAt,
+    updatedAt: startedAt,
+    completedAt: null,
+    username: options.username,
+    sourceUser,
+    request: {
+      apiBaseUrl: API_BASE_URL,
+      maxResults: options.maxResults,
+      userFields: USER_FIELDS,
+      omittedUserFields: USER_CONTEXT_ONLY_USER_FIELDS,
+    },
+    resume: {
+      page: 0,
+      nextToken: null,
+    },
+    stats: {
+      fetchedUsers: 0,
+      pagesFetched: 0,
+      duplicatesSkipped: 0,
+      apiErrors: 0,
+      sourceFollowersCount: sourceUser.public_metrics?.followers_count ?? null,
+    },
+    pageSummaries: [],
+    apiErrors: [],
+    followers: [],
+  };
+}
+
+function loadState(options, paths) {
+  if (fs.existsSync(paths.outputPath) && !options.force) {
+    return {
+      state: null,
+      skipReason: `Completed snapshot already exists at ${paths.outputPath}. Re-run with --force to fetch again.`,
+    };
+  }
+
+  if (options.force) {
+    removeFileIfExists(paths.outputPath);
+    removeFileIfExists(paths.partialPath);
+  }
+
+  if (!fs.existsSync(paths.partialPath)) {
+    return {
+      state: null,
+      skipReason: null,
+    };
+  }
+
+  const state = readJson(paths.partialPath);
+  if (state.username !== options.username) {
+    throw new Error(
+      `Checkpoint username mismatch: expected @${options.username}, found @${state.username}. Use --force to start fresh.`,
+    );
+  }
+
+  if (state.request?.maxResults !== options.maxResults) {
+    throw new Error(
+      `Checkpoint max-results mismatch: expected ${options.maxResults}, found ${state.request?.maxResults}. Use --force to start fresh.`,
+    );
+  }
+
+  return {
+    state,
+    skipReason: null,
+  };
+}
+
+function createFollowerRequest(userId, maxResults, nextToken) {
+  const url = new URL(`${API_BASE_URL}/users/${userId}/followers`);
+  url.searchParams.set("max_results", String(maxResults));
+  url.searchParams.set("user.fields", USER_FIELDS.join(","));
+
+  if (nextToken) {
+    url.searchParams.set("pagination_token", nextToken);
+  }
+
+  return url;
+}
+
+function summarizePage(response, pageNumber, requestedToken, usersReturned, usersAdded) {
+  return {
+    page: pageNumber,
+    fetchedAt: new Date().toISOString(),
+    requestedToken: requestedToken || null,
+    nextToken: response.meta?.next_token ?? null,
+    resultCount: response.meta?.result_count ?? usersReturned,
+    usersReturned,
+    usersAdded,
+    errorCount: Array.isArray(response.errors) ? response.errors.length : 0,
+  };
+}
+
+async function exportFollowers(options, paths, bearerToken) {
+  const loaded = loadState(options, paths);
+  if (loaded.skipReason) {
+    console.log(loaded.skipReason);
+    return;
+  }
+
+  const state = loaded.state || createInitialState(options, await lookupUser(options.username, bearerToken));
+  const seenIds = new Set(state.followers.map((user) => user.id));
+
+  if (loaded.state) {
+    console.log(
+      `Resuming @${state.username} export from page ${state.resume.page + 1} with ${state.followers.length} users already saved.`,
+    );
+  } else {
+    writeJson(paths.partialPath, state);
+    console.log(`Resolved @${state.username} to user ID ${state.sourceUser.id}.`);
+    console.log(
+      `Skipping auth-context-only user fields: ${USER_CONTEXT_ONLY_USER_FIELDS.map((entry) => entry.field).join(", ")}.`,
+    );
+  }
+
+  while (true) {
+    const requestedToken = state.resume.nextToken;
+    const pageNumber = state.resume.page + 1;
+    const url = createFollowerRequest(state.sourceUser.id, options.maxResults, requestedToken);
+    const response = await fetchJson(url, bearerToken, `followers page ${pageNumber}`);
+    const pageUsers = Array.isArray(response.data) ? response.data : [];
+    const pageErrors = Array.isArray(response.errors) ? response.errors : [];
+
+    let usersAdded = 0;
+
+    for (const user of pageUsers) {
+      if (!user || !user.id) {
+        continue;
+      }
+
+      if (seenIds.has(user.id)) {
+        state.stats.duplicatesSkipped += 1;
+        continue;
+      }
+
+      seenIds.add(user.id);
+      state.followers.push(user);
+      usersAdded += 1;
+    }
+
+    state.pageSummaries.push(summarizePage(response, pageNumber, requestedToken, pageUsers.length, usersAdded));
+
+    if (pageErrors.length > 0) {
+      state.apiErrors.push(
+        ...pageErrors.map((error) => ({
+          page: pageNumber,
+          receivedAt: new Date().toISOString(),
+          ...error,
+        })),
+      );
+    }
+
+    state.resume.page = pageNumber;
+    state.resume.nextToken = response.meta?.next_token ?? null;
+    state.stats.fetchedUsers = state.followers.length;
+    state.stats.pagesFetched = state.pageSummaries.length;
+    state.stats.apiErrors = state.apiErrors.length;
+    state.updatedAt = new Date().toISOString();
+
+    writeJson(paths.partialPath, state);
+
+    console.log(
+      `Page ${pageNumber}: returned ${pageUsers.length}, added ${usersAdded}, total saved ${state.followers.length}.`,
+    );
+
+    if (!state.resume.nextToken) {
+      break;
+    }
+  }
+
+  state.complete = true;
+  state.completedAt = new Date().toISOString();
+  state.updatedAt = state.completedAt;
+  state.resume.nextToken = null;
+
+  writeJson(paths.outputPath, state);
+  removeFileIfExists(paths.partialPath);
+
+  console.log(`Saved ${state.followers.length} followers for @${state.username} to ${paths.outputPath}`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const paths = resolvePaths(options.outputPath);
+  const bearerToken = loadBearerToken(paths.repoRoot);
+
+  await exportFollowers(options, paths, bearerToken);
+}
+
+main().catch((error) => {
+  console.error(error.message || String(error));
+  usage();
+  process.exitCode = 1;
+});

--- a/backend/import-accounts.js
+++ b/backend/import-accounts.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const dotenv = require("dotenv");
 
 const { openDatabase, resolveRepoPath } = require("./lib/db");
+const { loadAppConfig } = require("./lib/app-config");
 const { createAccountStore } = require("./lib/x-account-store");
 
 dotenv.config({ path: path.join(__dirname, "..", ".env"), quiet: true });
@@ -52,6 +53,7 @@ function parseArgs(argv) {
 
 function main() {
   const options = parseArgs(process.argv.slice(2));
+  const appConfig = loadAppConfig();
   const db = openDatabase();
   const accountStore = createAccountStore(db);
   const resolvedFilePath = resolveRepoPath(options.filePath);

--- a/backend/import-accounts.js
+++ b/backend/import-accounts.js
@@ -1,0 +1,78 @@
+const path = require("node:path");
+
+const dotenv = require("dotenv");
+
+const { openDatabase, resolveRepoPath } = require("./lib/db");
+const { createAccountStore } = require("./lib/x-account-store");
+
+dotenv.config({ path: path.join(__dirname, "..", ".env"), quiet: true });
+
+function usage() {
+  console.error(
+    [
+      "Usage:",
+      "  node backend/import-accounts.js --file <combined-accounts.csv> [--imported-at <iso8601>]",
+      "",
+      "Behavior:",
+      "  - imports a combined follower/form-response CSV into SQLite",
+      "  - updates follower flags, recovery flags, and form wallets on x_accounts",
+      "  - keeps existing recovery submissions intact",
+    ].join("\n"),
+  );
+}
+
+function parseArgs(argv) {
+  const options = {
+    filePath: "",
+    importedAt: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--file") {
+      options.filePath = String(argv[++index] || "").trim();
+      continue;
+    }
+
+    if (arg === "--imported-at") {
+      options.importedAt = String(argv[++index] || "").trim();
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!options.filePath) {
+    throw new Error("A combined accounts CSV file path is required.");
+  }
+
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const db = openDatabase();
+  const accountStore = createAccountStore(db);
+  const resolvedFilePath = resolveRepoPath(options.filePath);
+  const result = accountStore.importCombinedAccountsFromFile(resolvedFilePath, {
+    importedAt: options.importedAt || undefined,
+  });
+  const stats = accountStore.getStats();
+
+  console.log(`Imported combined accounts: ${resolvedFilePath}`);
+  console.log(`Imported at: ${result.importedAt}`);
+  console.log(`Accounts imported: ${result.importedCount}`);
+  console.log(`Accounts in DB: ${stats.accountCount}`);
+  console.log(`Current followers in DB: ${stats.followerCount}`);
+  console.log(`Recovery candidates in DB: ${stats.recoveryCandidateCount}`);
+  console.log(`Latest snapshot captured at: ${stats.latestSnapshotCapturedAt || "(none)"}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message || String(error));
+  usage();
+  process.exitCode = 1;
+}

--- a/backend/import-claim-rounds.js
+++ b/backend/import-claim-rounds.js
@@ -1,0 +1,144 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const dotenv = require("dotenv");
+
+const { openDatabase, resolveRepoPath } = require("./lib/db");
+const { loadAppConfig, requireChainConfig } = require("./lib/app-config");
+const { buildClaimRound } = require("./lib/claim-round");
+const { createAirdropRoundStore } = require("./lib/airdrop-round-store");
+const { fetchEpochMetadata } = require("./lib/airdrop-chain");
+
+dotenv.config({ path: path.join(__dirname, "..", ".env"), quiet: true });
+
+function normalizeClaimCatalog(rawCatalog) {
+  const sourceRows = Array.isArray(rawCatalog)
+    ? rawCatalog
+    : rawCatalog?.epochs || rawCatalog?.rounds || rawCatalog?.claims || [];
+
+  if (!Array.isArray(sourceRows)) {
+    throw new Error("Claims catalog must be an array or an object with an epochs array.");
+  }
+
+  return sourceRows.map((row, idx) => {
+    const epoch = Number(row?.epoch);
+    if (!Number.isInteger(epoch) || epoch <= 0) {
+      throw new Error(`Claims catalog row ${idx} has an invalid epoch.`);
+    }
+
+    const file = String(row?.file || row?.path || row?.url || "").trim();
+    if (!file) {
+      throw new Error(`Claims catalog row ${idx} is missing a file path.`);
+    }
+
+    return { epoch, file };
+  });
+}
+
+function usage(defaultManifestPath) {
+  console.error(
+    [
+      "Usage:",
+      "  node backend/import-claim-rounds.js [--manifest <manifest.json>] [--decimals <tokenDecimals>]",
+      "",
+      "Defaults:",
+      `  manifest: ${defaultManifestPath || "(missing)"}`,
+      "",
+      "Behavior:",
+      "  - imports file-backed claim rounds into SQLite",
+      "  - recomputes the Merkle root and proofs from each claims file",
+      "  - enriches deadline data from chain when the imported root matches the live epoch",
+    ].join("\n"),
+  );
+}
+
+function parseArgs(argv, defaultManifestPath) {
+  const options = {
+    manifestPath: defaultManifestPath,
+    decimals: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--manifest") {
+      options.manifestPath = String(argv[++index] || "").trim();
+      continue;
+    }
+
+    if (arg === "--decimals") {
+      options.decimals = Number.parseInt(String(argv[++index] || "").trim(), 10);
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!options.manifestPath) {
+    throw new Error("A claims manifest path is required.");
+  }
+
+  return options;
+}
+
+async function main() {
+  const appConfig = loadAppConfig();
+  const defaultManifestPath = appConfig.claimsManifestPath || path.join("frontend", "claims", "index.json");
+  const options = parseArgs(process.argv.slice(2), defaultManifestPath);
+  const manifestPath = resolveRepoPath(options.manifestPath);
+  const manifestDir = path.dirname(manifestPath);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const catalog = normalizeClaimCatalog(manifest);
+  const tokenDecimals = Number.isInteger(options.decimals) ? options.decimals : Number(appConfig.tokenDecimals || 18);
+  const chainConfig = requireChainConfig(appConfig);
+
+  const db = openDatabase();
+  const roundStore = createAirdropRoundStore(db);
+
+  let importedCount = 0;
+  for (const source of catalog) {
+    const sourcePath = path.resolve(manifestDir, source.file);
+    const rawClaims = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
+    const builtRound = buildClaimRound(rawClaims, tokenDecimals);
+
+    let deadline = 0;
+    try {
+      const onchain = await fetchEpochMetadata(chainConfig, source.epoch);
+      if (onchain.merkleRoot === builtRound.root.toLowerCase()) {
+        deadline = onchain.deadline;
+      }
+    } catch {
+      deadline = 0;
+    }
+
+    roundStore.upsertRound({
+      deploymentKey: appConfig.deploymentKey,
+      epoch: source.epoch,
+      merkleRoot: builtRound.root,
+      deadline,
+      claimCount: builtRound.claimCount,
+      totalAmountRaw: builtRound.totalAmountRaw,
+      decimals: builtRound.decimals,
+      chainId: chainConfig.chainId,
+      contractAddress: chainConfig.airdropAddress,
+      sourceKind: "imported-file",
+      claims: builtRound.claims,
+      updatedAt: new Date().toISOString(),
+    });
+    importedCount += 1;
+  }
+
+  const stats = roundStore.getStats(appConfig.deploymentKey);
+  console.log(`Imported claim manifest: ${manifestPath}`);
+  console.log(`Deployment key: ${appConfig.deploymentKey || "(missing)"}`);
+  console.log(`Rounds imported: ${importedCount}`);
+  console.log(`Airdrop rounds in current deployment: ${stats.roundCount}`);
+  console.log(`Airdrop claims in current deployment: ${stats.claimCount}`);
+}
+
+main().catch((error) => {
+  const appConfig = loadAppConfig();
+  usage(appConfig.claimsManifestPath || path.join("frontend", "claims", "index.json"));
+  console.error(error.message || String(error));
+  process.exitCode = 1;
+});

--- a/backend/import-recovery-candidates.js
+++ b/backend/import-recovery-candidates.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const dotenv = require("dotenv");
 
 const { openDatabase, resolveRepoPath } = require("./lib/db");
+const { loadAppConfig } = require("./lib/app-config");
 const { createAccountStore } = require("./lib/x-account-store");
 
 const DEFAULT_RECOVERY_CANDIDATES_FILE = path.join("cache", "x", "missing-address-usernames.json");
@@ -57,6 +58,7 @@ function parseArgs(argv) {
 
 function main() {
   const options = parseArgs(process.argv.slice(2));
+  const appConfig = loadAppConfig();
   const db = openDatabase();
   const accountStore = createAccountStore(db);
   const resolvedFilePath = resolveRepoPath(options.filePath);

--- a/backend/import-recovery-candidates.js
+++ b/backend/import-recovery-candidates.js
@@ -1,0 +1,81 @@
+const path = require("node:path");
+
+const dotenv = require("dotenv");
+
+const { openDatabase, resolveRepoPath } = require("./lib/db");
+const { createAccountStore } = require("./lib/x-account-store");
+
+const DEFAULT_RECOVERY_CANDIDATES_FILE = path.join("cache", "x", "missing-address-usernames.json");
+
+dotenv.config({ path: path.join(__dirname, "..", ".env"), quiet: true });
+
+function usage() {
+  console.error(
+    [
+      "Usage:",
+      "  node backend/import-recovery-candidates.js [--file <candidates.csv|json>] [--imported-at <iso8601>]",
+      "",
+      "Defaults:",
+      `  file: ${DEFAULT_RECOVERY_CANDIDATES_FILE}`,
+      "",
+      "Behavior:",
+      "  - imports a recovery-candidate list into SQLite",
+      "  - supports the processed CSV format and the legacy JSON username list",
+      "  - marks the latest needs-recovery set on x_accounts",
+    ].join("\n"),
+  );
+}
+
+function parseArgs(argv) {
+  const options = {
+    filePath: process.env.X_RECOVERY_CANDIDATES_FILE || DEFAULT_RECOVERY_CANDIDATES_FILE,
+    importedAt: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--file") {
+      options.filePath = String(argv[++index] || "").trim();
+      continue;
+    }
+
+    if (arg === "--imported-at") {
+      options.importedAt = String(argv[++index] || "").trim();
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!options.filePath) {
+    throw new Error("A recovery-candidate file path is required.");
+  }
+
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const db = openDatabase();
+  const accountStore = createAccountStore(db);
+  const resolvedFilePath = resolveRepoPath(options.filePath);
+  const result = accountStore.importRecoveryCandidatesFromFile(resolvedFilePath, {
+    importedAt: options.importedAt || undefined,
+  });
+  const stats = accountStore.getStats();
+
+  console.log(`Imported recovery candidates: ${resolvedFilePath}`);
+  console.log(`Imported at: ${result.importedAt}`);
+  console.log(`Candidates imported: ${result.importedCount}`);
+  console.log(`Accounts in DB: ${stats.accountCount}`);
+  console.log(`Recovery candidates in DB: ${stats.recoveryCandidateCount}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message || String(error));
+  usage();
+  process.exitCode = 1;
+}

--- a/backend/import-recovery-submissions.js
+++ b/backend/import-recovery-submissions.js
@@ -1,0 +1,72 @@
+const path = require("node:path");
+
+const dotenv = require("dotenv");
+
+const { openDatabase, resolveRepoPath } = require("./lib/db");
+const { createAccountStore } = require("./lib/x-account-store");
+const { createRecoverySubmissionStore } = require("./lib/recovery-submission-store");
+
+const DEFAULT_RECOVERY_STORE_FILE = path.join("cache", "x", "recovery-links.json");
+
+dotenv.config({ path: path.join(__dirname, "..", ".env"), quiet: true });
+
+function usage() {
+  console.error(
+    [
+      "Usage:",
+      "  node backend/import-recovery-submissions.js [--file <recovery-links.json>]",
+      "",
+      "Defaults:",
+      `  file: ${DEFAULT_RECOVERY_STORE_FILE}`,
+      "",
+      "Behavior:",
+      "  - imports legacy recovery-links.json rows into SQLite",
+      "  - keeps future runtime submissions in recovery_submissions",
+    ].join("\n"),
+  );
+}
+
+function parseArgs(argv) {
+  const options = {
+    filePath: process.env.X_RECOVERY_STORE_FILE || DEFAULT_RECOVERY_STORE_FILE,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--file") {
+      options.filePath = String(argv[++index] || "").trim();
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!options.filePath) {
+    throw new Error("A recovery submissions file path is required.");
+  }
+
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const db = openDatabase();
+  const accountStore = createAccountStore(db);
+  const submissionStore = createRecoverySubmissionStore(db);
+  const resolvedFilePath = resolveRepoPath(options.filePath);
+  const result = submissionStore.importLegacyStore(resolvedFilePath, accountStore);
+  const stats = submissionStore.getStats();
+
+  console.log(`Imported recovery submissions: ${result.sourceFilePath}`);
+  console.log(`New submissions imported: ${result.importedCount}`);
+  console.log(`Recovery submissions in DB: ${stats.submissionCount}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message || String(error));
+  usage();
+  process.exitCode = 1;
+}

--- a/backend/import-recovery-submissions.js
+++ b/backend/import-recovery-submissions.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const dotenv = require("dotenv");
 
 const { openDatabase, resolveRepoPath } = require("./lib/db");
+const { loadAppConfig } = require("./lib/app-config");
 const { createAccountStore } = require("./lib/x-account-store");
 const { createRecoverySubmissionStore } = require("./lib/recovery-submission-store");
 
@@ -51,6 +52,7 @@ function parseArgs(argv) {
 
 function main() {
   const options = parseArgs(process.argv.slice(2));
+  const appConfig = loadAppConfig();
   const db = openDatabase();
   const accountStore = createAccountStore(db);
   const submissionStore = createRecoverySubmissionStore(db);

--- a/backend/import-x-followers.js
+++ b/backend/import-x-followers.js
@@ -3,6 +3,7 @@ const path = require("node:path");
 const dotenv = require("dotenv");
 
 const { openDatabase, resolveRepoPath } = require("./lib/db");
+const { loadAppConfig } = require("./lib/app-config");
 const { createAccountStore } = require("./lib/x-account-store");
 
 const DEFAULT_FOLLOWER_SNAPSHOT_FILE = path.join("cache", "x", "liberdus-followers.json");
@@ -57,6 +58,7 @@ function parseArgs(argv) {
 
 function main() {
   const options = parseArgs(process.argv.slice(2));
+  const appConfig = loadAppConfig();
   const db = openDatabase();
   const accountStore = createAccountStore(db);
   const resolvedFilePath = resolveRepoPath(options.filePath);

--- a/backend/import-x-followers.js
+++ b/backend/import-x-followers.js
@@ -1,0 +1,83 @@
+const path = require("node:path");
+
+const dotenv = require("dotenv");
+
+const { openDatabase, resolveRepoPath } = require("./lib/db");
+const { createAccountStore } = require("./lib/x-account-store");
+
+const DEFAULT_FOLLOWER_SNAPSHOT_FILE = path.join("cache", "x", "liberdus-followers.json");
+
+dotenv.config({ path: path.join(__dirname, "..", ".env"), quiet: true });
+
+function usage() {
+  console.error(
+    [
+      "Usage:",
+      "  node backend/import-x-followers.js [--file <snapshot.json>] [--imported-at <iso8601>]",
+      "",
+      "Defaults:",
+      `  file: ${DEFAULT_FOLLOWER_SNAPSHOT_FILE}`,
+      "",
+      "Behavior:",
+      "  - imports a raw follower snapshot JSON into SQLite",
+      "  - upserts the latest follower state on x_accounts",
+      "  - updates per-account snapshot rollups for follower longevity",
+    ].join("\n"),
+  );
+}
+
+function parseArgs(argv) {
+  const options = {
+    filePath: process.env.X_FOLLOWER_SNAPSHOT_FILE || DEFAULT_FOLLOWER_SNAPSHOT_FILE,
+    importedAt: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--file") {
+      options.filePath = String(argv[++index] || "").trim();
+      continue;
+    }
+
+    if (arg === "--imported-at") {
+      options.importedAt = String(argv[++index] || "").trim();
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!options.filePath) {
+    throw new Error("A follower snapshot file path is required.");
+  }
+
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const db = openDatabase();
+  const accountStore = createAccountStore(db);
+  const resolvedFilePath = resolveRepoPath(options.filePath);
+  const result = accountStore.importFollowerSnapshotFromFile(resolvedFilePath, {
+    importedAt: options.importedAt || undefined,
+  });
+  const stats = accountStore.getStats();
+
+  console.log(`Imported follower snapshot: ${resolvedFilePath}`);
+  console.log(`Captured at: ${result.capturedAt}`);
+  console.log(`Accounts processed: ${result.importedCount}`);
+  console.log(`Became latest snapshot: ${result.becameLatest ? "yes" : "no"}`);
+  console.log(`Accounts in DB: ${stats.accountCount}`);
+  console.log(`Current followers in DB: ${stats.followerCount}`);
+  console.log(`Latest snapshot captured at: ${stats.latestSnapshotCapturedAt || "(none)"}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message || String(error));
+  usage();
+  process.exitCode = 1;
+}

--- a/backend/lib/airdrop-chain.js
+++ b/backend/lib/airdrop-chain.js
@@ -1,0 +1,92 @@
+const { ethers } = require("ethers");
+
+const AIRDROP_ABI = [
+  "event AirdropStarted(uint256 indexed epoch, bytes32 indexed merkleRoot, uint256 deadline)",
+  "function epochInfo(uint256) view returns (bytes32,uint256,uint256)",
+];
+
+function createAirdropProvider(appConfig) {
+  return new ethers.JsonRpcProvider(appConfig.rpcUrl, appConfig.chainId);
+}
+
+function createAirdropContract(appConfig, runner) {
+  return new ethers.Contract(appConfig.airdropAddress, AIRDROP_ABI, runner);
+}
+
+async function fetchEpochMetadata(appConfig, epoch) {
+  const provider = createAirdropProvider(appConfig);
+  const contract = createAirdropContract(appConfig, provider);
+  const [merkleRoot, deadline, claimedAmount] = await contract.epochInfo(BigInt(epoch));
+
+  return {
+    epoch: Number(epoch),
+    merkleRoot: String(merkleRoot || "").trim().toLowerCase(),
+    deadline: Number(deadline || 0),
+    claimedAmount: String(claimedAmount || "0"),
+  };
+}
+
+async function verifyAirdropStartTransaction(appConfig, txHash, expectedMerkleRoot) {
+  const provider = createAirdropProvider(appConfig);
+  const contract = createAirdropContract(appConfig, provider);
+  const normalizedTxHash = String(txHash || "").trim();
+
+  if (!ethers.isHexString(normalizedTxHash, 32)) {
+    throw new Error("Transaction hash must be a 32-byte hex string.");
+  }
+
+  const receipt = await provider.getTransactionReceipt(normalizedTxHash);
+  if (!receipt) {
+    throw new Error("Transaction receipt was not found yet.");
+  }
+
+  if (Number(receipt.status || 0) !== 1) {
+    throw new Error("Transaction did not succeed on chain.");
+  }
+
+  const normalizedContractAddress = appConfig.airdropAddress.toLowerCase();
+  const matchingLogs = receipt.logs
+    .filter((log) => String(log.address || "").toLowerCase() === normalizedContractAddress)
+    .map((log) => {
+      try {
+        return contract.interface.parseLog(log);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean)
+    .filter((parsed) => parsed.name === "AirdropStarted");
+
+  if (matchingLogs.length !== 1) {
+    throw new Error("Expected exactly one AirdropStarted event in the transaction receipt.");
+  }
+
+  const [event] = matchingLogs;
+  const epoch = Number(event.args.epoch);
+  const merkleRoot = String(event.args.merkleRoot || "").trim().toLowerCase();
+  const deadline = Number(event.args.deadline || 0);
+
+  if (expectedMerkleRoot && merkleRoot !== String(expectedMerkleRoot).trim().toLowerCase()) {
+    throw new Error("Merkle root from the transaction did not match the submitted claims.");
+  }
+
+  const onchain = await fetchEpochMetadata(appConfig, epoch);
+  if (onchain.merkleRoot !== merkleRoot || onchain.deadline !== deadline) {
+    throw new Error("On-chain epoch data did not match the transaction event.");
+  }
+
+  return {
+    epoch,
+    merkleRoot,
+    deadline,
+    txHash: normalizedTxHash.toLowerCase(),
+    blockNumber: Number(receipt.blockNumber || 0),
+    blockHash: String(receipt.blockHash || "").trim().toLowerCase(),
+  };
+}
+
+module.exports = {
+  createAirdropProvider,
+  fetchEpochMetadata,
+  verifyAirdropStartTransaction,
+};

--- a/backend/lib/airdrop-chain.js
+++ b/backend/lib/airdrop-chain.js
@@ -3,6 +3,7 @@ const { ethers } = require("ethers");
 const AIRDROP_ABI = [
   "event AirdropStarted(uint256 indexed epoch, bytes32 indexed merkleRoot, uint256 deadline)",
   "function epochInfo(uint256) view returns (bytes32,uint256,uint256)",
+  "function owner() view returns (address)",
 ];
 
 function createAirdropProvider(appConfig) {
@@ -85,8 +86,16 @@ async function verifyAirdropStartTransaction(appConfig, txHash, expectedMerkleRo
   };
 }
 
+async function fetchAirdropOwner(appConfig) {
+  const provider = createAirdropProvider(appConfig);
+  const contract = createAirdropContract(appConfig, provider);
+  const owner = await contract.owner();
+  return ethers.getAddress(String(owner || "").trim());
+}
+
 module.exports = {
   createAirdropProvider,
+  fetchAirdropOwner,
   fetchEpochMetadata,
   verifyAirdropStartTransaction,
 };

--- a/backend/lib/airdrop-round-store.js
+++ b/backend/lib/airdrop-round-store.js
@@ -1,0 +1,298 @@
+const { ethers } = require("ethers");
+
+function normalizeIsoDate(value, fallbackValue = null) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue) return fallbackValue;
+
+  const date = new Date(rawValue);
+  if (Number.isNaN(date.getTime())) return fallbackValue;
+  return date.toISOString();
+}
+
+function normalizeRoundRecord(row) {
+  if (!row) return null;
+
+  return {
+    id: Number(row.id),
+    deploymentKey: String(row.deployment_key || "").trim(),
+    epoch: Number(row.epoch),
+    merkleRoot: String(row.merkle_root || "").trim(),
+    deadline: Number(row.deadline || 0),
+    claimCount: Number(row.claim_count || 0),
+    totalAmountRaw: String(row.total_amount_raw || "0"),
+    decimals: Number(row.decimals || 18),
+    chainId: Number(row.chain_id || 0),
+    contractAddress: String(row.contract_address || "").trim(),
+    sourceKind: String(row.source_kind || "").trim(),
+    startTxHash: String(row.start_tx_hash || "").trim(),
+    startBlockNumber: row.start_block_number == null ? null : Number(row.start_block_number),
+    startBlockHash: String(row.start_block_hash || "").trim(),
+    createdAt: normalizeIsoDate(row.created_at),
+    updatedAt: normalizeIsoDate(row.updated_at),
+  };
+}
+
+function normalizeClaimRecord(row) {
+  if (!row) return null;
+
+  return {
+    roundId: Number(row.round_id),
+    index: String(row.claim_index),
+    account: ethers.getAddress(String(row.wallet_address || "").trim()),
+    amountRaw: String(row.amount_raw || "0"),
+    proof: JSON.parse(String(row.proof_json || "[]")),
+  };
+}
+
+function normalizeDeploymentKey(value) {
+  const normalized = String(value || "").trim();
+  if (!normalized) {
+    throw new Error("A deployment key is required for stored airdrop rounds.");
+  }
+
+  return normalized;
+}
+
+function createAirdropRoundStore(db) {
+  const statements = {
+    getRoundByDeploymentAndEpoch: db.prepare(`
+      SELECT *
+      FROM airdrop_rounds
+      WHERE deployment_key = ?
+        AND epoch = ?
+    `),
+    getRoundById: db.prepare(`
+      SELECT *
+      FROM airdrop_rounds
+      WHERE id = ?
+    `),
+    insertRound: db.prepare(`
+      INSERT INTO airdrop_rounds (
+        deployment_key,
+        epoch,
+        merkle_root,
+        deadline,
+        claim_count,
+        total_amount_raw,
+        decimals,
+        chain_id,
+        contract_address,
+        source_kind,
+        start_tx_hash,
+        start_block_number,
+        start_block_hash,
+        created_at,
+        updated_at
+      ) VALUES (
+        @deploymentKey,
+        @epoch,
+        @merkleRoot,
+        @deadline,
+        @claimCount,
+        @totalAmountRaw,
+        @decimals,
+        @chainId,
+        @contractAddress,
+        @sourceKind,
+        @startTxHash,
+        @startBlockNumber,
+        @startBlockHash,
+        @createdAt,
+        @updatedAt
+      )
+    `),
+    updateRound: db.prepare(`
+      UPDATE airdrop_rounds
+      SET deployment_key = @deploymentKey,
+          merkle_root = @merkleRoot,
+          deadline = @deadline,
+          claim_count = @claimCount,
+          total_amount_raw = @totalAmountRaw,
+          decimals = @decimals,
+          chain_id = @chainId,
+          contract_address = @contractAddress,
+          source_kind = @sourceKind,
+          start_tx_hash = @startTxHash,
+          start_block_number = @startBlockNumber,
+          start_block_hash = @startBlockHash,
+          updated_at = @updatedAt
+      WHERE id = @id
+    `),
+    deleteClaimsByRoundId: db.prepare(`
+      DELETE FROM airdrop_claims
+      WHERE round_id = ?
+    `),
+    insertClaim: db.prepare(`
+      INSERT INTO airdrop_claims (
+        round_id,
+        claim_index,
+        wallet_address,
+        amount_raw,
+        proof_json,
+        created_at
+      ) VALUES (
+        @roundId,
+        @claimIndex,
+        @walletAddress,
+        @amountRaw,
+        @proofJson,
+        @createdAt
+      )
+    `),
+    listRounds: db.prepare(`
+      SELECT *
+      FROM airdrop_rounds
+      WHERE deployment_key = ?
+      ORDER BY epoch DESC, id DESC
+    `),
+    listWalletRounds: db.prepare(`
+      SELECT
+        r.*,
+        c.round_id,
+        c.claim_index,
+        c.wallet_address,
+        c.amount_raw,
+        c.proof_json
+      FROM airdrop_claims c
+      INNER JOIN airdrop_rounds r
+        ON r.id = c.round_id
+      WHERE r.deployment_key = ?
+        AND LOWER(c.wallet_address) = LOWER(?)
+      ORDER BY r.epoch DESC, r.id DESC
+    `),
+    getClaimByEpochAndIndex: db.prepare(`
+      SELECT
+        r.*,
+        c.round_id,
+        c.claim_index,
+        c.wallet_address,
+        c.amount_raw,
+        c.proof_json
+      FROM airdrop_claims c
+      INNER JOIN airdrop_rounds r
+        ON r.id = c.round_id
+      WHERE r.deployment_key = ?
+        AND r.epoch = ?
+        AND c.claim_index = ?
+      LIMIT 1
+    `),
+    getStats: db.prepare(`
+      SELECT
+        COUNT(*) AS roundCount,
+        COALESCE(SUM(claim_count), 0) AS claimCount
+      FROM airdrop_rounds
+      WHERE deployment_key = ?
+    `),
+    getAllStats: db.prepare(`
+      SELECT
+        COUNT(*) AS roundCount,
+        COALESCE(SUM(claim_count), 0) AS claimCount
+      FROM airdrop_rounds
+    `),
+  };
+
+  const upsertRound = db.transaction((round) => {
+    const deploymentKey = normalizeDeploymentKey(round.deploymentKey);
+    const existing = normalizeRoundRecord(
+      statements.getRoundByDeploymentAndEpoch.get(deploymentKey, round.epoch),
+    );
+    const updatedAt = normalizeIsoDate(round.updatedAt, new Date().toISOString());
+    const baseRecord = {
+      deploymentKey,
+      epoch: Number(round.epoch),
+      merkleRoot: String(round.merkleRoot || "").trim().toLowerCase(),
+      deadline: Number(round.deadline || 0),
+      claimCount: Number(round.claimCount || 0),
+      totalAmountRaw: String(round.totalAmountRaw || "0"),
+      decimals: Number(round.decimals || 18),
+      chainId: Number(round.chainId || 0),
+      contractAddress: ethers.getAddress(String(round.contractAddress || "").trim()).toLowerCase(),
+      sourceKind: String(round.sourceKind || "manual").trim(),
+      startTxHash: String(round.startTxHash || "").trim().toLowerCase() || null,
+      startBlockNumber: round.startBlockNumber == null ? null : Number(round.startBlockNumber),
+      startBlockHash: String(round.startBlockHash || "").trim().toLowerCase() || null,
+      createdAt: existing?.createdAt || updatedAt,
+      updatedAt,
+    };
+
+    let roundId = existing?.id || null;
+    if (!existing) {
+      const insertResult = statements.insertRound.run(baseRecord);
+      roundId = Number(insertResult.lastInsertRowid);
+    } else {
+      statements.updateRound.run({
+        id: existing.id,
+        ...baseRecord,
+      });
+      roundId = existing.id;
+    }
+
+    statements.deleteClaimsByRoundId.run(roundId);
+    for (const claim of round.claims) {
+      statements.insertClaim.run({
+        roundId,
+        claimIndex: Number(claim.index),
+        walletAddress: ethers.getAddress(String(claim.account || "").trim()).toLowerCase(),
+        amountRaw: String(claim.amountRaw || "0"),
+        proofJson: JSON.stringify(Array.isArray(claim.proof) ? claim.proof : []),
+        createdAt: updatedAt,
+      });
+    }
+
+    return normalizeRoundRecord(statements.getRoundById.get(roundId));
+  });
+
+  return {
+    upsertRound(round) {
+      return upsertRound(round);
+    },
+
+    listRounds(deploymentKey) {
+      const normalizedDeploymentKey = normalizeDeploymentKey(deploymentKey);
+      return statements.listRounds.all(normalizedDeploymentKey).map((row) => normalizeRoundRecord(row));
+    },
+
+    getWalletRounds(walletAddress, deploymentKey) {
+      const normalizedDeploymentKey = normalizeDeploymentKey(deploymentKey);
+      return statements.listWalletRounds.all(normalizedDeploymentKey, walletAddress).map((row) => {
+        const round = normalizeRoundRecord(row);
+        const entry = normalizeClaimRecord(row);
+        return {
+          ...round,
+          entry,
+        };
+      });
+    },
+
+    getClaimByEpochAndIndex(epoch, index, deploymentKey) {
+      const normalizedDeploymentKey = normalizeDeploymentKey(deploymentKey);
+      const row = statements.getClaimByEpochAndIndex.get(
+        normalizedDeploymentKey,
+        Number(epoch),
+        Number(index),
+      );
+      if (!row) {
+        return null;
+      }
+
+      return {
+        ...normalizeRoundRecord(row),
+        entry: normalizeClaimRecord(row),
+      };
+    },
+
+    getStats(deploymentKey = null) {
+      const row = deploymentKey
+        ? (statements.getStats.get(normalizeDeploymentKey(deploymentKey)) || {})
+        : (statements.getAllStats.get() || {});
+      return {
+        roundCount: Number(row.roundCount || 0),
+        claimCount: Number(row.claimCount || 0),
+      };
+    },
+  };
+}
+
+module.exports = {
+  createAirdropRoundStore,
+};

--- a/backend/lib/app-config.js
+++ b/backend/lib/app-config.js
@@ -1,0 +1,133 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { ethers } = require("ethers");
+
+function getRepoRoot() {
+  return path.resolve(__dirname, "..", "..");
+}
+
+function resolveRepoPath(filePath) {
+  return path.resolve(getRepoRoot(), filePath);
+}
+
+function resolveFrontendConfigPath() {
+  const explicitPath = String(process.env.LIBERDUS_FRONTEND_CONFIG || "").trim();
+  if (explicitPath) {
+    return resolveRepoPath(explicitPath);
+  }
+
+  const candidatePaths = [
+    path.join("frontend", "config.local.json"),
+    path.join("frontend", "config.json"),
+    path.join("frontend", "config.prod.json"),
+    path.join("frontend", "config.test.json"),
+    path.join("frontend", "config.local.template.json"),
+  ];
+
+  for (const candidatePath of candidatePaths) {
+    const resolvedPath = resolveRepoPath(candidatePath);
+    if (fs.existsSync(resolvedPath)) {
+      return resolvedPath;
+    }
+  }
+
+  return "";
+}
+
+function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function normalizeAddress(value) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue) return "";
+
+  try {
+    return ethers.getAddress(rawValue);
+  } catch {
+    return "";
+  }
+}
+
+function normalizeInteger(value, fallbackValue = null) {
+  const parsed = Number.parseInt(String(value || "").trim(), 10);
+  if (!Number.isInteger(parsed)) return fallbackValue;
+  return parsed;
+}
+
+function normalizeClaimsManifestPath(value) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue) return "";
+
+  if (path.isAbsolute(rawValue)) {
+    return rawValue;
+  }
+
+  const withoutPrefix = rawValue.replace(/^\.\//u, "");
+  if (withoutPrefix.startsWith("frontend/") || withoutPrefix.startsWith("frontend\\")) {
+    return withoutPrefix;
+  }
+
+  return path.join("frontend", withoutPrefix);
+}
+
+function normalizeDeploymentKey(value) {
+  return String(value || "").trim();
+}
+
+function getDefaultDeploymentKey(chainId, airdropAddress) {
+  if (!Number.isInteger(chainId) || !airdropAddress) {
+    return "";
+  }
+
+  return `${chainId}:${String(airdropAddress).toLowerCase()}`;
+}
+
+function loadAppConfig() {
+  const frontendConfigPath = resolveFrontendConfigPath();
+  const frontendConfig = frontendConfigPath ? readJsonFile(frontendConfigPath) : {};
+  const xAuthConfig = frontendConfig?.xAuth && typeof frontendConfig.xAuth === "object"
+    ? frontendConfig.xAuth
+    : {};
+  const chainId = normalizeInteger(process.env.LIBERDUS_CHAIN_ID, normalizeInteger(frontendConfig.chainId, null));
+  const airdropAddress = normalizeAddress(process.env.LIBERDUS_AIRDROP_ADDRESS || frontendConfig.airdropAddress || "");
+
+  return {
+    sourcePath: frontendConfigPath,
+    chainId,
+    rpcUrl: String(process.env.LIBERDUS_RPC_URL || frontendConfig.rpcUrl || "").trim(),
+    airdropAddress,
+    tokenAddress: normalizeAddress(process.env.LIBERDUS_TOKEN_ADDRESS || frontendConfig.tokenAddress || ""),
+    apiBaseUrl: String(
+      process.env.LIBERDUS_API_BASE_URL
+      || frontendConfig.apiBaseUrl
+      || xAuthConfig.backendUrl
+      || ""
+    ).trim(),
+    claimsManifestPath: normalizeClaimsManifestPath(process.env.LIBERDUS_CLAIMS_MANIFEST || frontendConfig.claimsManifestPath || ""),
+    tokenDecimals: normalizeInteger(process.env.LIBERDUS_TOKEN_DECIMALS, 18),
+    deploymentKey: normalizeDeploymentKey(
+      process.env.LIBERDUS_DEPLOYMENT_KEY
+      || frontendConfig.deploymentKey
+      || getDefaultDeploymentKey(chainId, airdropAddress),
+    ),
+  };
+}
+
+function requireChainConfig(appConfig = loadAppConfig()) {
+  if (!appConfig.rpcUrl || !appConfig.airdropAddress || !Number.isInteger(appConfig.chainId)) {
+    throw new Error(
+      "Backend chain config is incomplete. Set LIBERDUS_RPC_URL, LIBERDUS_CHAIN_ID, and LIBERDUS_AIRDROP_ADDRESS or provide them in the frontend config file.",
+    );
+  }
+
+  return appConfig;
+}
+
+module.exports = {
+  loadAppConfig,
+  requireChainConfig,
+  resolveFrontendConfigPath,
+  resolveRepoPath,
+};

--- a/backend/lib/claim-round.js
+++ b/backend/lib/claim-round.js
@@ -1,0 +1,216 @@
+const { ethers } = require("ethers");
+
+const STANDARD_MERKLE_LEAF_TYPES = ["uint256", "address", "uint256"];
+
+function compareHex(left, right) {
+  const leftValue = BigInt(left);
+  const rightValue = BigInt(right);
+
+  if (leftValue === rightValue) return 0;
+  return leftValue < rightValue ? -1 : 1;
+}
+
+function trimFormattedUnits(value) {
+  return value.includes(".") ? value.replace(/\.?0+$/, "") : value;
+}
+
+function normalizeAddress(value, label) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue) {
+    throw new Error(`${label} is required.`);
+  }
+
+  try {
+    const normalized = ethers.getAddress(rawValue);
+    if (normalized === ethers.ZeroAddress) {
+      throw new Error();
+    }
+    return normalized;
+  } catch {
+    throw new Error(`${label} is invalid.`);
+  }
+}
+
+function parseRequiredBigInt(value, label) {
+  const rawValue = String(value ?? "").trim();
+  if (!rawValue) {
+    throw new Error(`${label} is required.`);
+  }
+
+  try {
+    return BigInt(rawValue);
+  } catch {
+    throw new Error(`${label} must be an integer.`);
+  }
+}
+
+function parseHumanAmount(value, decimals) {
+  const rawValue = String(value ?? "").trim();
+  if (!rawValue) {
+    throw new Error("Amount is required.");
+  }
+
+  try {
+    return ethers.parseUnits(rawValue, decimals);
+  } catch {
+    throw new Error(`Amount "${rawValue}" is invalid.`);
+  }
+}
+
+function hashLeaf(index, account, amountRaw) {
+  const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+    STANDARD_MERKLE_LEAF_TYPES,
+    [index, account, amountRaw],
+  );
+
+  return ethers.keccak256(ethers.keccak256(encoded));
+}
+
+function hashPair(left, right) {
+  const ordered = compareHex(left, right) <= 0 ? [left, right] : [right, left];
+  return ethers.keccak256(ethers.concat(ordered));
+}
+
+function normalizeClaimsInput(rawInput, tokenDecimals) {
+  const rawClaims = Array.isArray(rawInput)
+    ? rawInput
+    : rawInput?.claims;
+
+  if (!Array.isArray(rawClaims)) {
+    throw new Error("Claims input must be an array or an object with a claims array.");
+  }
+
+  if (rawClaims.length === 0) {
+    throw new Error("Claims array is empty.");
+  }
+
+  const seenIndexes = new Set();
+  const seenAccounts = new Set();
+
+  return rawClaims.map((entry, idx) => {
+    if (!entry || typeof entry !== "object") {
+      throw new Error(`Claim ${idx} must be an object.`);
+    }
+
+    const index = parseRequiredBigInt(entry.index, `Claim ${idx} index`);
+    if (index < 0n) {
+      throw new Error(`Claim ${idx} index cannot be negative.`);
+    }
+
+    const indexKey = index.toString();
+    if (seenIndexes.has(indexKey)) {
+      throw new Error(`Claim ${idx} reuses index ${indexKey}.`);
+    }
+    seenIndexes.add(indexKey);
+
+    const account = normalizeAddress(entry.account, `Claim ${idx} account`);
+    const accountKey = account.toLowerCase();
+    if (seenAccounts.has(accountKey)) {
+      throw new Error(`Claim ${idx} reuses account ${account}.`);
+    }
+    seenAccounts.add(accountKey);
+
+    let amountRaw;
+    let amountDisplay;
+
+    if (entry.amountRaw != null && String(entry.amountRaw).trim() !== "") {
+      amountRaw = parseRequiredBigInt(entry.amountRaw, `Claim ${idx} amountRaw`);
+      amountDisplay = entry.amount != null
+        ? String(entry.amount).trim()
+        : trimFormattedUnits(ethers.formatUnits(amountRaw, tokenDecimals));
+    } else if (entry.amount != null) {
+      amountDisplay = String(entry.amount).trim();
+      if (!amountDisplay) {
+        throw new Error(`Claim ${idx} amount is required.`);
+      }
+      amountRaw = parseHumanAmount(amountDisplay, tokenDecimals);
+    } else {
+      throw new Error(`Claim ${idx} must include amount or amountRaw.`);
+    }
+
+    if (amountRaw < 0n) {
+      throw new Error(`Claim ${idx} amount cannot be negative.`);
+    }
+
+    return {
+      index,
+      account,
+      amountRaw,
+      amountDisplay,
+    };
+  });
+}
+
+function buildStandardMerkleData(claims) {
+  if (!Array.isArray(claims) || claims.length === 0) {
+    throw new Error("Claims array is empty.");
+  }
+
+  const hashedValues = claims
+    .map((claim, valueIndex) => ({
+      claim,
+      valueIndex,
+      hash: hashLeaf(claim.index, claim.account, claim.amountRaw),
+    }))
+    .sort((left, right) => compareHex(left.hash, right.hash));
+
+  const tree = new Array((2 * hashedValues.length) - 1);
+  const claimTreeIndices = new Array(claims.length);
+
+  for (const [leafIndex, item] of hashedValues.entries()) {
+    const treeIndex = tree.length - 1 - leafIndex;
+    tree[treeIndex] = item.hash;
+    claimTreeIndices[item.valueIndex] = treeIndex;
+  }
+
+  for (let treeIndex = tree.length - hashedValues.length - 1; treeIndex >= 0; treeIndex -= 1) {
+    tree[treeIndex] = hashPair(tree[(2 * treeIndex) + 1], tree[(2 * treeIndex) + 2]);
+  }
+
+  return {
+    root: tree[0],
+    totalAmountRaw: claims.reduce((total, claim) => total + claim.amountRaw, 0n),
+    claimCount: claims.length,
+    claims: claims.map((claim, valueIndex) => {
+      let treeIndex = claimTreeIndices[valueIndex];
+      const proof = [];
+
+      while (treeIndex > 0) {
+        const siblingIndex = treeIndex % 2 === 0 ? treeIndex - 1 : treeIndex + 1;
+        proof.push(tree[siblingIndex]);
+        treeIndex = Math.floor((treeIndex - 1) / 2);
+      }
+
+      return {
+        ...claim,
+        proof,
+      };
+    }),
+  };
+}
+
+function buildClaimRound(rawInput, tokenDecimals) {
+  const normalizedClaims = normalizeClaimsInput(rawInput, tokenDecimals);
+  const merkleData = buildStandardMerkleData(normalizedClaims);
+
+  return {
+    root: merkleData.root,
+    leafEncoding: [...STANDARD_MERKLE_LEAF_TYPES],
+    decimals: tokenDecimals,
+    claimCount: merkleData.claimCount,
+    totalAmountRaw: merkleData.totalAmountRaw.toString(),
+    claims: merkleData.claims.map((claim) => ({
+      index: claim.index.toString(),
+      account: claim.account,
+      amount: claim.amountDisplay,
+      amountRaw: claim.amountRaw.toString(),
+      proof: [...claim.proof],
+    })),
+  };
+}
+
+module.exports = {
+  STANDARD_MERKLE_LEAF_TYPES,
+  buildClaimRound,
+  normalizeClaimsInput,
+};

--- a/backend/lib/db.js
+++ b/backend/lib/db.js
@@ -78,6 +78,56 @@ function initializeSchema(db) {
     CREATE INDEX idx_recovery_submissions_wallet_address
       ON recovery_submissions(wallet_address);
   `);
+
+  createAirdropSchema(db);
+}
+
+function createAirdropSchema(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS airdrop_rounds (
+      id INTEGER PRIMARY KEY,
+      deployment_key TEXT NOT NULL,
+      epoch INTEGER NOT NULL,
+      merkle_root TEXT NOT NULL,
+      deadline INTEGER NOT NULL DEFAULT 0,
+      claim_count INTEGER NOT NULL DEFAULT 0,
+      total_amount_raw TEXT NOT NULL,
+      decimals INTEGER NOT NULL DEFAULT 18,
+      chain_id INTEGER NOT NULL,
+      contract_address TEXT NOT NULL,
+      source_kind TEXT NOT NULL DEFAULT 'manual',
+      start_tx_hash TEXT,
+      start_block_number INTEGER,
+      start_block_hash TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_airdrop_rounds_deployment_epoch
+      ON airdrop_rounds(deployment_key, epoch);
+
+    CREATE INDEX IF NOT EXISTS idx_airdrop_rounds_deployment_merkle_root
+      ON airdrop_rounds(deployment_key, LOWER(merkle_root));
+
+    CREATE INDEX IF NOT EXISTS idx_airdrop_rounds_deployment_contract_epoch
+      ON airdrop_rounds(deployment_key, LOWER(contract_address), epoch);
+
+    CREATE TABLE IF NOT EXISTS airdrop_claims (
+      round_id INTEGER NOT NULL REFERENCES airdrop_rounds(id) ON DELETE CASCADE,
+      claim_index INTEGER NOT NULL,
+      wallet_address TEXT NOT NULL,
+      amount_raw TEXT NOT NULL,
+      proof_json TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (round_id, claim_index)
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_airdrop_claims_round_wallet
+      ON airdrop_claims(round_id, LOWER(wallet_address));
+
+    CREATE INDEX IF NOT EXISTS idx_airdrop_claims_wallet_lookup
+      ON airdrop_claims(LOWER(wallet_address));
+  `);
 }
 
 function dropKnownTablesAndIndexes(db) {
@@ -89,6 +139,17 @@ function dropKnownTablesAndIndexes(db) {
     DROP INDEX IF EXISTS idx_recovery_submissions_account_id;
     DROP INDEX IF EXISTS idx_recovery_submissions_x_user_id;
     DROP INDEX IF EXISTS idx_recovery_submissions_wallet_address;
+    DROP INDEX IF EXISTS idx_airdrop_rounds_merkle_root;
+    DROP INDEX IF EXISTS idx_airdrop_rounds_contract_epoch;
+    DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_epoch;
+    DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_merkle_root;
+    DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_contract_epoch;
+    DROP INDEX IF EXISTS idx_airdrop_claims_round_wallet;
+    DROP INDEX IF EXISTS idx_airdrop_claims_wallet_lookup;
+    DROP TABLE IF EXISTS airdrop_claims;
+    DROP TABLE IF EXISTS airdrop_rounds;
+    DROP TABLE IF EXISTS airdrop_claims_legacy;
+    DROP TABLE IF EXISTS airdrop_rounds_legacy;
     DROP TABLE IF EXISTS recovery_submissions;
     DROP TABLE IF EXISTS x_recovery_candidates;
     DROP TABLE IF EXISTS x_recovery_candidate_imports;
@@ -100,16 +161,42 @@ function dropKnownTablesAndIndexes(db) {
   `);
 }
 
+function tableExists(db, tableName) {
+  const row = db.prepare(`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'table'
+      AND name = ?
+    LIMIT 1
+  `).get(tableName);
+
+  return Boolean(row);
+}
+
+function getTableColumnNames(db, tableName) {
+  if (!tableExists(db, tableName)) {
+    return [];
+  }
+
+  return db.prepare(`PRAGMA table_info(${tableName})`).all().map((row) => String(row.name || ""));
+}
+
 function hasCurrentSchema(db) {
   const tableNames = db.prepare(`
     SELECT name
     FROM sqlite_master
     WHERE type = 'table'
-      AND name IN ('x_accounts', 'recovery_submissions')
+      AND name IN ('x_accounts', 'recovery_submissions', 'airdrop_rounds', 'airdrop_claims')
     ORDER BY name
   `).all().map((row) => row.name);
 
-  return tableNames.includes("x_accounts") && tableNames.includes("recovery_submissions");
+  const airdropRoundColumns = getTableColumnNames(db, "airdrop_rounds");
+
+  return tableNames.includes("x_accounts")
+    && tableNames.includes("recovery_submissions")
+    && tableNames.includes("airdrop_rounds")
+    && tableNames.includes("airdrop_claims")
+    && airdropRoundColumns.includes("deployment_key");
 }
 
 function resetToCurrentSchema(db) {
@@ -119,16 +206,12 @@ function resetToCurrentSchema(db) {
 }
 
 function migrateSchema(db) {
-  const transaction = db.transaction(() => {
-    if (hasCurrentSchema(db)) {
-      setSchemaVersion(db, BASE_SCHEMA_VERSION);
-      return;
-    }
+  if (hasCurrentSchema(db)) {
+    setSchemaVersion(db, BASE_SCHEMA_VERSION);
+    return;
+  }
 
-    resetToCurrentSchema(db);
-  });
-
-  transaction();
+  resetToCurrentSchema(db);
 }
 
 function openDatabase() {

--- a/backend/lib/db.js
+++ b/backend/lib/db.js
@@ -1,0 +1,152 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const Database = require("better-sqlite3");
+
+const DEFAULT_DB_PATH = path.join("data", "liberdus.sqlite");
+const BASE_SCHEMA_VERSION = 1;
+function getRepoRoot() {
+  return path.resolve(__dirname, "..", "..");
+}
+
+function resolveRepoPath(filePath) {
+  return path.resolve(getRepoRoot(), filePath);
+}
+
+function getDatabasePath() {
+  return resolveRepoPath(process.env.LIBERDUS_DB_PATH || DEFAULT_DB_PATH);
+}
+
+function ensureDatabaseDirectory(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function setSchemaVersion(db, version) {
+  db.pragma(`user_version = ${Number(version)}`);
+}
+
+function initializeSchema(db) {
+  db.exec(`
+    CREATE TABLE x_accounts (
+      id INTEGER PRIMARY KEY,
+      x_user_id TEXT UNIQUE,
+      username_display TEXT NOT NULL,
+      x_account_created_at TEXT,
+      is_follower INTEGER NOT NULL DEFAULT 0,
+      needs_recovery INTEGER NOT NULL DEFAULT 0,
+      wallet_address TEXT,
+      wallet_source TEXT CHECK (wallet_source IN ('form', 'recovery')),
+      first_seen_following_at TEXT,
+      last_seen_following_at TEXT,
+      snapshots_seen_count INTEGER NOT NULL DEFAULT 0,
+      latest_snapshot_captured_at TEXT,
+      snapshot_history_json TEXT NOT NULL DEFAULT '[]',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX idx_x_accounts_username_lookup
+      ON x_accounts(LOWER(username_display));
+
+    CREATE INDEX idx_x_accounts_is_follower
+      ON x_accounts(is_follower);
+
+    CREATE INDEX idx_x_accounts_needs_recovery
+      ON x_accounts(needs_recovery);
+
+    CREATE TABLE recovery_submissions (
+      id TEXT PRIMARY KEY,
+      account_id INTEGER REFERENCES x_accounts(id) ON DELETE SET NULL,
+      x_user_id TEXT NOT NULL,
+      username_at_submission TEXT NOT NULL,
+      wallet_address TEXT NOT NULL,
+      signed_message TEXT NOT NULL,
+      signature TEXT NOT NULL,
+      was_known_follower INTEGER NOT NULL DEFAULT 0,
+      was_recovery_candidate INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'received',
+      submitted_at TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX idx_recovery_submissions_account_id
+      ON recovery_submissions(account_id);
+
+    CREATE INDEX idx_recovery_submissions_x_user_id
+      ON recovery_submissions(x_user_id);
+
+    CREATE INDEX idx_recovery_submissions_wallet_address
+      ON recovery_submissions(wallet_address);
+  `);
+}
+
+function dropKnownTablesAndIndexes(db) {
+  db.exec(`
+    DROP INDEX IF EXISTS idx_x_accounts_username_norm;
+    DROP INDEX IF EXISTS idx_x_accounts_username_lookup;
+    DROP INDEX IF EXISTS idx_x_accounts_is_follower;
+    DROP INDEX IF EXISTS idx_x_accounts_needs_recovery;
+    DROP INDEX IF EXISTS idx_recovery_submissions_account_id;
+    DROP INDEX IF EXISTS idx_recovery_submissions_x_user_id;
+    DROP INDEX IF EXISTS idx_recovery_submissions_wallet_address;
+    DROP TABLE IF EXISTS recovery_submissions;
+    DROP TABLE IF EXISTS x_recovery_candidates;
+    DROP TABLE IF EXISTS x_recovery_candidate_imports;
+    DROP TABLE IF EXISTS x_follower_snapshot_members;
+    DROP TABLE IF EXISTS x_follower_snapshots;
+    DROP TABLE IF EXISTS x_account_usernames;
+    DROP TABLE IF EXISTS x_accounts;
+    DROP TABLE IF EXISTS x_accounts_legacy;
+  `);
+}
+
+function hasCurrentSchema(db) {
+  const tableNames = db.prepare(`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'table'
+      AND name IN ('x_accounts', 'recovery_submissions')
+    ORDER BY name
+  `).all().map((row) => row.name);
+
+  return tableNames.includes("x_accounts") && tableNames.includes("recovery_submissions");
+}
+
+function resetToCurrentSchema(db) {
+  dropKnownTablesAndIndexes(db);
+  initializeSchema(db);
+  setSchemaVersion(db, BASE_SCHEMA_VERSION);
+}
+
+function migrateSchema(db) {
+  const transaction = db.transaction(() => {
+    if (hasCurrentSchema(db)) {
+      setSchemaVersion(db, BASE_SCHEMA_VERSION);
+      return;
+    }
+
+    resetToCurrentSchema(db);
+  });
+
+  transaction();
+}
+
+function openDatabase() {
+  const databasePath = getDatabasePath();
+  ensureDatabaseDirectory(databasePath);
+
+  const db = new Database(databasePath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("synchronous = NORMAL");
+  db.pragma("foreign_keys = ON");
+  db.pragma("busy_timeout = 5000");
+  migrateSchema(db);
+  return db;
+}
+
+module.exports = {
+  DEFAULT_DB_PATH,
+  getDatabasePath,
+  openDatabase,
+  resolveRepoPath,
+};

--- a/backend/lib/recovery-submission-store.js
+++ b/backend/lib/recovery-submission-store.js
@@ -1,0 +1,171 @@
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function createRecoverySubmissionStore(db) {
+  const statements = {
+    insertSubmission: db.prepare(`
+      INSERT INTO recovery_submissions (
+        id,
+        account_id,
+        x_user_id,
+        username_at_submission,
+        wallet_address,
+        signed_message,
+        signature,
+        was_known_follower,
+        was_recovery_candidate,
+        status,
+        submitted_at,
+        created_at
+      ) VALUES (
+        @id,
+        @accountId,
+        @xUserId,
+        @usernameAtSubmission,
+        @walletAddress,
+        @signedMessage,
+        @signature,
+        @wasKnownFollower,
+        @wasRecoveryCandidate,
+        @status,
+        @submittedAt,
+        @createdAt
+      )
+    `),
+    hasSubmissionId: db.prepare(`
+      SELECT 1
+      FROM recovery_submissions
+      WHERE id = ?
+      LIMIT 1
+    `),
+    getStats: db.prepare(`
+      SELECT COUNT(*) AS submissionCount
+      FROM recovery_submissions
+    `),
+    getLatestByUserId: db.prepare(`
+      SELECT *
+      FROM recovery_submissions
+      WHERE x_user_id = ?
+      ORDER BY datetime(submitted_at) DESC, rowid DESC
+      LIMIT 1
+    `),
+    getLatestByUsername: db.prepare(`
+      SELECT *
+      FROM recovery_submissions
+      WHERE LOWER(username_at_submission) = ?
+      ORDER BY datetime(submitted_at) DESC, rowid DESC
+      LIMIT 1
+    `),
+  };
+
+  const createSubmission = db.transaction((submission) => {
+    statements.insertSubmission.run({
+      id: submission.id || crypto.randomUUID(),
+      accountId: submission.accountId || null,
+      xUserId: submission.xUserId,
+      usernameAtSubmission: submission.usernameAtSubmission,
+      walletAddress: submission.walletAddress,
+      signedMessage: submission.signedMessage,
+      signature: submission.signature,
+      wasKnownFollower: submission.wasKnownFollower ? 1 : 0,
+      wasRecoveryCandidate: submission.wasRecoveryCandidate ? 1 : 0,
+      status: submission.status || "received",
+      submittedAt: submission.submittedAt,
+      createdAt: submission.createdAt || submission.submittedAt,
+    });
+  });
+
+  return {
+    createSubmission(submission) {
+      createSubmission(submission);
+    },
+
+    importLegacyStore(filePath, accountStore) {
+      const resolvedPath = path.resolve(filePath);
+      const rawStore = readJsonFile(resolvedPath);
+      const records = Array.isArray(rawStore?.records) ? rawStore.records : [];
+      let importedCount = 0;
+
+      const transaction = db.transaction(() => {
+        for (const record of records) {
+          if (!record?.id || statements.hasSubmissionId.get(record.id)) {
+            continue;
+          }
+
+          const profile = {
+            id: String(record.xUserId || "").trim(),
+            username: String(record.xUsername || "").trim(),
+            name: String(record.xName || record.xUsername || "").trim(),
+          };
+          const account = accountStore.upsertAuthenticatedProfile(profile, record.updatedAt || new Date().toISOString());
+
+          if (record.isRecoveryCandidate && record.walletAddress) {
+            accountStore.saveRecoveryWallet(profile, String(record.walletAddress).trim(), record.updatedAt || new Date().toISOString());
+          }
+
+          statements.insertSubmission.run({
+            id: record.id,
+            accountId: account?.id || null,
+            xUserId: String(record.xUserId || "").trim(),
+            usernameAtSubmission: String(record.xUsername || "").trim(),
+            walletAddress: String(record.walletAddress || "").trim(),
+            signedMessage: String(record.signedMessage || "").trim(),
+            signature: String(record.signature || "").trim(),
+            wasKnownFollower: record.isKnownFollower ? 1 : 0,
+            wasRecoveryCandidate: record.isRecoveryCandidate ? 1 : 0,
+            status: "legacy-import",
+            submittedAt: String(record.updatedAt || record.createdAt || new Date().toISOString()),
+            createdAt: String(record.createdAt || record.updatedAt || new Date().toISOString()),
+          });
+          importedCount += 1;
+        }
+      });
+
+      transaction();
+      return {
+        importedCount,
+        sourceFilePath: resolvedPath,
+      };
+    },
+
+    getStats() {
+      const row = statements.getStats.get() || {};
+      return {
+        submissionCount: Number(row.submissionCount || 0),
+      };
+    },
+
+    getLatestSubmissionForProfile(profile = {}) {
+      const xUserId = String(profile.id || "").trim();
+      const username = String(profile.username || "").trim().replace(/^@+/u, "").toLowerCase();
+
+      const row = (xUserId ? statements.getLatestByUserId.get(xUserId) : null)
+        || (username ? statements.getLatestByUsername.get(username) : null);
+
+      if (!row) {
+        return null;
+      }
+
+      return {
+        id: String(row.id || "").trim(),
+        accountId: row.account_id == null ? null : Number(row.account_id),
+        xUserId: String(row.x_user_id || "").trim(),
+        usernameAtSubmission: String(row.username_at_submission || "").trim(),
+        walletAddress: String(row.wallet_address || "").trim(),
+        wasKnownFollower: Boolean(row.was_known_follower),
+        wasRecoveryCandidate: Boolean(row.was_recovery_candidate),
+        status: String(row.status || "").trim(),
+        submittedAt: String(row.submitted_at || "").trim(),
+      };
+    },
+  };
+}
+
+module.exports = {
+  createRecoverySubmissionStore,
+};

--- a/backend/lib/x-account-store.js
+++ b/backend/lib/x-account-store.js
@@ -1,0 +1,699 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { parse } = require("csv-parse/sync");
+
+function normalizeUsername(username) {
+  return String(username || "").trim().replace(/^@+/u, "").toLowerCase();
+}
+
+function normalizeIsoDate(value, fallbackValue = null) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue) return fallbackValue;
+
+  const date = new Date(rawValue);
+  if (Number.isNaN(date.getTime())) return fallbackValue;
+  return date.toISOString();
+}
+
+function parseBoolean(value) {
+  const rawValue = String(value || "").trim().toLowerCase();
+  return rawValue === "true" || rawValue === "1" || rawValue === "yes";
+}
+
+function parseInteger(value, fallbackValue = 0) {
+  const parsed = Number.parseInt(String(value || "").trim(), 10);
+  if (!Number.isFinite(parsed)) return fallbackValue;
+  return parsed;
+}
+
+function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function parseSnapshotHistory(rawValue) {
+  try {
+    const parsed = JSON.parse(rawValue || "[]");
+    if (!Array.isArray(parsed)) return [];
+    return [...new Set(parsed.map((value) => normalizeIsoDate(value)).filter(Boolean))].sort();
+  } catch {
+    return [];
+  }
+}
+
+function serializeSnapshotHistory(values) {
+  return JSON.stringify([...new Set(values.filter(Boolean))].sort());
+}
+
+function buildSnapshotHistory(existingAccount, capturedAt) {
+  const normalizedCapturedAt = normalizeIsoDate(capturedAt);
+  const existingHistory = existingAccount?.snapshotHistory || [];
+  const history = [...new Set([...existingHistory, normalizedCapturedAt].filter(Boolean))].sort();
+  const previousCount = Number(existingAccount?.snapshotsSeenCount || 0);
+  const previousLatest = normalizeIsoDate(existingAccount?.latestSnapshotCapturedAt);
+  const isExistingLatest = Boolean(previousLatest && previousLatest === normalizedCapturedAt);
+
+  return {
+    history,
+    historyJson: serializeSnapshotHistory(history),
+    firstSeenFollowingAt: normalizeIsoDate(
+      existingAccount?.firstSeenFollowingAt,
+      history[0] || normalizedCapturedAt || null,
+    ) || history[0] || normalizedCapturedAt || null,
+    lastSeenFollowingAt: [existingAccount?.lastSeenFollowingAt, normalizedCapturedAt]
+      .map((value) => normalizeIsoDate(value))
+      .filter(Boolean)
+      .sort()
+      .at(-1) || null,
+    snapshotsSeenCount: normalizedCapturedAt
+      ? Math.max(history.length, previousCount + (isExistingLatest ? 0 : 1))
+      : Math.max(history.length, previousCount),
+    latestSnapshotCapturedAt: [previousLatest, normalizedCapturedAt]
+      .filter(Boolean)
+      .sort()
+      .at(-1) || null,
+  };
+}
+
+function resolveSnapshotRollup(existingAccount, input) {
+  if (input.snapshotCapturedAt) {
+    return buildSnapshotHistory(existingAccount, input.snapshotCapturedAt);
+  }
+
+  const explicitHistory = Array.isArray(input.snapshotHistory)
+    ? [...new Set(input.snapshotHistory.map((value) => normalizeIsoDate(value)).filter(Boolean))].sort()
+    : null;
+  const history = explicitHistory || existingAccount?.snapshotHistory || [];
+
+  return {
+    history,
+    historyJson: serializeSnapshotHistory(history),
+    firstSeenFollowingAt: normalizeIsoDate(
+      input.firstSeenFollowingAt,
+      existingAccount?.firstSeenFollowingAt || history[0] || null,
+    ),
+    lastSeenFollowingAt: normalizeIsoDate(
+      input.lastSeenFollowingAt,
+      existingAccount?.lastSeenFollowingAt || history[history.length - 1] || null,
+    ),
+    snapshotsSeenCount: parseInteger(
+      input.snapshotsSeenCount,
+      existingAccount?.snapshotsSeenCount || history.length || 0,
+    ),
+    latestSnapshotCapturedAt: normalizeIsoDate(
+      input.latestSnapshotCapturedAt,
+      existingAccount?.latestSnapshotCapturedAt || history[history.length - 1] || null,
+    ),
+  };
+}
+
+function normalizeFollowerSnapshot(rawSnapshot, options = {}) {
+  const importedAt = normalizeIsoDate(options.importedAt, new Date().toISOString());
+  const sourceUsernameDisplay = String(
+    rawSnapshot?.username
+    || rawSnapshot?.sourceUser?.username
+    || options.sourceUsername
+    || "",
+  ).trim();
+  const sourceUsernameNorm = normalizeUsername(sourceUsernameDisplay);
+
+  if (!sourceUsernameNorm) {
+    throw new Error("Follower snapshot is missing the source account username.");
+  }
+
+  const capturedAt = normalizeIsoDate(
+    rawSnapshot?.completedAt
+    || rawSnapshot?.updatedAt
+    || rawSnapshot?.startedAt,
+    importedAt,
+  );
+  const rawFollowers = Array.isArray(rawSnapshot?.followers) ? rawSnapshot.followers : [];
+  const dedupedFollowers = new Map();
+
+  for (const follower of rawFollowers) {
+    const xUserId = String(follower?.id || "").trim();
+    const usernameDisplay = String(follower?.username || "").trim().replace(/^@+/u, "");
+    const usernameNorm = normalizeUsername(usernameDisplay);
+    if (!xUserId || !usernameNorm) continue;
+
+    dedupedFollowers.set(xUserId, {
+      xUserId,
+      usernameDisplay: usernameDisplay || usernameNorm,
+      xAccountCreatedAt: normalizeIsoDate(follower?.created_at),
+    });
+  }
+
+  return {
+    sourceUsernameNorm,
+    sourceUsernameDisplay,
+    capturedAt,
+    importedAt,
+    followers: [...dedupedFollowers.values()],
+  };
+}
+
+function loadJsonCandidates(filePath) {
+  const rawValue = readJsonFile(filePath);
+  if (Array.isArray(rawValue)) {
+    return rawValue;
+  }
+  if (Array.isArray(rawValue?.usernames)) {
+    return rawValue.usernames;
+  }
+  if (Array.isArray(rawValue?.records)) {
+    return rawValue.records;
+  }
+  throw new Error("Recovery candidates JSON must be an array or an object with a usernames array.");
+}
+
+function normalizeRecoveryCandidates(filePath, options = {}) {
+  const importedAt = normalizeIsoDate(options.importedAt, new Date().toISOString());
+  const extension = path.extname(filePath).toLowerCase();
+  const dedupedCandidates = new Map();
+
+  if (extension === ".csv") {
+    const rows = parse(fs.readFileSync(filePath, "utf8"), {
+      columns: true,
+      bom: true,
+      skip_empty_lines: true,
+      relax_column_count: true,
+      trim: true,
+    });
+
+    for (const row of rows) {
+      const usernameDisplay = String(
+        row.api_username
+        || row.username
+        || row.x_username
+        || "",
+      ).trim().replace(/^@+/u, "");
+      const usernameNorm = normalizeUsername(usernameDisplay);
+      if (!usernameNorm) continue;
+
+      dedupedCandidates.set(usernameNorm, {
+        xUserId: String(row.api_user_id || row.x_user_id || row.user_id || "").trim(),
+        usernameDisplay: usernameDisplay || usernameNorm,
+        xAccountCreatedAt: normalizeIsoDate(row.api_created_at || row.created_at),
+        apiVerified: parseBoolean(row.api_verified || row.verified),
+        isRecentAccount: parseBoolean(
+          row.api_created_on_or_after_2026_03_25
+          || row.created_on_or_after_cutoff
+          || row.is_recent_account,
+        ),
+      });
+    }
+  } else {
+    for (const candidate of loadJsonCandidates(filePath)) {
+      if (typeof candidate === "string") {
+        const usernameDisplay = String(candidate).trim().replace(/^@+/u, "");
+        const usernameNorm = normalizeUsername(usernameDisplay);
+        if (!usernameNorm) continue;
+        dedupedCandidates.set(usernameNorm, {
+          xUserId: "",
+          usernameDisplay: usernameDisplay || usernameNorm,
+          xAccountCreatedAt: null,
+          apiVerified: false,
+          isRecentAccount: false,
+        });
+        continue;
+      }
+
+      if (!candidate || typeof candidate !== "object") {
+        continue;
+      }
+
+      const usernameDisplay = String(
+        candidate.username
+        || candidate.xUsername
+        || "",
+      ).trim().replace(/^@+/u, "");
+      const usernameNorm = normalizeUsername(usernameDisplay);
+      if (!usernameNorm) continue;
+
+      dedupedCandidates.set(usernameNorm, {
+        xUserId: String(candidate.xUserId || candidate.userId || "").trim(),
+        usernameDisplay: usernameDisplay || usernameNorm,
+        xAccountCreatedAt: normalizeIsoDate(candidate.xCreatedAt || candidate.createdAt),
+        apiVerified: Boolean(candidate.apiVerified || candidate.verified),
+        isRecentAccount: Boolean(candidate.createdOnOrAfterCutoff),
+      });
+    }
+  }
+
+  return {
+    importedAt,
+    candidates: [...dedupedCandidates.values()],
+  };
+}
+
+function normalizeCombinedAccounts(filePath, options = {}) {
+  const importedAt = normalizeIsoDate(options.importedAt, new Date().toISOString());
+  const rows = parse(fs.readFileSync(filePath, "utf8"), {
+    columns: true,
+    bom: true,
+    skip_empty_lines: true,
+    relax_column_count: true,
+    trim: true,
+  });
+  const dedupedAccounts = new Map();
+
+  for (const row of rows) {
+    const xUserId = String(row.x_user_id || row.user_id || "").trim();
+    const usernameDisplay = String(
+      row.x_username
+      || row.username
+      || row.api_username
+      || "",
+    ).trim().replace(/^@+/u, "");
+    const usernameNorm = normalizeUsername(usernameDisplay);
+
+    if (!xUserId && !usernameNorm) {
+      continue;
+    }
+
+    dedupedAccounts.set(xUserId || usernameNorm, {
+      xUserId,
+      usernameDisplay: usernameDisplay || usernameNorm,
+      xAccountCreatedAt: normalizeIsoDate(row.x_account_created_at || row.created_at),
+      isFollower: parseBoolean(row.is_follower),
+      needsRecovery: parseBoolean(row.needs_recovery),
+      walletAddress: String(row.wallet_address || "").trim(),
+      walletSource: String(row.wallet_address || "").trim() ? "form" : null,
+      firstSeenFollowingAt: normalizeIsoDate(row.first_seen_following_at),
+      lastSeenFollowingAt: normalizeIsoDate(row.last_seen_following_at),
+      snapshotsSeenCount: parseInteger(row.snapshots_seen_count, 0),
+      latestSnapshotCapturedAt: normalizeIsoDate(row.latest_snapshot_captured_at),
+      updatedAt: importedAt,
+    });
+  }
+
+  return {
+    importedAt,
+    accounts: [...dedupedAccounts.values()],
+  };
+}
+
+function pickWallet(existingRow, nextWalletAddress, nextWalletSource) {
+  if (existingRow?.walletAddress) {
+    return {
+      walletAddress: existingRow.walletAddress,
+      walletSource: existingRow?.walletSource || null,
+    };
+  }
+
+  if (!nextWalletAddress || !nextWalletSource) {
+    return {
+      walletAddress: existingRow?.walletAddress || null,
+      walletSource: existingRow?.walletSource || null,
+    };
+  }
+
+  return {
+    walletAddress: nextWalletAddress,
+    walletSource: nextWalletSource,
+  };
+}
+
+function toSqlParams(record) {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => {
+      if (value === undefined) return [key, null];
+      if (typeof value === "boolean") return [key, value ? 1 : 0];
+      return [key, value];
+    }),
+  );
+}
+
+function createAccountStore(db) {
+  const statements = {
+    getGlobalLatestSnapshot: db.prepare(`
+      SELECT MAX(latest_snapshot_captured_at) AS latestSnapshotCapturedAt
+      FROM x_accounts
+      WHERE latest_snapshot_captured_at IS NOT NULL
+    `),
+    clearFollowerFlags: db.prepare(`
+      UPDATE x_accounts
+      SET is_follower = 0,
+          updated_at = @updatedAt
+    `),
+    clearRecoveryFlags: db.prepare(`
+      UPDATE x_accounts
+      SET needs_recovery = 0,
+          updated_at = @updatedAt
+    `),
+    listByUsernameNorm: db.prepare(`
+      SELECT *
+      FROM x_accounts
+      WHERE LOWER(username_display) = ?
+      ORDER BY datetime(updated_at) DESC, id DESC
+    `),
+    getByXUserId: db.prepare(`
+      SELECT *
+      FROM x_accounts
+      WHERE x_user_id = ?
+    `),
+    getById: db.prepare(`
+      SELECT *
+      FROM x_accounts
+      WHERE id = ?
+    `),
+    insertAccount: db.prepare(`
+      INSERT INTO x_accounts (
+        x_user_id,
+        username_display,
+        x_account_created_at,
+        is_follower,
+        needs_recovery,
+        wallet_address,
+        wallet_source,
+        first_seen_following_at,
+        last_seen_following_at,
+        snapshots_seen_count,
+        latest_snapshot_captured_at,
+        snapshot_history_json,
+        created_at,
+        updated_at
+      ) VALUES (
+        @xUserId,
+        @usernameDisplay,
+        @xAccountCreatedAt,
+        @isFollower,
+        @needsRecovery,
+        @walletAddress,
+        @walletSource,
+        @firstSeenFollowingAt,
+        @lastSeenFollowingAt,
+        @snapshotsSeenCount,
+        @latestSnapshotCapturedAt,
+        @snapshotHistoryJson,
+        @createdAt,
+        @updatedAt
+      )
+    `),
+    updateAccount: db.prepare(`
+      UPDATE x_accounts
+      SET x_user_id = @xUserId,
+          username_display = @usernameDisplay,
+          x_account_created_at = @xAccountCreatedAt,
+          is_follower = @isFollower,
+          needs_recovery = @needsRecovery,
+          wallet_address = @walletAddress,
+          wallet_source = @walletSource,
+          first_seen_following_at = @firstSeenFollowingAt,
+          last_seen_following_at = @lastSeenFollowingAt,
+          snapshots_seen_count = @snapshotsSeenCount,
+          latest_snapshot_captured_at = @latestSnapshotCapturedAt,
+          snapshot_history_json = @snapshotHistoryJson,
+          updated_at = @updatedAt
+      WHERE id = @id
+    `),
+    deleteAccount: db.prepare(`
+      DELETE FROM x_accounts
+      WHERE id = ?
+    `),
+    reassignSubmissions: db.prepare(`
+      UPDATE recovery_submissions
+      SET account_id = ?
+      WHERE account_id = ?
+    `),
+    getCounts: db.prepare(`
+      SELECT
+        COUNT(*) AS accountCount,
+        SUM(CASE WHEN is_follower = 1 THEN 1 ELSE 0 END) AS followerCount,
+        SUM(CASE WHEN needs_recovery = 1 THEN 1 ELSE 0 END) AS recoveryCandidateCount,
+        MAX(latest_snapshot_captured_at) AS latestSnapshotCapturedAt
+      FROM x_accounts
+    `),
+  };
+
+  function toAccountRecord(row) {
+    if (!row) return null;
+    return {
+      id: Number(row.id),
+      xUserId: String(row.x_user_id || "").trim(),
+      usernameDisplay: String(row.username_display || "").trim(),
+      xAccountCreatedAt: normalizeIsoDate(row.x_account_created_at),
+      isFollower: Boolean(row.is_follower),
+      needsRecovery: Boolean(row.needs_recovery),
+      walletAddress: String(row.wallet_address || "").trim(),
+      walletSource: String(row.wallet_source || "").trim(),
+      firstSeenFollowingAt: normalizeIsoDate(row.first_seen_following_at),
+      lastSeenFollowingAt: normalizeIsoDate(row.last_seen_following_at),
+      snapshotsSeenCount: Number(row.snapshots_seen_count || 0),
+      latestSnapshotCapturedAt: normalizeIsoDate(row.latest_snapshot_captured_at),
+      snapshotHistory: parseSnapshotHistory(row.snapshot_history_json),
+      createdAt: normalizeIsoDate(row.created_at),
+      updatedAt: normalizeIsoDate(row.updated_at),
+    };
+  }
+
+  function mergeAccounts(primaryRow, secondaryRow, updatedAt) {
+    if (!primaryRow || !secondaryRow || primaryRow.id === secondaryRow.id) {
+      return primaryRow;
+    }
+
+    const history = [...new Set([...primaryRow.snapshotHistory, ...secondaryRow.snapshotHistory])].sort();
+    const preferredWallet = primaryRow.walletSource === "form"
+      ? primaryRow
+      : secondaryRow.walletSource === "form"
+        ? secondaryRow
+        : primaryRow.walletSource === "recovery"
+          ? primaryRow
+          : secondaryRow.walletSource === "recovery"
+            ? secondaryRow
+            : primaryRow;
+
+    statements.updateAccount.run(toSqlParams({
+      id: primaryRow.id,
+      xUserId: primaryRow.xUserId || secondaryRow.xUserId || null,
+      usernameDisplay: primaryRow.usernameDisplay || secondaryRow.usernameDisplay || "",
+      xAccountCreatedAt: normalizeIsoDate(primaryRow.xAccountCreatedAt || secondaryRow.xAccountCreatedAt),
+      isFollower: primaryRow.isFollower || secondaryRow.isFollower ? 1 : 0,
+      needsRecovery: primaryRow.needsRecovery || secondaryRow.needsRecovery ? 1 : 0,
+      walletAddress: preferredWallet.walletAddress || null,
+      walletSource: preferredWallet.walletSource || null,
+      firstSeenFollowingAt: history[0] || normalizeIsoDate(primaryRow.firstSeenFollowingAt || secondaryRow.firstSeenFollowingAt),
+      lastSeenFollowingAt: history[history.length - 1] || normalizeIsoDate(primaryRow.lastSeenFollowingAt || secondaryRow.lastSeenFollowingAt),
+      snapshotsSeenCount: history.length,
+      latestSnapshotCapturedAt: history[history.length - 1] || normalizeIsoDate(primaryRow.latestSnapshotCapturedAt || secondaryRow.latestSnapshotCapturedAt),
+      snapshotHistoryJson: serializeSnapshotHistory(history),
+      updatedAt,
+    }));
+    statements.reassignSubmissions.run(primaryRow.id, secondaryRow.id);
+    statements.deleteAccount.run(secondaryRow.id);
+    return toAccountRecord(statements.getById.get(primaryRow.id));
+  }
+
+  function resolveExistingAccount(xUserId, usernameLookup, updatedAt) {
+    const byUserId = xUserId ? toAccountRecord(statements.getByXUserId.get(xUserId)) : null;
+    const byUsername = usernameLookup ? toAccountRecord(statements.listByUsernameNorm.get(usernameLookup)) : null;
+
+    if (byUserId && byUsername && byUserId.id !== byUsername.id) {
+      return mergeAccounts(byUserId, byUsername, updatedAt);
+    }
+
+    return byUserId || byUsername || null;
+  }
+
+  function saveAccount(input) {
+    const updatedAt = normalizeIsoDate(input.updatedAt, new Date().toISOString());
+    const usernameLookup = normalizeUsername(input.usernameDisplay || input.usernameNorm);
+    const usernameDisplay = String(input.usernameDisplay || input.usernameNorm || "").trim().replace(/^@+/u, "");
+    if (!usernameDisplay && !String(input.xUserId || "").trim()) {
+      throw new Error("Account row requires an X user id or username.");
+    }
+
+    let existing = resolveExistingAccount(String(input.xUserId || "").trim(), usernameLookup, updatedAt);
+    const historyState = resolveSnapshotRollup(existing, input);
+    const preferredWallet = pickWallet(existing, input.walletAddress, input.walletSource);
+    const record = {
+      xUserId: String(input.xUserId || existing?.xUserId || "").trim() || null,
+      usernameDisplay: usernameDisplay || existing?.usernameDisplay || input.xUserId || "",
+      xAccountCreatedAt: normalizeIsoDate(input.xAccountCreatedAt || existing?.xAccountCreatedAt),
+      isFollower: input.isFollower ?? existing?.isFollower ?? false,
+      needsRecovery: input.needsRecovery ?? existing?.needsRecovery ?? false,
+      walletAddress: preferredWallet.walletAddress || null,
+      walletSource: preferredWallet.walletSource || null,
+      firstSeenFollowingAt: historyState.firstSeenFollowingAt || null,
+      lastSeenFollowingAt: historyState.lastSeenFollowingAt || null,
+      snapshotsSeenCount: historyState.snapshotsSeenCount || 0,
+      latestSnapshotCapturedAt: historyState.latestSnapshotCapturedAt || null,
+      snapshotHistoryJson: historyState.historyJson,
+      createdAt: existing?.createdAt || updatedAt,
+      updatedAt,
+    };
+
+    if (!existing) {
+      const insertResult = statements.insertAccount.run(toSqlParams(record));
+      return toAccountRecord(statements.getById.get(insertResult.lastInsertRowid));
+    }
+
+    statements.updateAccount.run(toSqlParams({
+      id: existing.id,
+      ...record,
+    }));
+    return toAccountRecord(statements.getById.get(existing.id));
+  }
+
+  const importFollowerSnapshot = db.transaction((snapshot) => {
+    const updatedAt = snapshot.importedAt;
+    const currentLatest = normalizeIsoDate(statements.getGlobalLatestSnapshot.get()?.latestSnapshotCapturedAt);
+    const becomesLatest = !currentLatest || snapshot.capturedAt >= currentLatest;
+
+    if (becomesLatest) {
+      statements.clearFollowerFlags.run({ updatedAt });
+    }
+
+    let importedCount = 0;
+    for (const follower of snapshot.followers) {
+      saveAccount({
+        xUserId: follower.xUserId,
+        usernameDisplay: follower.usernameDisplay,
+        xAccountCreatedAt: follower.xAccountCreatedAt,
+        snapshotCapturedAt: snapshot.capturedAt,
+        isFollower: becomesLatest ? true : undefined,
+        updatedAt,
+      });
+      importedCount += 1;
+    }
+
+    return {
+      importedCount,
+      becameLatest: becomesLatest,
+      capturedAt: snapshot.capturedAt,
+    };
+  });
+
+  const importRecoveryCandidates = db.transaction((candidateImport) => {
+    const updatedAt = candidateImport.importedAt;
+    statements.clearRecoveryFlags.run({ updatedAt });
+
+    let importedCount = 0;
+    for (const candidate of candidateImport.candidates) {
+      saveAccount({
+        xUserId: candidate.xUserId,
+        usernameDisplay: candidate.usernameDisplay,
+        xAccountCreatedAt: candidate.xAccountCreatedAt,
+        needsRecovery: true,
+        updatedAt,
+      });
+      importedCount += 1;
+    }
+
+    return {
+      importedCount,
+      importedAt: candidateImport.importedAt,
+    };
+  });
+
+  const importCombinedAccounts = db.transaction((accountImport) => {
+    const updatedAt = accountImport.importedAt;
+    statements.clearFollowerFlags.run({ updatedAt });
+    statements.clearRecoveryFlags.run({ updatedAt });
+
+    let importedCount = 0;
+    for (const account of accountImport.accounts) {
+      saveAccount({
+        xUserId: account.xUserId,
+        usernameDisplay: account.usernameDisplay,
+        xAccountCreatedAt: account.xAccountCreatedAt,
+        isFollower: account.isFollower,
+        needsRecovery: account.needsRecovery,
+        walletAddress: account.walletAddress,
+        walletSource: account.walletSource,
+        firstSeenFollowingAt: account.firstSeenFollowingAt,
+        lastSeenFollowingAt: account.lastSeenFollowingAt,
+        snapshotsSeenCount: account.snapshotsSeenCount,
+        latestSnapshotCapturedAt: account.latestSnapshotCapturedAt,
+        updatedAt,
+      });
+      importedCount += 1;
+    }
+
+    return {
+      importedCount,
+      importedAt: accountImport.importedAt,
+    };
+  });
+
+  return {
+    normalizeFollowerSnapshotFromFile(filePath, options = {}) {
+      return normalizeFollowerSnapshot(readJsonFile(filePath), options);
+    },
+
+    normalizeRecoveryCandidatesFromFile(filePath, options = {}) {
+      return normalizeRecoveryCandidates(filePath, options);
+    },
+
+    normalizeCombinedAccountsFromFile(filePath, options = {}) {
+      return normalizeCombinedAccounts(filePath, options);
+    },
+
+    importFollowerSnapshotFromFile(filePath, options = {}) {
+      const resolvedPath = path.resolve(filePath);
+      return importFollowerSnapshot(this.normalizeFollowerSnapshotFromFile(resolvedPath, options));
+    },
+
+    importRecoveryCandidatesFromFile(filePath, options = {}) {
+      const resolvedPath = path.resolve(filePath);
+      return importRecoveryCandidates(this.normalizeRecoveryCandidatesFromFile(resolvedPath, options));
+    },
+
+    importCombinedAccountsFromFile(filePath, options = {}) {
+      const resolvedPath = path.resolve(filePath);
+      return importCombinedAccounts(this.normalizeCombinedAccountsFromFile(resolvedPath, options));
+    },
+
+    getAccountByProfile(profile = {}) {
+      return resolveExistingAccount(String(profile.id || "").trim(), normalizeUsername(profile.username), new Date().toISOString());
+    },
+
+    getFlagsForProfile(profile = {}) {
+      const account = this.getAccountByProfile(profile);
+      return {
+        account,
+        isKnownFollower: Boolean(account && (account.isFollower || account.snapshotsSeenCount > 0)),
+        isRecoveryCandidate: Boolean(account?.needsRecovery),
+      };
+    },
+
+    upsertAuthenticatedProfile(profile = {}, updatedAt = new Date().toISOString()) {
+      return saveAccount({
+        xUserId: String(profile.id || "").trim(),
+        usernameDisplay: String(profile.username || "").trim(),
+        updatedAt,
+      });
+    },
+
+    saveRecoveryWallet(profile = {}, walletAddress, updatedAt = new Date().toISOString()) {
+      const account = this.getAccountByProfile(profile);
+      if (!account?.needsRecovery || account?.walletAddress) {
+        return account;
+      }
+
+      return saveAccount({
+        xUserId: String(profile.id || account.xUserId || "").trim(),
+        usernameDisplay: String(profile.username || account.usernameDisplay || "").trim(),
+        walletAddress,
+        walletSource: "recovery",
+        updatedAt,
+      });
+    },
+
+    getStats() {
+      const row = statements.getCounts.get() || {};
+      return {
+        accountCount: Number(row.accountCount || 0),
+        followerCount: Number(row.followerCount || 0),
+        recoveryCandidateCount: Number(row.recoveryCandidateCount || 0),
+        latestSnapshotCapturedAt: normalizeIsoDate(row.latestSnapshotCapturedAt),
+      };
+    },
+  };
+}
+
+module.exports = {
+  createAccountStore,
+  normalizeIsoDate,
+  normalizeUsername,
+};

--- a/backend/pm2.config.cjs
+++ b/backend/pm2.config.cjs
@@ -1,0 +1,22 @@
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+module.exports = {
+  apps: [
+    {
+      name: process.env.PM2_APP_NAME || "liberdus-airdrop-backend",
+      cwd: repoRoot,
+      script: path.join(repoRoot, "backend", "server.js"),
+      interpreter: "node",
+      exec_mode: "fork",
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: "512M",
+      env: {
+        NODE_ENV: process.env.NODE_ENV || "production",
+      },
+    },
+  ],
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,9 @@ const path = require("node:path");
 
 const dotenv = require("dotenv");
 const { ethers } = require("ethers");
+const { openDatabase, getDatabasePath } = require("./lib/db");
+const { createAccountStore } = require("./lib/x-account-store");
+const { createRecoverySubmissionStore } = require("./lib/recovery-submission-store");
 
 dotenv.config({ path: path.join(__dirname, "..", ".env"), quiet: true });
 
@@ -126,15 +129,15 @@ function validateReturnUri(returnUri) {
   return normalized;
 }
 
-function getFollowerSnapshotPath() {
+function getLegacyFollowerSnapshotPath() {
   return resolveRepoPath(process.env.X_FOLLOWER_SNAPSHOT_FILE || DEFAULT_FOLLOWER_SNAPSHOT_FILE);
 }
 
-function getRecoveryCandidatesPath() {
+function getLegacyRecoveryCandidatesPath() {
   return resolveRepoPath(process.env.X_RECOVERY_CANDIDATES_FILE || DEFAULT_RECOVERY_CANDIDATES_FILE);
 }
 
-function getRecoveryStorePath() {
+function getLegacyRecoveryStorePath() {
   return resolveRepoPath(process.env.X_RECOVERY_STORE_FILE || DEFAULT_RECOVERY_STORE_FILE);
 }
 
@@ -158,72 +161,9 @@ function shouldTrustProxy() {
   return /^true$/iu.test(String(process.env.X_AUTH_TRUST_PROXY || "").trim());
 }
 
-function normalizeUsername(username) {
-  return String(username || "").trim().replace(/^@+/u, "").toLowerCase();
-}
-
-function readJsonIfExists(filePath, fallbackValue) {
-  try {
-    if (!fs.existsSync(filePath)) return fallbackValue;
-    return JSON.parse(fs.readFileSync(filePath, "utf8"));
-  } catch {
-    return fallbackValue;
-  }
-}
-
-function ensureDirectory(filePath) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-}
-
-function writeJsonFile(filePath, value) {
-  ensureDirectory(filePath);
-  const tempPath = `${filePath}.${crypto.randomUUID()}.tmp`;
-  fs.writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
-  fs.renameSync(tempPath, filePath);
-}
-
-function loadFollowerUsernames() {
-  const snapshot = readJsonIfExists(getFollowerSnapshotPath(), {});
-  const followers = Array.isArray(snapshot?.followers) ? snapshot.followers : [];
-  return new Set(
-    followers
-      .map((follower) => normalizeUsername(follower?.username))
-      .filter(Boolean),
-  );
-}
-
-function loadRecoveryCandidateUsernames() {
-  const rawValue = readJsonIfExists(getRecoveryCandidatesPath(), []);
-  const usernames = Array.isArray(rawValue)
-    ? rawValue
-    : Array.isArray(rawValue?.usernames)
-      ? rawValue.usernames
-      : [];
-
-  return new Set(usernames.map((username) => normalizeUsername(username)).filter(Boolean));
-}
-
-function loadRecoveryStore() {
-  const loaded = readJsonIfExists(getRecoveryStorePath(), null);
-  if (loaded && typeof loaded === "object" && Array.isArray(loaded.records)) {
-    return loaded;
-  }
-
-  return {
-    version: 1,
-    updatedAt: null,
-    records: [],
-  };
-}
-
-function saveRecoveryStore(store) {
-  store.updatedAt = new Date().toISOString();
-  writeJsonFile(getRecoveryStorePath(), store);
-}
-
-const followerUsernames = loadFollowerUsernames();
-const recoveryCandidateUsernames = loadRecoveryCandidateUsernames();
-const recoveryStore = loadRecoveryStore();
+const db = openDatabase();
+const accountStore = createAccountStore(db);
+const recoverySubmissionStore = createRecoverySubmissionStore(db);
 
 function createRandomToken(bytes = 32) {
   return crypto.randomBytes(bytes).toString("hex");
@@ -685,30 +625,6 @@ function buildWalletLinkMessage({ profile, walletAddress, challengeId, issuedAt 
   ].join("\n");
 }
 
-function upsertRecoveryRecord(record) {
-  const existingIndex = recoveryStore.records.findIndex(
-    (entry) => String(entry.xUserId || "").trim() === String(record.xUserId || "").trim()
-      && String(entry.walletAddress || "").toLowerCase() === String(record.walletAddress || "").toLowerCase(),
-  );
-
-  if (existingIndex >= 0) {
-    recoveryStore.records[existingIndex] = {
-      ...recoveryStore.records[existingIndex],
-      ...record,
-      updatedAt: new Date().toISOString(),
-    };
-    return recoveryStore.records[existingIndex];
-  }
-
-  const nextRecord = {
-    ...record,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-  };
-  recoveryStore.records.push(nextRecord);
-  return nextRecord;
-}
-
 function appendAuthQuery(returnUri, key, value) {
   const redirectUrl = new URL(returnUri);
   redirectUrl.searchParams.set(key, value);
@@ -761,26 +677,80 @@ function normalizeIdentityFromOAuth1(accessTokenResponse, verifiedCredentials = 
   };
 }
 
+function serializeAccountForClient(account) {
+  if (!account) return null;
+
+  return {
+    id: account.id,
+    xUserId: account.xUserId,
+    username: account.usernameDisplay,
+    walletAddress: account.walletAddress || "",
+    walletSource: account.walletSource || "",
+    isFollower: Boolean(account.isFollower),
+    needsRecovery: Boolean(account.needsRecovery),
+    firstSeenFollowingAt: account.firstSeenFollowingAt || null,
+    lastSeenFollowingAt: account.lastSeenFollowingAt || null,
+    snapshotsSeenCount: Number(account.snapshotsSeenCount || 0),
+  };
+}
+
+function serializeSubmissionForClient(submission) {
+  if (!submission) return null;
+
+  return {
+    id: submission.id,
+    xUserId: submission.xUserId,
+    usernameAtSubmission: submission.usernameAtSubmission,
+    walletAddress: submission.walletAddress,
+    wasKnownFollower: Boolean(submission.wasKnownFollower),
+    wasRecoveryCandidate: Boolean(submission.wasRecoveryCandidate),
+    status: submission.status || "",
+    submittedAt: submission.submittedAt || null,
+  };
+}
+
+function getExistingWalletMessage(account) {
+  if (!account?.walletAddress) {
+    return "";
+  }
+
+  if (account.walletSource === "form") {
+    return `We already have a wallet on file for this X account: ${account.walletAddress}.`;
+  }
+
+  return "We already received a response for this X account.";
+}
+
+function getExistingRecoverySubmissionMessage() {
+  return "We already received a response for this X account.";
+}
+
 function getHealthPayload(request) {
   const basePayload = { ok: true };
   if (!isLoopbackAddress(getClientIp(request))) {
     return basePayload;
   }
 
+  const accountStats = accountStore.getStats();
+  const submissionStats = recoverySubmissionStore.getStats();
+
   return {
     ...basePayload,
     apiKeyConfigured: Boolean(getApiKey()),
     apiSecretConfigured: Boolean(getApiSecret()),
     callbackUrl: getCallbackUrl(),
+    databasePath: getDatabasePath(),
     defaultFrontendReturnUrl: getDefaultFrontendReturnUrl(),
     allowedOrigins: getAllowedOrigins(),
     allowedReturnUrls: getAllowedReturnUrls(),
-    followerSnapshotPath: getFollowerSnapshotPath(),
-    followerSnapshotCount: followerUsernames.size,
-    recoveryCandidatesPath: getRecoveryCandidatesPath(),
-    recoveryCandidateCount: recoveryCandidateUsernames.size,
-    recoveryStorePath: getRecoveryStorePath(),
-    recoveryRecordCount: recoveryStore.records.length,
+    legacyFollowerSnapshotPath: getLegacyFollowerSnapshotPath(),
+    legacyRecoveryCandidatesPath: getLegacyRecoveryCandidatesPath(),
+    legacyRecoveryStorePath: getLegacyRecoveryStorePath(),
+    accountCount: accountStats.accountCount,
+    followerCount: accountStats.followerCount,
+    recoveryCandidateCount: accountStats.recoveryCandidateCount,
+    latestSnapshotCapturedAt: accountStats.latestSnapshotCapturedAt,
+    recoverySubmissionCount: submissionStats.submissionCount,
     activeAuthSessions: authSessions.size,
     activeRequestTokens: requestTokens.size,
     activeChallenges: linkChallenges.size,
@@ -959,18 +929,32 @@ async function handleCallback(request, response) {
 
 async function handleSessionLookup(request, response) {
   const session = getRequiredSessionFromCookie(request, response);
+  const account = accountStore.getAccountByProfile(session.profile);
+  const existingSubmission = recoverySubmissionStore.getLatestSubmissionForProfile(session.profile);
 
   writeJson(response, 200, {
     profile: session.profile,
     authenticatedAt: session.authenticatedAt,
     expiresAt: session.expiresAtMs,
     csrfToken: session.csrfToken,
+    account: serializeAccountForClient(account),
+    existingSubmission: serializeSubmissionForClient(existingSubmission),
   });
 }
 
 async function handleLinkChallenge(request, response) {
   const session = getRequiredSessionFromCookie(request, response);
   requireCsrf(request, session);
+  const flags = accountStore.getFlagsForProfile(session.profile);
+  const existingSubmission = recoverySubmissionStore.getLatestSubmissionForProfile(session.profile);
+
+  if (flags.account?.walletAddress) {
+    throw new HttpError(409, getExistingWalletMessage(flags.account));
+  }
+
+  if (existingSubmission) {
+    throw new HttpError(409, getExistingRecoverySubmissionMessage());
+  }
 
   const body = await readJsonRequest(request);
   const walletAddress = requireWalletAddress(body.walletAddress);
@@ -1008,6 +992,16 @@ async function handleLinkChallenge(request, response) {
 async function handleLinkComplete(request, response) {
   const session = getRequiredSessionFromCookie(request, response);
   requireCsrf(request, session);
+  const flags = accountStore.getFlagsForProfile(session.profile);
+  const existingSubmission = recoverySubmissionStore.getLatestSubmissionForProfile(session.profile);
+
+  if (flags.account?.walletAddress) {
+    throw new HttpError(409, getExistingWalletMessage(flags.account));
+  }
+
+  if (existingSubmission) {
+    throw new HttpError(409, getExistingRecoverySubmissionMessage());
+  }
 
   const body = await readJsonRequest(request);
   const challengeId = String(body.challengeId || "").trim();
@@ -1044,38 +1038,40 @@ async function handleLinkComplete(request, response) {
   }
 
   linkChallenges.delete(challengeId);
+  const savedAt = new Date().toISOString();
+  const knownAccount = accountStore.upsertAuthenticatedProfile(session.profile, savedAt);
+  const walletAccount = flags.isRecoveryCandidate
+    ? (accountStore.saveRecoveryWallet(session.profile, walletAddress, savedAt) || knownAccount)
+    : knownAccount;
+  const submissionId = crypto.randomUUID();
 
-  const normalizedUsername = normalizeUsername(session.profile.username);
-  const isKnownFollower = followerUsernames.has(normalizedUsername);
-  const isRecoveryCandidate = recoveryCandidateUsernames.has(normalizedUsername);
-  const savedRecord = upsertRecoveryRecord({
-    id: crypto.randomUUID(),
-    xUserId: String(session.profile.id),
-    xUsername: String(session.profile.username),
-    xName: String(session.profile.name || session.profile.username),
+  recoverySubmissionStore.createSubmission({
+    id: submissionId,
+    accountId: walletAccount?.id || knownAccount?.id || flags.account?.id || null,
+    xUserId: String(session.profile.id || "").trim(),
+    usernameAtSubmission: String(session.profile.username || "").trim(),
     walletAddress,
-    profileImageUrl: String(session.profile.profile_image_url || session.profile.profileImageUrl || ""),
-    verified: Boolean(session.profile.verified),
-    verifiedType: String(session.profile.verified_type || session.profile.verifiedType || ""),
-    authenticatedAt: session.authenticatedAt,
-    challengeId,
     signedMessage: challenge.message,
     signature,
-    isKnownFollower,
-    isRecoveryCandidate,
-    source: "x-follow-recovery",
+    wasKnownFollower: flags.isKnownFollower,
+    wasRecoveryCandidate: flags.isRecoveryCandidate,
+    status: "received",
+    submittedAt: savedAt,
+    createdAt: savedAt,
   });
 
-  saveRecoveryStore(recoveryStore);
-
   writeJson(response, 200, {
-    recordId: savedRecord.id,
-    walletAddress: savedRecord.walletAddress,
-    xUsername: savedRecord.xUsername,
-    xUserId: savedRecord.xUserId,
-    isKnownFollower: savedRecord.isKnownFollower,
-    isRecoveryCandidate: savedRecord.isRecoveryCandidate,
-    savedAt: savedRecord.updatedAt,
+    recordId: submissionId,
+    walletAddress,
+    xUsername: String(session.profile.username || "").trim(),
+    xUserId: String(session.profile.id || "").trim(),
+    isKnownFollower: flags.isKnownFollower,
+    isRecoveryCandidate: flags.isRecoveryCandidate,
+    savedAt,
+    account: serializeAccountForClient(walletAccount || knownAccount || flags.account),
+    existingSubmission: serializeSubmissionForClient(
+      recoverySubmissionStore.getLatestSubmissionForProfile(session.profile),
+    ),
   });
 }
 
@@ -1119,7 +1115,7 @@ function handleError(response, error) {
   const statusCode = error instanceof HttpError ? error.statusCode : 500;
   const headers = error instanceof HttpError ? error.headers : {};
   if (!(error instanceof HttpError) || statusCode >= 500) {
-    console.error("[X auth server]", error);
+    console.error("[Liberdus server]", error);
   }
   writeJson(response, statusCode, {
     error: getPublicErrorMessage(error, "Request failed."),
@@ -1189,7 +1185,10 @@ const server = http.createServer(async (request, response) => {
 });
 
 server.listen(PORT, HOST, () => {
-  console.log(`X auth server listening at http://${HOST}:${PORT}`);
+  const accountStats = accountStore.getStats();
+  const submissionStats = recoverySubmissionStore.getStats();
+  console.log(`Liberdus server listening at http://${HOST}:${PORT}`);
+  console.log(`SQLite path: ${getDatabasePath()}`);
   console.log(`Allowed origins: ${getAllowedOrigins().join(", ")}`);
   console.log(`Allowed return URLs: ${getAllowedReturnUrls().join(", ")}`);
   console.log(`API key configured: ${getApiKey() ? "yes" : "no"}`);
@@ -1197,7 +1196,19 @@ server.listen(PORT, HOST, () => {
   console.log(`OAuth 1 callback URL: ${getCallbackUrl() || "(missing)"}`);
   console.log(`Default frontend return URL: ${getDefaultFrontendReturnUrl()}`);
   console.log(`Secure cookies: ${shouldUseSecureCookies() ? "yes" : "no"}`);
-  console.log(`Follower snapshot usernames loaded: ${followerUsernames.size}`);
-  console.log(`Recovery candidate usernames loaded: ${recoveryCandidateUsernames.size}`);
-  console.log(`Recovery store path: ${getRecoveryStorePath()}`);
+  console.log(`X accounts in DB: ${accountStats.accountCount}`);
+  console.log(`Current followers in DB: ${accountStats.followerCount}`);
+  console.log(`Recovery candidates in DB: ${accountStats.recoveryCandidateCount}`);
+  console.log(`Latest follower snapshot captured at: ${accountStats.latestSnapshotCapturedAt || "(none)"}`);
+  console.log(`Recovery submissions in DB: ${submissionStats.submissionCount}`);
+  console.log(`Legacy recovery submission import path: ${getLegacyRecoveryStorePath()}`);
+  if (accountStats.followerCount === 0 && fs.existsSync(getLegacyFollowerSnapshotPath())) {
+    console.log(`Follower DB is empty. Import a snapshot with: npm run followers:import`);
+  }
+  if (accountStats.recoveryCandidateCount === 0 && fs.existsSync(getLegacyRecoveryCandidatesPath())) {
+    console.log(`Recovery candidate DB is empty. Import candidates with: npm run recovery-candidates:import`);
+  }
+  if (submissionStats.submissionCount === 0 && fs.existsSync(getLegacyRecoveryStorePath())) {
+    console.log(`Recovery submissions DB is empty. Import legacy submissions with: npm run recovery-submissions:import`);
+  }
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,7 +9,7 @@ const { openDatabase, getDatabasePath } = require("./lib/db");
 const { loadAppConfig, requireChainConfig } = require("./lib/app-config");
 const { buildClaimRound } = require("./lib/claim-round");
 const { createAirdropRoundStore } = require("./lib/airdrop-round-store");
-const { verifyAirdropStartTransaction } = require("./lib/airdrop-chain");
+const { fetchAirdropOwner, verifyAirdropStartTransaction } = require("./lib/airdrop-chain");
 const { createAccountStore } = require("./lib/x-account-store");
 const { createRecoverySubmissionStore } = require("./lib/recovery-submission-store");
 
@@ -34,6 +34,7 @@ const AUTH_INIT_COOKIE_NAME = "liberdus_x_oauth_init";
 const AUTH_SESSION_TTL_MS = 15 * 60 * 1000;
 const REQUEST_TOKEN_TTL_MS = 10 * 60 * 1000;
 const CHALLENGE_TTL_MS = 10 * 60 * 1000;
+const ADMIN_FINALIZE_CHALLENGE_TTL_MS = 10 * 60 * 1000;
 const MAX_JSON_BODY_BYTES = 32 * 1024;
 const RATE_LIMITS = {
   start: { limit: 12, windowMs: 10 * 60 * 1000 },
@@ -45,6 +46,7 @@ const RATE_LIMITS = {
   walletClaims: { limit: 120, windowMs: 60 * 1000 },
   rounds: { limit: 120, windowMs: 60 * 1000 },
   claimLookup: { limit: 120, windowMs: 60 * 1000 },
+  adminChallenge: { limit: 20, windowMs: 10 * 60 * 1000 },
   finalizeRound: { limit: 20, windowMs: 10 * 60 * 1000 },
   health: { limit: 30, windowMs: 60 * 1000 },
 };
@@ -52,6 +54,7 @@ const RATE_LIMITS = {
 const authSessions = new Map();
 const requestTokens = new Map();
 const linkChallenges = new Map();
+const adminFinalizeChallenges = new Map();
 const rateLimits = new Map();
 
 class HttpError extends Error {
@@ -513,6 +516,12 @@ function pruneExpiredState() {
     }
   }
 
+  for (const [challengeId, challenge] of adminFinalizeChallenges.entries()) {
+    if (challenge.expiresAtMs <= now) {
+      adminFinalizeChallenges.delete(challengeId);
+    }
+  }
+
   for (const [key, bucket] of rateLimits.entries()) {
     if (bucket.resetAtMs <= now) {
       rateLimits.delete(key);
@@ -560,6 +569,15 @@ function requireWalletAddress(walletAddress) {
   } catch {
     throw new HttpError(400, "Wallet address is invalid.");
   }
+}
+
+function requireBytes32Hex(value, label) {
+  const normalized = String(value || "").trim();
+  if (!ethers.isHexString(normalized, 32)) {
+    throw new HttpError(400, `${label} must be a 32-byte hex string.`);
+  }
+
+  return normalized.toLowerCase();
 }
 
 function deleteAuthSession(sessionId) {
@@ -632,6 +650,32 @@ function buildWalletLinkMessage({ profile, walletAddress, challengeId, issuedAt 
     `Issued at: ${issuedAt}`,
     "",
     "Sign this message to prove wallet ownership for follower reward recovery.",
+  ].join("\n");
+}
+
+function buildAdminFinalizeMessage({
+  walletAddress,
+  txHash,
+  merkleRoot,
+  challengeId,
+  issuedAt,
+  chainId,
+  contractAddress,
+  deploymentKey,
+}) {
+  return [
+    "Liberdus admin airdrop finalize",
+    "",
+    `Wallet: ${walletAddress}`,
+    `Chain ID: ${chainId}`,
+    `Contract: ${contractAddress}`,
+    `Deployment key: ${deploymentKey}`,
+    `Transaction hash: ${txHash}`,
+    `Merkle root: ${merkleRoot}`,
+    `Challenge: ${challengeId}`,
+    `Issued at: ${issuedAt}`,
+    "",
+    "Sign this message to authorize saving the finalized airdrop round to the backend.",
   ].join("\n");
 }
 
@@ -780,6 +824,21 @@ function getRequiredDeploymentKey() {
   }
 
   return deploymentKey;
+}
+
+function getRequiredAdminChallenge(body) {
+  const challengeId = String(body?.challengeId || "").trim();
+  if (!challengeId) {
+    throw new HttpError(400, "Admin finalize request must include challengeId.");
+  }
+
+  pruneExpiredState();
+  const challenge = adminFinalizeChallenges.get(challengeId);
+  if (!challenge) {
+    throw new HttpError(400, "Admin finalize challenge expired. Start again.");
+  }
+
+  return challenge;
 }
 
 function getHealthPayload(request) {
@@ -1058,6 +1117,51 @@ async function handleClaimByEpochAndIndexLookup(response, epoch, claimIndex) {
   });
 }
 
+async function handleAdminFinalizeChallenge(request, response) {
+  const body = await readJsonRequest(request);
+  const walletAddress = requireWalletAddress(body.walletAddress);
+  const txHash = requireBytes32Hex(body.txHash, "Transaction hash");
+  const merkleRoot = requireBytes32Hex(body.merkleRoot, "Merkle root");
+  const chainConfig = requireChainConfig(appConfig);
+  const currentOwner = await fetchAirdropOwner(chainConfig);
+
+  if (ethers.getAddress(currentOwner) !== walletAddress) {
+    throw new HttpError(403, "Only the current contract owner can save finalized rounds.");
+  }
+
+  const challengeId = createRandomToken(18);
+  const issuedAt = new Date().toISOString();
+  const deploymentKey = getRequiredDeploymentKey();
+  const message = buildAdminFinalizeMessage({
+    walletAddress,
+    txHash,
+    merkleRoot,
+    challengeId,
+    issuedAt,
+    chainId: chainConfig.chainId,
+    contractAddress: chainConfig.airdropAddress,
+    deploymentKey,
+  });
+
+  adminFinalizeChallenges.set(challengeId, {
+    challengeId,
+    walletAddress,
+    txHash,
+    merkleRoot,
+    deploymentKey,
+    message,
+    issuedAt,
+    expiresAtMs: Date.now() + ADMIN_FINALIZE_CHALLENGE_TTL_MS,
+  });
+
+  writeJson(response, 200, {
+    challengeId,
+    message,
+    expiresAt: Date.now() + ADMIN_FINALIZE_CHALLENGE_TTL_MS,
+    walletAddress,
+  });
+}
+
 async function handleFinalizeAirdropRound(request, response) {
   const body = await readJsonRequest(request);
   const rawClaims = Array.isArray(body.claims)
@@ -1076,9 +1180,52 @@ async function handleFinalizeAirdropRound(request, response) {
     throw new HttpError(400, "Token decimals must be a non-negative integer.");
   }
 
+  const challenge = getRequiredAdminChallenge(body);
+  const signedWalletAddress = requireWalletAddress(body.walletAddress);
+  const signature = String(body.signature || "").trim();
+  const expectedTxHash = requireBytes32Hex(txHash, "Transaction hash");
+  if (!signature) {
+    throw new HttpError(400, "Admin finalize request must include a wallet signature.");
+  }
+
   const builtRound = buildClaimRound(rawClaims, decimals);
+  const expectedMerkleRoot = String(builtRound.root || "").trim().toLowerCase();
+
+  if (challenge.walletAddress !== signedWalletAddress) {
+    throw new HttpError(403, "Admin finalize challenge does not match the signing wallet.");
+  }
+
+  if (challenge.txHash !== expectedTxHash) {
+    throw new HttpError(400, "Admin finalize challenge does not match the transaction hash.");
+  }
+
+  if (challenge.merkleRoot !== expectedMerkleRoot) {
+    throw new HttpError(400, "Admin finalize challenge does not match the Merkle root.");
+  }
+
+  if (challenge.deploymentKey !== getRequiredDeploymentKey()) {
+    throw new HttpError(400, "Admin finalize challenge does not match the active deployment.");
+  }
+
+  let recoveredAddress;
+  try {
+    recoveredAddress = ethers.verifyMessage(challenge.message, signature);
+  } catch {
+    throw new HttpError(400, "Admin finalize signature is invalid.");
+  }
+
+  if (ethers.getAddress(recoveredAddress) !== signedWalletAddress) {
+    throw new HttpError(403, "Admin finalize signature did not match the supplied wallet.");
+  }
+
   const chainConfig = requireChainConfig(appConfig);
+  const currentOwner = await fetchAirdropOwner(chainConfig);
+  if (ethers.getAddress(currentOwner) !== signedWalletAddress) {
+    throw new HttpError(403, "Only the current contract owner can save finalized rounds.");
+  }
+
   const verifiedRound = await verifyAirdropStartTransaction(chainConfig, txHash, builtRound.root);
+  adminFinalizeChallenges.delete(challenge.challengeId);
   const savedRound = airdropRoundStore.upsertRound({
     deploymentKey: getRequiredDeploymentKey(),
     epoch: verifiedRound.epoch,
@@ -1339,6 +1486,13 @@ const server = http.createServer(async (request, response) => {
       requireAllowedOrigin(request, response);
       consumeRateLimit(request, "claimLookup");
       await handleClaimByEpochAndIndexLookup(response, claimLookupMatch[1], claimLookupMatch[2]);
+      return;
+    }
+
+    if (request.method === "POST" && pathname === "/api/admin/airdrop-rounds/challenge") {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "adminChallenge");
+      await handleAdminFinalizeChallenge(request, response);
       return;
     }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,10 @@ const path = require("node:path");
 const dotenv = require("dotenv");
 const { ethers } = require("ethers");
 const { openDatabase, getDatabasePath } = require("./lib/db");
+const { loadAppConfig, requireChainConfig } = require("./lib/app-config");
+const { buildClaimRound } = require("./lib/claim-round");
+const { createAirdropRoundStore } = require("./lib/airdrop-round-store");
+const { verifyAirdropStartTransaction } = require("./lib/airdrop-chain");
 const { createAccountStore } = require("./lib/x-account-store");
 const { createRecoverySubmissionStore } = require("./lib/recovery-submission-store");
 
@@ -38,6 +42,10 @@ const RATE_LIMITS = {
   challenge: { limit: 20, windowMs: 10 * 60 * 1000 },
   complete: { limit: 20, windowMs: 10 * 60 * 1000 },
   logout: { limit: 40, windowMs: 10 * 60 * 1000 },
+  walletClaims: { limit: 120, windowMs: 60 * 1000 },
+  rounds: { limit: 120, windowMs: 60 * 1000 },
+  claimLookup: { limit: 120, windowMs: 60 * 1000 },
+  finalizeRound: { limit: 20, windowMs: 10 * 60 * 1000 },
   health: { limit: 30, windowMs: 60 * 1000 },
 };
 
@@ -161,9 +169,11 @@ function shouldTrustProxy() {
   return /^true$/iu.test(String(process.env.X_AUTH_TRUST_PROXY || "").trim());
 }
 
+const appConfig = loadAppConfig();
 const db = openDatabase();
 const accountStore = createAccountStore(db);
 const recoverySubmissionStore = createRecoverySubmissionStore(db);
+const airdropRoundStore = createAirdropRoundStore(db);
 
 function createRandomToken(bytes = 32) {
   return crypto.randomBytes(bytes).toString("hex");
@@ -709,6 +719,44 @@ function serializeSubmissionForClient(submission) {
   };
 }
 
+function serializeAirdropRoundSummary(round) {
+  if (!round) return null;
+
+  return {
+    deploymentKey: String(round.deploymentKey || "").trim(),
+    epoch: Number(round.epoch || 0),
+    merkleRoot: String(round.merkleRoot || "").trim(),
+    deadline: Number(round.deadline || 0),
+    claimCount: Number(round.claimCount || 0),
+    totalAmountRaw: String(round.totalAmountRaw || "0"),
+    decimals: Number(round.decimals || 18),
+    chainId: Number(round.chainId || 0),
+    contractAddress: String(round.contractAddress || "").trim(),
+    sourceKind: String(round.sourceKind || "").trim(),
+    startTxHash: String(round.startTxHash || "").trim(),
+    startBlockNumber: round.startBlockNumber == null ? null : Number(round.startBlockNumber),
+    startBlockHash: String(round.startBlockHash || "").trim(),
+    createdAt: String(round.createdAt || "").trim(),
+    updatedAt: String(round.updatedAt || "").trim(),
+  };
+}
+
+function serializeAirdropWalletRound(round) {
+  if (!round) return null;
+
+  return {
+    ...serializeAirdropRoundSummary(round),
+    entry: round.entry
+      ? {
+        index: String(round.entry.index || ""),
+        account: String(round.entry.account || "").trim(),
+        amountRaw: String(round.entry.amountRaw || "0"),
+        proof: Array.isArray(round.entry.proof) ? [...round.entry.proof] : [],
+      }
+      : null,
+  };
+}
+
 function getExistingWalletMessage(account) {
   if (!account?.walletAddress) {
     return "";
@@ -725,6 +773,15 @@ function getExistingRecoverySubmissionMessage() {
   return "We already received a response for this X account.";
 }
 
+function getRequiredDeploymentKey() {
+  const deploymentKey = String(appConfig.deploymentKey || "").trim();
+  if (!deploymentKey) {
+    throw new HttpError(500, "Airdrop deployment key is not configured.", { expose: false });
+  }
+
+  return deploymentKey;
+}
+
 function getHealthPayload(request) {
   const basePayload = { ok: true };
   if (!isLoopbackAddress(getClientIp(request))) {
@@ -733,6 +790,11 @@ function getHealthPayload(request) {
 
   const accountStats = accountStore.getStats();
   const submissionStats = recoverySubmissionStore.getStats();
+  const roundStats = airdropRoundStore.getStats();
+  const deploymentKey = String(appConfig.deploymentKey || "").trim();
+  const deploymentRoundStats = deploymentKey
+    ? airdropRoundStore.getStats(deploymentKey)
+    : { roundCount: 0, claimCount: 0 };
 
   return {
     ...basePayload,
@@ -751,6 +813,16 @@ function getHealthPayload(request) {
     recoveryCandidateCount: accountStats.recoveryCandidateCount,
     latestSnapshotCapturedAt: accountStats.latestSnapshotCapturedAt,
     recoverySubmissionCount: submissionStats.submissionCount,
+    airdropRoundCount: deploymentRoundStats.roundCount,
+    airdropClaimCount: deploymentRoundStats.claimCount,
+    airdropRoundCountTotal: roundStats.roundCount,
+    airdropClaimCountTotal: roundStats.claimCount,
+    chainId: appConfig.chainId,
+    rpcUrlConfigured: Boolean(appConfig.rpcUrl),
+    airdropAddress: appConfig.airdropAddress,
+    deploymentKey: appConfig.deploymentKey,
+    apiBaseUrl: appConfig.apiBaseUrl,
+    claimsManifestPath: appConfig.claimsManifestPath,
     activeAuthSessions: authSessions.size,
     activeRequestTokens: requestTokens.size,
     activeChallenges: linkChallenges.size,
@@ -942,6 +1014,94 @@ async function handleSessionLookup(request, response) {
   });
 }
 
+async function handleWalletClaimsLookup(request, response, walletAddress) {
+  const normalizedWalletAddress = requireWalletAddress(walletAddress);
+  const rounds = airdropRoundStore.getWalletRounds(normalizedWalletAddress, getRequiredDeploymentKey());
+
+  writeJson(response, 200, {
+    walletAddress: normalizedWalletAddress,
+    rounds: rounds.map((round) => serializeAirdropWalletRound(round)),
+  });
+}
+
+async function handleRoundsLookup(response) {
+  const rounds = airdropRoundStore.listRounds(getRequiredDeploymentKey());
+  writeJson(response, 200, {
+    rounds: rounds.map((round) => serializeAirdropRoundSummary(round)),
+  });
+}
+
+async function handleClaimByEpochAndIndexLookup(response, epoch, claimIndex) {
+  const normalizedEpoch = Number.parseInt(String(epoch || "").trim(), 10);
+  const normalizedClaimIndex = Number.parseInt(String(claimIndex || "").trim(), 10);
+
+  if (!Number.isInteger(normalizedEpoch) || normalizedEpoch <= 0) {
+    throw new HttpError(400, "Epoch must be a positive integer.");
+  }
+
+  if (!Number.isInteger(normalizedClaimIndex) || normalizedClaimIndex < 0) {
+    throw new HttpError(400, "Claim index must be zero or greater.");
+  }
+
+  const claim = airdropRoundStore.getClaimByEpochAndIndex(
+    normalizedEpoch,
+    normalizedClaimIndex,
+    getRequiredDeploymentKey(),
+  );
+  if (!claim) {
+    throw new HttpError(404, "Claim was not found.");
+  }
+
+  writeJson(response, 200, {
+    round: serializeAirdropRoundSummary(claim),
+    entry: serializeAirdropWalletRound(claim).entry,
+  });
+}
+
+async function handleFinalizeAirdropRound(request, response) {
+  const body = await readJsonRequest(request);
+  const rawClaims = Array.isArray(body.claims)
+    ? body.claims
+    : Array.isArray(body.round?.claims)
+      ? body.round.claims
+      : null;
+  const txHash = String(body.txHash || body.transactionHash || "").trim();
+  const decimals = Number.parseInt(String(body.decimals || body.round?.decimals || appConfig.tokenDecimals || "18").trim(), 10);
+
+  if (!rawClaims?.length) {
+    throw new HttpError(400, "Claims payload is required.");
+  }
+
+  if (!Number.isInteger(decimals) || decimals < 0) {
+    throw new HttpError(400, "Token decimals must be a non-negative integer.");
+  }
+
+  const builtRound = buildClaimRound(rawClaims, decimals);
+  const chainConfig = requireChainConfig(appConfig);
+  const verifiedRound = await verifyAirdropStartTransaction(chainConfig, txHash, builtRound.root);
+  const savedRound = airdropRoundStore.upsertRound({
+    deploymentKey: getRequiredDeploymentKey(),
+    epoch: verifiedRound.epoch,
+    merkleRoot: verifiedRound.merkleRoot,
+    deadline: verifiedRound.deadline,
+    claimCount: builtRound.claimCount,
+    totalAmountRaw: builtRound.totalAmountRaw,
+    decimals: builtRound.decimals,
+    chainId: chainConfig.chainId,
+    contractAddress: chainConfig.airdropAddress,
+    sourceKind: "admin-finalized",
+    startTxHash: verifiedRound.txHash,
+    startBlockNumber: verifiedRound.blockNumber,
+    startBlockHash: verifiedRound.blockHash,
+    claims: builtRound.claims,
+    updatedAt: new Date().toISOString(),
+  });
+
+  writeJson(response, 200, {
+    round: serializeAirdropRoundSummary(savedRound),
+  });
+}
+
 async function handleLinkChallenge(request, response) {
   const session = getRequiredSessionFromCookie(request, response);
   requireCsrf(request, session);
@@ -1126,52 +1286,84 @@ const server = http.createServer(async (request, response) => {
   setStandardHeaders(response);
 
   try {
+    const requestUrl = new URL(request.url, `http://${request.headers.host}`);
+    const pathname = requestUrl.pathname;
+
     if (request.method === "OPTIONS") {
       handleOptions(request, response);
       return;
     }
 
-    if (request.method === "GET" && request.url.startsWith("/health")) {
+    if (request.method === "GET" && pathname === "/health") {
       consumeRateLimit(request, "health");
       pruneExpiredState();
       writeJson(response, 200, getHealthPayload(request));
       return;
     }
 
-    if (request.method === "GET" && request.url.startsWith("/api/x/start")) {
+    if (request.method === "GET" && pathname === "/api/x/start") {
       consumeRateLimit(request, "start");
       await handleStart(request, response);
       return;
     }
 
-    if (request.method === "GET" && request.url.startsWith("/api/x/callback")) {
+    if (request.method === "GET" && pathname === "/api/x/callback") {
       consumeRateLimit(request, "callback");
       await handleCallback(request, response);
       return;
     }
 
-    if (request.method === "GET" && request.url.startsWith("/api/x/session")) {
+    if (request.method === "GET" && pathname === "/api/x/session") {
       requireAllowedOrigin(request, response);
       consumeRateLimit(request, "session");
       await handleSessionLookup(request, response);
       return;
     }
 
-    if (request.method === "POST" && request.url === "/api/x/link/challenge") {
+    if (request.method === "GET" && pathname.startsWith("/api/claims/wallet/")) {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "walletClaims");
+      await handleWalletClaimsLookup(request, response, decodeURIComponent(pathname.slice("/api/claims/wallet/".length)));
+      return;
+    }
+
+    if (request.method === "GET" && pathname === "/api/airdrop/rounds") {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "rounds");
+      await handleRoundsLookup(response);
+      return;
+    }
+
+    const claimLookupMatch = pathname.match(/^\/api\/airdrop\/epochs\/(\d+)\/claims\/(\d+)$/u);
+    if (request.method === "GET" && claimLookupMatch) {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "claimLookup");
+      await handleClaimByEpochAndIndexLookup(response, claimLookupMatch[1], claimLookupMatch[2]);
+      return;
+    }
+
+    if (request.method === "POST" && pathname === "/api/admin/airdrop-rounds/finalize") {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "finalizeRound");
+      await handleFinalizeAirdropRound(request, response);
+      return;
+    }
+
+    if (request.method === "POST" && pathname === "/api/x/link/challenge") {
       requireAllowedOrigin(request, response);
       consumeRateLimit(request, "challenge");
       await handleLinkChallenge(request, response);
       return;
     }
 
-    if (request.method === "POST" && request.url === "/api/x/link/complete") {
+    if (request.method === "POST" && pathname === "/api/x/link/complete") {
       requireAllowedOrigin(request, response);
       consumeRateLimit(request, "complete");
       await handleLinkComplete(request, response);
       return;
     }
 
-    if (request.method === "POST" && request.url === "/api/x/logout") {
+    if (request.method === "POST" && pathname === "/api/x/logout") {
       requireAllowedOrigin(request, response);
       consumeRateLimit(request, "logout");
       await handleLogout(request, response);
@@ -1187,6 +1379,10 @@ const server = http.createServer(async (request, response) => {
 server.listen(PORT, HOST, () => {
   const accountStats = accountStore.getStats();
   const submissionStats = recoverySubmissionStore.getStats();
+  const deploymentKey = String(appConfig.deploymentKey || "").trim();
+  const deploymentRoundStats = deploymentKey
+    ? airdropRoundStore.getStats(deploymentKey)
+    : { roundCount: 0, claimCount: 0 };
   console.log(`Liberdus server listening at http://${HOST}:${PORT}`);
   console.log(`SQLite path: ${getDatabasePath()}`);
   console.log(`Allowed origins: ${getAllowedOrigins().join(", ")}`);
@@ -1201,6 +1397,13 @@ server.listen(PORT, HOST, () => {
   console.log(`Recovery candidates in DB: ${accountStats.recoveryCandidateCount}`);
   console.log(`Latest follower snapshot captured at: ${accountStats.latestSnapshotCapturedAt || "(none)"}`);
   console.log(`Recovery submissions in DB: ${submissionStats.submissionCount}`);
+  console.log(`Backend deployment key: ${deploymentKey || "(missing)"}`);
+  console.log(`Airdrop rounds in current deployment: ${deploymentRoundStats.roundCount}`);
+  console.log(`Airdrop claims in current deployment: ${deploymentRoundStats.claimCount}`);
+  console.log(`Backend chain config source: ${appConfig.sourcePath || "(env only)"}`);
+  console.log(`Backend chain ID: ${appConfig.chainId ?? "(missing)"}`);
+  console.log(`Backend RPC URL: ${appConfig.rpcUrl || "(missing)"}`);
+  console.log(`Backend airdrop address: ${appConfig.airdropAddress || "(missing)"}`);
   console.log(`Legacy recovery submission import path: ${getLegacyRecoveryStorePath()}`);
   if (accountStats.followerCount === 0 && fs.existsSync(getLegacyFollowerSnapshotPath())) {
     console.log(`Follower DB is empty. Import a snapshot with: npm run followers:import`);

--- a/e2e/fixtures/testWithMockWallet.js
+++ b/e2e/fixtures/testWithMockWallet.js
@@ -1,17 +1,25 @@
 const path = require("node:path");
 const { expect, test: base } = require("@playwright/test");
 const {
+  clearE2EAirdropData,
   createSnapshot,
+  E2E_BACKEND_ORIGIN,
   resetLocalChain,
+  resetE2eDatabaseFile,
   revertSnapshot,
   rpcCall,
   RPC_URL,
+  startBackendServer,
 } = require("../helpers/hardhatChain");
 
 const STORAGE_KEY = "liberdus-airdrop-ui-config";
 const DEFAULT_UI_CONFIG = {
-  claimsManifestPath: "./claims/e2e/index.json",
+  apiBaseUrl: E2E_BACKEND_ORIGIN,
   explorerBaseUrl: "https://explorer.local.test",
+  xAuth: {
+    enabled: false,
+    backendUrl: E2E_BACKEND_ORIGIN,
+  },
 };
 
 const MOCK_WALLETS = {
@@ -203,6 +211,14 @@ function installHardhatBackedWalletMock(config) {
         return true;
       }
 
+      if (method === "personal_sign") {
+        return rpcRequest(method, Array.isArray(params) ? params : [params]);
+      }
+
+      if (method === "eth_sign") {
+        return rpcRequest(method, Array.isArray(params) ? params : [params]);
+      }
+
       if (method === "wallet_addEthereumChain") {
         const target = params[0]?.chainId;
         if (!target) {
@@ -315,11 +331,22 @@ function installHardhatBackedWalletMock(config) {
     existingUiConfig = {};
   }
 
-  localStorage.setItem(config.storageKey, JSON.stringify({
-    claimsManifestPath: config.claimsManifestPath,
+  const mergedUiConfig = {
+    apiBaseUrl: config.apiBaseUrl,
     explorerBaseUrl: config.explorerBaseUrl,
     ...existingUiConfig,
-  }));
+  };
+  const existingXAuth = existingUiConfig?.xAuth && typeof existingUiConfig.xAuth === "object"
+    ? existingUiConfig.xAuth
+    : {};
+  if (config.xAuth || Object.keys(existingXAuth).length) {
+    mergedUiConfig.xAuth = {
+      ...(config.xAuth || {}),
+      ...existingXAuth,
+    };
+  }
+
+  localStorage.setItem(config.storageKey, JSON.stringify(mergedUiConfig));
 
   window.dispatchEvent(new Event("ethereum#initialized"));
 }
@@ -327,21 +354,29 @@ function installHardhatBackedWalletMock(config) {
 const test = base.extend({
   hardhatChain: [async ({}, use) => {
     await resetLocalChain();
+    resetE2eDatabaseFile();
+    const backendServer = await startBackendServer();
     let baseSnapshotId = await createSnapshot(RPC_URL);
 
-    await use({
-      rpcCall: (method, params = []) => rpcCall(method, params, RPC_URL),
-      async resetToBase(testTitle = "test") {
-        const reverted = await revertSnapshot(baseSnapshotId, RPC_URL);
-        if (!reverted) {
-          throw new Error(`Failed to revert Hardhat snapshot ${baseSnapshotId} before ${testTitle}.`);
-        }
+    try {
+      await use({
+        backendUrl: backendServer.url,
+        rpcCall: (method, params = []) => rpcCall(method, params, RPC_URL),
+        async resetToBase(testTitle = "test") {
+          const reverted = await revertSnapshot(baseSnapshotId, RPC_URL);
+          if (!reverted) {
+            throw new Error(`Failed to revert Hardhat snapshot ${baseSnapshotId} before ${testTitle}.`);
+          }
 
-        baseSnapshotId = await createSnapshot(RPC_URL);
-        return baseSnapshotId;
-      },
-      rpcUrl: RPC_URL,
-    });
+          clearE2EAirdropData();
+          baseSnapshotId = await createSnapshot(RPC_URL);
+          return baseSnapshotId;
+        },
+        rpcUrl: RPC_URL,
+      });
+    } finally {
+      await backendServer.stop();
+    }
   }, { scope: "worker" }],
   isolatedChain: [
     async ({ hardhatChain }, use, testInfo) => {
@@ -356,8 +391,12 @@ const test = base.extend({
       chainId: toHexChainId(1337),
       rpcUrl: RPC_URL,
       storageKey: STORAGE_KEY,
-      claimsManifestPath: "./claims/e2e/index.json",
+      apiBaseUrl: E2E_BACKEND_ORIGIN,
       explorerBaseUrl: "https://explorer.local.test",
+      xAuth: {
+        enabled: false,
+        backendUrl: E2E_BACKEND_ORIGIN,
+      },
     });
 
     await use(context);
@@ -419,9 +458,6 @@ const test = base.extend({
   },
   e2eClaimsFileEpoch2: async ({}, use) => {
     await use(path.join(process.cwd(), "frontend", "claims", "e2e", "epoch-2.claims.json"));
-  },
-  e2eMultiEpochManifest: async ({}, use) => {
-    await use("./claims/e2e/index.multi-epoch.json");
   },
 });
 

--- a/e2e/helpers/hardhatChain.js
+++ b/e2e/helpers/hardhatChain.js
@@ -1,11 +1,50 @@
-const { execSync } = require("node:child_process");
+const { execSync, spawn } = require("node:child_process");
+const fs = require("node:fs");
 const path = require("node:path");
+const Database = require("better-sqlite3");
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const RPC_URL = "http://127.0.0.1:8545";
+const E2E_BACKEND_HOST = "127.0.0.1";
+const E2E_BACKEND_PORT = 8788;
+const E2E_BACKEND_ORIGIN = `http://${E2E_BACKEND_HOST}:${E2E_BACKEND_PORT}`;
+const E2E_FRONTEND_ORIGIN = "http://127.0.0.1:4173";
+const E2E_FRONTEND_RETURN_URL = `${E2E_FRONTEND_ORIGIN}/frontend/`;
+const E2E_DB_PATH = path.join(REPO_ROOT, "data", "e2e.sqlite");
 
 function getNpmCommand() {
   return process.platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function removeFileIfExists(filePath) {
+  try {
+    fs.rmSync(filePath, { force: true });
+  } catch {
+    // Best effort cleanup for local test artifacts.
+  }
+}
+
+function resetE2eDatabaseFile() {
+  removeFileIfExists(E2E_DB_PATH);
+  removeFileIfExists(`${E2E_DB_PATH}-wal`);
+  removeFileIfExists(`${E2E_DB_PATH}-shm`);
+}
+
+function clearE2EAirdropData() {
+  if (!fs.existsSync(E2E_DB_PATH)) {
+    return;
+  }
+
+  const db = new Database(E2E_DB_PATH);
+  try {
+    db.pragma("foreign_keys = ON");
+    db.exec(`
+      DELETE FROM airdrop_claims;
+      DELETE FROM airdrop_rounds;
+    `);
+  } finally {
+    db.close();
+  }
 }
 
 async function rpcCall(method, params = [], rpcUrl = RPC_URL) {
@@ -50,6 +89,25 @@ async function waitForRpc(rpcUrl = RPC_URL, timeoutMs = 30_000) {
   throw new Error(`Hardhat RPC did not become ready within ${timeoutMs}ms.`);
 }
 
+async function waitForBackend(backendUrl = E2E_BACKEND_ORIGIN, timeoutMs = 30_000) {
+  const startedAt = Date.now();
+
+  while ((Date.now() - startedAt) < timeoutMs) {
+    try {
+      const response = await fetch(`${backendUrl}/health`, { cache: "no-store" });
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Keep polling until timeout.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(`Backend did not become ready within ${timeoutMs}ms.`);
+}
+
 function runNpmScript(script, extraArgs = []) {
   const commandParts = [getNpmCommand(), "run", script, ...extraArgs];
   execSync(commandParts.join(" "), {
@@ -66,6 +124,73 @@ async function resetLocalChain() {
   runNpmScript("fund:owner:local", ["--", "1000000"]);
 }
 
+async function startBackendServer() {
+  const env = {
+    ...process.env,
+    LIBERDUS_DB_PATH: E2E_DB_PATH,
+    LIBERDUS_API_BASE_URL: E2E_BACKEND_ORIGIN,
+    X_AUTH_ALLOWED_ORIGINS: E2E_FRONTEND_ORIGIN,
+    X_FRONTEND_RETURN_URL: E2E_FRONTEND_RETURN_URL,
+    X_FRONTEND_RETURN_URLS: E2E_FRONTEND_RETURN_URL,
+    X_AUTH_COOKIE_SECURE: "false",
+    X_AUTH_HOST: E2E_BACKEND_HOST,
+    X_AUTH_PORT: String(E2E_BACKEND_PORT),
+  };
+
+  const backendProcess = spawn(process.execPath, ["backend/server.js"], {
+    cwd: REPO_ROOT,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let logs = "";
+  const appendLog = (chunk) => {
+    logs = `${logs}${chunk.toString()}`.slice(-16_384);
+  };
+
+  backendProcess.stdout?.on("data", appendLog);
+  backendProcess.stderr?.on("data", appendLog);
+
+  try {
+    await waitForBackend(E2E_BACKEND_ORIGIN);
+  } catch (error) {
+    if (!backendProcess.killed) {
+      try {
+        if (process.platform === "win32") {
+          execSync(`taskkill /pid ${backendProcess.pid} /T /F`, { stdio: "ignore" });
+        } else {
+          backendProcess.kill("SIGKILL");
+        }
+      } catch {
+        // Ignore cleanup failures during startup.
+      }
+    }
+
+    throw new Error(
+      `Failed to start E2E backend.\n${error.message}\n\nBackend logs:\n${logs.trim() || "(none)"}`,
+    );
+  }
+
+  return {
+    url: E2E_BACKEND_ORIGIN,
+    async stop() {
+      if (backendProcess.exitCode != null || backendProcess.killed) {
+        return;
+      }
+
+      try {
+        if (process.platform === "win32") {
+          execSync(`taskkill /pid ${backendProcess.pid} /T /F`, { stdio: "ignore" });
+        } else {
+          backendProcess.kill("SIGTERM");
+        }
+      } catch {
+        // Ignore cleanup failures for test worker shutdown.
+      }
+    },
+  };
+}
+
 async function createSnapshot(rpcUrl = RPC_URL) {
   return rpcCall("evm_snapshot", [], rpcUrl);
 }
@@ -76,10 +201,15 @@ async function revertSnapshot(snapshotId, rpcUrl = RPC_URL) {
 
 module.exports = {
   createSnapshot,
+  clearE2EAirdropData,
+  E2E_BACKEND_ORIGIN,
+  E2E_DB_PATH,
   REPO_ROOT,
   RPC_URL,
   resetLocalChain,
+  resetE2eDatabaseFile,
   revertSnapshot,
   rpcCall,
+  startBackendServer,
   waitForRpc,
 };

--- a/e2e/tests/admin/start-airdrop.spec.js
+++ b/e2e/tests/admin/start-airdrop.spec.js
@@ -29,7 +29,6 @@ test("@smoke admin claims builder can prepare and start a matching airdrop", asy
   await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
 
   await page.getByRole("button", { name: "Start New Airdrop" }).click();
-  await expect(page.getByText("Start airdrop complete.")).toBeVisible();
   await expect(page.locator("#currentEpoch")).toHaveText("1");
   await expect(page.getByRole("button", { name: "Start New Airdrop" })).toBeDisabled();
   await expect(page.locator("#startRootWarning")).toContainText("already started successfully");

--- a/e2e/tests/admin/upload-existing-file.spec.js
+++ b/e2e/tests/admin/upload-existing-file.spec.js
@@ -17,7 +17,7 @@ test("admin can upload an existing claims file and gets a duplicate-root warning
   await page.getByRole("button", { name: "Fund Contract" }).click();
   await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
   await page.getByRole("button", { name: "Start New Airdrop" }).click();
-  await expect(page.getByText("Start airdrop complete.")).toBeVisible();
+  await expect(page.locator("#currentEpoch")).toHaveText("1");
 
   await page.getByRole("button", { name: "Clear Claims" }).click();
   await page.locator("#uploadClaimsFileInput").setInputFiles(e2eClaimsFile);

--- a/e2e/tests/claim/availability-and-ordering.spec.js
+++ b/e2e/tests/claim/availability-and-ordering.spec.js
@@ -1,7 +1,7 @@
 const { expect, test } = require("../../fixtures/testWithMockWallet");
 const { connectViaWalletPicker, startAirdropFromUpload } = require("../helpers");
 
-test("claimant only sees deployed active rounds sorted newest-first", async ({ page, e2eClaimsFile, e2eClaimsFileEpoch2, e2eMultiEpochManifest, mockWallet }) => {
+test("claimant only sees deployed active rounds sorted newest-first", async ({ page, e2eClaimsFile, e2eClaimsFileEpoch2, mockWallet }) => {
   await page.goto("admin.html");
   await connectViaWalletPicker(page);
 
@@ -9,7 +9,6 @@ test("claimant only sees deployed active rounds sorted newest-first", async ({ p
   await startAirdropFromUpload(page, e2eClaimsFileEpoch2);
   await expect(page.locator("#currentEpoch")).toHaveText("2");
 
-  await mockWallet.setUiConfig(page, { claimsManifestPath: e2eMultiEpochManifest });
   await mockWallet.setAccount(page, mockWallet.accounts.claimant);
   await page.goto("index.html");
 

--- a/e2e/tests/claim/claim-flow.spec.js
+++ b/e2e/tests/claim/claim-flow.spec.js
@@ -11,7 +11,7 @@ test("@smoke claimant can claim from the wrong network after wallet switch", asy
   await page.getByRole("button", { name: "Fund Contract" }).click();
   await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
   await page.getByRole("button", { name: "Start New Airdrop" }).click();
-  await expect(page.getByText("Start airdrop complete.")).toBeVisible();
+  await expect(page.locator("#currentEpoch")).toHaveText("1");
 
   await mockWallet.setAccount(page, mockWallet.accounts.claimant);
   await mockWallet.setChainId(page, toHexChainId(31337));
@@ -37,7 +37,7 @@ test("claimant outsider sees the generic empty state", async ({ page, e2eClaimsF
   await page.getByRole("button", { name: "Fund Contract" }).click();
   await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
   await page.getByRole("button", { name: "Start New Airdrop" }).click();
-  await expect(page.getByText("Start airdrop complete.")).toBeVisible();
+  await expect(page.locator("#currentEpoch")).toHaveText("1");
 
   await mockWallet.setAccount(page, mockWallet.accounts.outsider);
   await page.goto("index.html");

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -1,3 +1,5 @@
+const { expect } = require("@playwright/test");
+
 async function connectViaWalletPicker(page) {
   await page.getByRole("button", { name: "Connect Wallet" }).click();
   await page.getByRole("button", { name: /MetaMask/i }).click();
@@ -32,12 +34,15 @@ async function getUtcDateTimeInputValue(page, unixTimestamp) {
 }
 
 async function startAirdropFromUpload(page, claimsFile, { deadlineSelector = "#startDeadlineInput" } = {}) {
+  const currentEpochText = (await page.locator("#currentEpoch").textContent())?.trim() || "0";
+  const currentEpoch = Number.parseInt(currentEpochText, 10) || 0;
+
   await page.locator("#uploadClaimsFileInput").setInputFiles(claimsFile);
   await setFutureDeadline(page, deadlineSelector);
   await page.getByRole("button", { name: "Fund Contract" }).click();
   await page.getByText("Fund airdrop complete.").waitFor();
   await page.getByRole("button", { name: "Start New Airdrop" }).click();
-  await page.getByText("Start airdrop complete.").waitFor();
+  await expect(page.locator("#currentEpoch")).toHaveText(String(currentEpoch + 1));
 }
 
 module.exports = {

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -116,7 +116,7 @@
             <div class="subsection-header">
               <div>
                 <h3>Build Claims JSON</h3>
-                <p class="hint">Create the raw claims file here, then download it for deployment or load it directly into the admin flow.</p>
+                <p class="hint">Create the raw claims list here, then start the airdrop. After the transaction confirms, the verified round is stored in the backend automatically.</p>
               </div>
             </div>
 
@@ -174,7 +174,7 @@
             <div class="subsection-header">
               <div>
                 <h3>Upload Existing Claims JSON</h3>
-                <p class="hint">Use this when the raw claims file was prepared outside the admin page.</p>
+                <p class="hint">Use this when the raw claims list was prepared outside the admin page.</p>
               </div>
             </div>
           </div>

--- a/frontend/config.local.template.json
+++ b/frontend/config.local.template.json
@@ -8,6 +8,8 @@
     "symbol": "ETH",
     "decimals": 18
   },
+  "apiBaseUrl": "http://127.0.0.1:8787",
+  "deploymentKey": "",
   "claimsManifestPath": "./claims/generated/index.json",
   "xAuth": {
     "enabled": true,

--- a/frontend/config.local.template.json
+++ b/frontend/config.local.template.json
@@ -9,6 +9,11 @@
     "decimals": 18
   },
   "claimsManifestPath": "./claims/generated/index.json",
+  "xAuth": {
+    "enabled": true,
+    "redirectUri": "http://127.0.0.1:5502/frontend/",
+    "backendUrl": "http://127.0.0.1:8787"
+  },
   "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
   "tokenAddress": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
   "dustTokenAddress": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",

--- a/frontend/config.prod.json
+++ b/frontend/config.prod.json
@@ -9,6 +9,11 @@
     "decimals": 18
   },
   "claimsManifestPath": "./claims/index.json",
+  "xAuth": {
+    "enabled": true,
+    "redirectUri": "",
+    "backendUrl": ""
+  },
   "tokenAddress": "",
   "airdropAddress": ""
 }

--- a/frontend/config.prod.json
+++ b/frontend/config.prod.json
@@ -8,6 +8,8 @@
     "symbol": "BNB",
     "decimals": 18
   },
+  "apiBaseUrl": "",
+  "deploymentKey": "",
   "claimsManifestPath": "./claims/index.json",
   "xAuth": {
     "enabled": true,

--- a/frontend/config.test.json
+++ b/frontend/config.test.json
@@ -9,6 +9,11 @@
     "decimals": 18
   },
   "claimsManifestPath": "./claims/index.json",
+  "xAuth": {
+    "enabled": true,
+    "redirectUri": "",
+    "backendUrl": ""
+  },
   "tokenAddress": "0x48463C89254d001Bdc6B5d2af92d531E60FB4f72",
   "airdropAddress": "0x822C39eFe9055593418071a80552760282fB1B71"
 }

--- a/frontend/config.test.json
+++ b/frontend/config.test.json
@@ -8,6 +8,8 @@
     "symbol": "tBNB",
     "decimals": 18
   },
+  "apiBaseUrl": "",
+  "deploymentKey": "",
   "claimsManifestPath": "./claims/index.json",
   "xAuth": {
     "enabled": true,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -65,6 +65,43 @@
       <div class="center-stage">
         <section class="frame claim-card">
           <section class="claim-card-block">
+            <div id="xAuthCard" class="x-auth-card">
+              <div class="x-auth-copy">
+                <p class="eyebrow">x.com</p>
+                <div>
+                  <h2>Sign In With X</h2>
+                  <p id="xAuthHint" class="hint">Attach your X account to this claim session.</p>
+                </div>
+              </div>
+
+              <div class="x-auth-shell">
+                <div id="xAuthIdentity" class="x-auth-identity" hidden>
+                  <img id="xAuthAvatar" class="x-auth-avatar" alt="" hidden>
+                  <div class="x-auth-profile">
+                    <p id="xAuthName" class="x-auth-name">-</p>
+                    <a
+                      id="xAuthProfileLink"
+                      class="x-auth-link"
+                      href="#"
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >@-</a>
+                  </div>
+                </div>
+
+                <p id="xAuthStatus" class="x-auth-status">Not signed in.</p>
+                <p id="xAuthLinkStatus" class="x-auth-status" hidden></p>
+
+                <div class="x-auth-actions">
+                  <button id="xAuthButton" type="button" class="secondary">Sign in with X</button>
+                  <button id="xVerifyButton" type="button" hidden>Verify Wallet And Save</button>
+                  <button id="xDisconnectButton" type="button" class="ghost" hidden>Sign out</button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="claim-card-block">
             <div class="panel-title-row">
               <div>
                 <h2>Available Claims</h2>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,7 +67,6 @@
           <section class="claim-card-block">
             <div id="xAuthCard" class="x-auth-card">
               <div class="x-auth-copy">
-                <p class="eyebrow">x.com</p>
                 <div>
                   <h2>Sign In With X</h2>
                   <p id="xAuthHint" class="hint">Attach your X account to this claim session.</p>
@@ -78,7 +77,6 @@
                 <div id="xAuthIdentity" class="x-auth-identity" hidden>
                   <img id="xAuthAvatar" class="x-auth-avatar" alt="" hidden>
                   <div class="x-auth-profile">
-                    <p id="xAuthName" class="x-auth-name">-</p>
                     <a
                       id="xAuthProfileLink"
                       class="x-auth-link"

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -28,7 +28,12 @@ import {
   getAvailableWallets,
 } from "../shared/wallet.js";
 import { promptForWalletSelection } from "../shared/wallet-picker.js";
-import { loadClaimCatalog, fetchClaimSource } from "../shared/claims.js";
+import {
+  fetchStoredAirdropRounds,
+  fetchStoredClaimByEpochAndIndex,
+  isClaimsApiConfigured,
+  persistAirdropRound,
+} from "../shared/claims.js";
 import { buildClaimRound } from "../shared/merkle.js";
 
 const runtime = {
@@ -45,13 +50,22 @@ const runtime = {
   pendingOwner: null,
   currentEpoch: 0,
   epochRows: [],
-  claimCatalog: null,
   claimSourcesByEpoch: new Map(),
   claimSourcesByRoot: new Map(),
   uploadedRound: null,
   builderRows: [],
   nextBuilderRowId: 1,
-  config: { chainId: null, networkName: "", rpcUrl: "", nativeCurrency: null, tokenAddress: "", dustTokenAddress: "", airdropAddress: "", claimsManifestPath: "./claims/index.json" },
+  config: {
+    chainId: null,
+    networkName: "",
+    rpcUrl: "",
+    nativeCurrency: null,
+    tokenAddress: "",
+    dustTokenAddress: "",
+    airdropAddress: "",
+    apiBaseUrl: "",
+    claimsManifestPath: "./claims/index.json",
+  },
   configSource: "template",
   tokenDecimals: 18,
   tokenSymbol: "LIB",
@@ -516,7 +530,13 @@ function updateStartAirdropButtonState() {
   const hasRound = Boolean(runtime.uploadedRound);
   const hasRoot = ethers.isHexString(els.startRootInput.value.trim(), 32);
   const hasDeadline = Number.isFinite(Number(els.startDeadlineUnix.value)) && Number(els.startDeadlineUnix.value) > 0;
-  const canSubmit = isOwner() && isReadyChain() && hasRound && hasRoot && hasDeadline && !runtime.startRequiresNewUpload;
+  const canSubmit = isOwner()
+    && isReadyChain()
+    && isClaimsApiConfigured(runtime.config)
+    && hasRound
+    && hasRoot
+    && hasDeadline
+    && !runtime.startRequiresNewUpload;
   els.startAirdropButton.disabled = !canSubmit;
   updateStartRootWarning();
 }
@@ -731,24 +751,16 @@ async function refreshCatalogRounds() {
   runtime.claimSourcesByEpoch = new Map();
   runtime.claimSourcesByRoot = new Map();
 
-  if (!runtime.config.claimsManifestPath) return;
+  if (!isClaimsApiConfigured(runtime.config)) return;
 
-  runtime.claimCatalog = await loadClaimCatalog(runtime.config.claimsManifestPath);
-  if (!runtime.claimCatalog?.sources?.length) return;
+  const payload = await fetchStoredAirdropRounds(runtime.config);
+  const rounds = Array.isArray(payload?.rounds) ? payload.rounds : [];
 
-  const roundEntries = await Promise.all(runtime.claimCatalog.sources.map(async (source) => {
-    try {
-      const round = await fetchClaimSource(source, runtime.claimCatalog.baseUrl, runtime.tokenDecimals);
-      return { epoch: source.epoch, source, round, errorMessage: "" };
-    } catch (error) {
-      return { epoch: source.epoch, source, round: null, errorMessage: formatUiError(error, "Load round data", runtime) };
-    }
-  }));
-
-  for (const entry of roundEntries) {
-    runtime.claimSourcesByEpoch.set(entry.epoch, entry);
-    if (entry.round?.root) {
-      runtime.claimSourcesByRoot.set(entry.round.root.toLowerCase(), entry);
+  for (const round of rounds) {
+    const entry = { epoch: round.epoch, source: null, round, errorMessage: "" };
+    runtime.claimSourcesByEpoch.set(round.epoch, entry);
+    if (round?.merkleRoot) {
+      runtime.claimSourcesByRoot.set(round.merkleRoot.toLowerCase(), entry);
     }
   }
 }
@@ -842,7 +854,7 @@ async function refreshEpochRows() {
         || runtime.claimSourcesByRoot.get(root.toLowerCase())
         || null;
       const localRound = localSource?.round;
-      const totalAmountRaw = localRound && localRound.root.toLowerCase() === root.toLowerCase()
+      const totalAmountRaw = localRound && localRound.merkleRoot.toLowerCase() === root.toLowerCase()
         ? BigInt(localRound.totalAmountRaw)
         : null;
 
@@ -1004,6 +1016,67 @@ async function fundUploadedRound() {
     },
     formatError: (error, label) => formatUiError(error, label, runtime),
   });
+}
+
+async function startAirdropAndPersistRound() {
+  if (!runtime.uploadedRound) {
+    throw new Error("Prepare a claims JSON file first.");
+  }
+
+  if (!isClaimsApiConfigured(runtime.config)) {
+    throw new Error("Backend API URL is not configured.");
+  }
+
+  const { airdrop } = getContracts({
+    config: runtime.config,
+    provider: runtime.provider,
+    signer: runtime.signer,
+    withSigner: true,
+  });
+
+  if (!airdrop) {
+    throw new Error("Airdrop address is not configured.");
+  }
+
+  const root = els.startRootInput.value.trim();
+  if (!ethers.isHexString(root, 32)) {
+    throw new Error("Merkle root must be a bytes32 hex string.");
+  }
+
+  const deadlineUnix = Number(els.startDeadlineUnix.value);
+  await validateFutureDeadlineAgainstChain(deadlineUnix);
+
+  const tx = await airdrop.startNewAirdrop(root, deadlineUnix);
+  logger.log(`Start airdrop: submitted ${tx.hash}`);
+  const receipt = await tx.wait();
+  logger.log(`Start airdrop: confirmed in block ${receipt.blockNumber}`, "success");
+
+  try {
+    const persisted = await persistAirdropRound(runtime.config, {
+      txHash: tx.hash,
+      decimals: runtime.tokenDecimals,
+      claims: runtime.uploadedRound.claims.map((claim) => ({
+        index: claim.index,
+        account: claim.account,
+        amountRaw: claim.amountRaw,
+      })),
+    });
+
+    runtime.startRequiresNewUpload = true;
+    await refreshPage();
+    updateStartAirdropButtonState();
+
+    if (persisted?.round?.epoch) {
+      logger.log(`Round ${persisted.round.epoch} saved to the backend.`, "success");
+    }
+  } catch (error) {
+    runtime.startRequiresNewUpload = true;
+    await refreshPage().catch(() => {});
+    updateStartAirdropButtonState();
+    throw new Error(
+      `Airdrop was started on chain, but saving the round to the backend failed. ${error?.message || String(error)}`,
+    );
+  }
 }
 
 async function updateEpochDeadline(newDeadline) {
@@ -1258,31 +1331,7 @@ function bindEvents() {
   els.startAirdropForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     try {
-      if (!runtime.uploadedRound) throw new Error("Prepare a claims JSON file first.");
-
-      const { airdrop } = getContracts({
-        config: runtime.config,
-        provider: runtime.provider,
-        signer: runtime.signer,
-        withSigner: true,
-      });
-
-      if (!airdrop) throw new Error("Airdrop address is not configured.");
-      const root = els.startRootInput.value.trim();
-      if (!ethers.isHexString(root, 32)) throw new Error("Merkle root must be a bytes32 hex string.");
-
-      const deadlineUnix = Number(els.startDeadlineUnix.value);
-      await validateFutureDeadlineAgainstChain(deadlineUnix);
-
-      await sendTransaction("Start airdrop", () => airdrop.startNewAirdrop(root, deadlineUnix), {
-        log: logger.log,
-        afterSuccess: async () => {
-          runtime.startRequiresNewUpload = true;
-          await refreshPage();
-          updateStartAirdropButtonState();
-        },
-        formatError: (error, label) => formatUiError(error, label, runtime),
-      });
+      await startAirdropAndPersistRound();
     } catch (error) {
       reportError(error, "Start airdrop");
     }
@@ -1417,7 +1466,7 @@ function bindEvents() {
       const epoch = readRequiredEpoch(els.queryEpochInput, "Epoch query");
       const [root, deadline, claimedAmount] = await airdrop.epochInfo(epoch);
       const localRound = runtime.claimSourcesByEpoch.get(Number(epoch))?.round;
-      const totalAmountRaw = localRound && localRound.root.toLowerCase() === root.toLowerCase()
+      const totalAmountRaw = localRound && localRound.merkleRoot.toLowerCase() === root.toLowerCase()
         ? localRound.totalAmountRaw
         : null;
 
@@ -1452,14 +1501,15 @@ function bindEvents() {
       if (index < 0n) throw new Error("Claim status index must be zero or greater.");
 
       const claimed = await airdrop.isClaimed(epoch, index);
-      const localSource = runtime.claimSourcesByEpoch.get(Number(epoch));
-      const localClaim = localSource?.round?.claims?.find((claim) => BigInt(claim.index) === index) || null;
+      const localClaim = isClaimsApiConfigured(runtime.config)
+        ? await fetchStoredClaimByEpochAndIndex(runtime.config, epoch.toString(), index.toString()).catch(() => null)
+        : null;
       els.claimStatusResult.textContent = JSON.stringify(
         {
           epoch: epoch.toString(),
           index: index.toString(),
-          account: localClaim?.account || null,
-          amount: localClaim?.amount || null,
+          account: localClaim?.entry?.account || null,
+          amountRaw: localClaim?.entry?.amountRaw || null,
           claimed,
         },
         null,

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -33,6 +33,7 @@ import {
   fetchStoredClaimByEpochAndIndex,
   isClaimsApiConfigured,
   persistAirdropRound,
+  requestAirdropFinalizeChallenge,
 } from "../shared/claims.js";
 import { buildClaimRound } from "../shared/merkle.js";
 
@@ -1052,8 +1053,18 @@ async function startAirdropAndPersistRound() {
   logger.log(`Start airdrop: confirmed in block ${receipt.blockNumber}`, "success");
 
   try {
+    const finalizeChallenge = await requestAirdropFinalizeChallenge(runtime.config, {
+      walletAddress: runtime.account,
+      txHash: tx.hash,
+      merkleRoot: runtime.uploadedRound.root,
+    });
+    const finalizeSignature = await runtime.signer.signMessage(finalizeChallenge.message);
+
     const persisted = await persistAirdropRound(runtime.config, {
       txHash: tx.hash,
+      walletAddress: runtime.account,
+      challengeId: finalizeChallenge.challengeId,
+      signature: finalizeSignature,
       decimals: runtime.tokenDecimals,
       claims: runtime.uploadedRound.claims.map((claim) => ({
         index: claim.index,

--- a/frontend/js/pages/claim.js
+++ b/frontend/js/pages/claim.js
@@ -22,6 +22,16 @@ import {
 } from "../shared/wallet.js";
 import { promptForWalletSelection } from "../shared/wallet-picker.js";
 import { loadClaimCatalog, fetchClaimSource, findClaimEntry, isMissingClaimSourceError } from "../shared/claims.js";
+import {
+  getXSession,
+  clearXSession,
+  saveXSession,
+  isXAuthConfigured,
+  isXSessionExpired,
+  startXLogin,
+  logoutXSession,
+  completeXLoginIfPresent,
+} from "../shared/x-auth.js";
 
 const runtime = {
   provider: null,
@@ -38,13 +48,30 @@ const runtime = {
   selectedWalletRdns: null,
   owner: null,
   currentEpoch: 0,
-  config: { chainId: null, networkName: "", rpcUrl: "", nativeCurrency: null, tokenAddress: "", dustTokenAddress: "", airdropAddress: "", claimsManifestPath: "./claims/index.json" },
+  config: {
+    chainId: null,
+    networkName: "",
+    rpcUrl: "",
+    nativeCurrency: null,
+    tokenAddress: "",
+    dustTokenAddress: "",
+    airdropAddress: "",
+    claimsManifestPath: "./claims/index.json",
+    xAuth: {
+      enabled: true,
+      redirectUri: "",
+      backendUrl: "",
+    },
+  },
   configSource: "template",
   tokenDecimals: 18,
   tokenSymbol: "LIB",
   claimCatalog: null,
   rounds: [],
   isConnectingWallet: false,
+  isConnectingX: false,
+  isSubmittingXWalletLink: false,
+  xSession: null,
   noticeTimerId: null,
 };
 
@@ -64,6 +91,17 @@ const els = {
   claimToastMessage: document.getElementById("claimToastMessage"),
   claimToastClose: document.getElementById("claimToastClose"),
   switchNetworkButton: document.getElementById("switchNetworkButton"),
+  xAuthCard: document.getElementById("xAuthCard"),
+  xAuthHint: document.getElementById("xAuthHint"),
+  xAuthIdentity: document.getElementById("xAuthIdentity"),
+  xAuthAvatar: document.getElementById("xAuthAvatar"),
+  xAuthName: document.getElementById("xAuthName"),
+  xAuthProfileLink: document.getElementById("xAuthProfileLink"),
+  xAuthStatus: document.getElementById("xAuthStatus"),
+  xAuthLinkStatus: document.getElementById("xAuthLinkStatus"),
+  xAuthButton: document.getElementById("xAuthButton"),
+  xVerifyButton: document.getElementById("xVerifyButton"),
+  xDisconnectButton: document.getElementById("xDisconnectButton"),
 };
 
 const toast = createToastController({
@@ -127,6 +165,142 @@ function isReadyChain() {
   return runtime.chainId === runtime.config.chainId;
 }
 
+function hasAnyOnchainClaimEntry() {
+  return runtime.rounds.some((round) => {
+    if (!round.entry) return false;
+    return !["not-live", "mismatch", "error"].includes(round.status);
+  });
+}
+
+function shouldOfferXRecovery() {
+  if (!runtime.account) return false;
+  if (!runtime.claimCatalog?.sources?.length) return false;
+  return !hasAnyOnchainClaimEntry();
+}
+
+function formatXLinkStatus(linkResult) {
+  if (!linkResult) {
+    return "";
+  }
+
+  return "Thanks. We received your wallet and X account and will review it.";
+}
+
+function syncXSessionFromStorage() {
+  const session = getXSession();
+  if (session && isXSessionExpired(session)) {
+    clearXSession();
+    runtime.xSession = null;
+    return false;
+  }
+
+  runtime.xSession = session;
+  return Boolean(session);
+}
+
+function syncXAuthCard() {
+  if (!els.xAuthCard) return;
+
+  const xAuthEnabled = runtime.config?.xAuth?.enabled !== false && shouldOfferXRecovery();
+  els.xAuthCard.hidden = !xAuthEnabled;
+  if (!xAuthEnabled) return;
+
+  const isConfigured = isXAuthConfigured(runtime.config);
+  const profile = runtime.xSession?.profile || null;
+  const isSignedIn = Boolean(profile?.username);
+  const linkResult = runtime.xSession?.linkResult || null;
+  const hasLinkedWallet = Boolean(
+    linkResult
+    && runtime.account
+    && normalizeAddress(linkResult.walletAddress || "") === normalizeAddress(runtime.account),
+  );
+
+  els.xAuthIdentity.hidden = !isSignedIn;
+  els.xDisconnectButton.hidden = !isSignedIn;
+  els.xAuthButton.hidden = isSignedIn;
+  els.xVerifyButton.hidden = !isSignedIn;
+
+  if (isSignedIn) {
+    els.xAuthName.textContent = profile.name || `@${profile.username}`;
+    els.xAuthProfileLink.textContent = `@${profile.username}`;
+    els.xAuthProfileLink.href = `https://x.com/${encodeURIComponent(profile.username)}`;
+    els.xAuthProfileLink.hidden = false;
+    els.xAuthHint.textContent = "This X account can be linked to your connected wallet for follower recovery.";
+    els.xAuthStatus.textContent = "Signed in on x.com.";
+    els.xAuthStatus.dataset.tone = "";
+
+    if (profile.profileImageUrl) {
+      els.xAuthAvatar.src = profile.profileImageUrl;
+      els.xAuthAvatar.alt = `${profile.username} avatar`;
+      els.xAuthAvatar.hidden = false;
+    } else {
+      els.xAuthAvatar.hidden = true;
+      els.xAuthAvatar.removeAttribute("src");
+      els.xAuthAvatar.alt = "";
+    }
+
+    if (runtime.isSubmittingXWalletLink) {
+      els.xVerifyButton.textContent = "Verifying...";
+      els.xVerifyButton.disabled = true;
+      els.xAuthLinkStatus.hidden = false;
+      els.xAuthLinkStatus.textContent = "Confirm the wallet signature to save this recovery request.";
+      return;
+    }
+
+    if (hasLinkedWallet) {
+      const status = formatXLinkStatus(linkResult);
+      els.xVerifyButton.textContent = "Wallet Verified";
+      els.xVerifyButton.disabled = true;
+      els.xAuthLinkStatus.hidden = false;
+      els.xAuthLinkStatus.textContent = status;
+      return;
+    }
+
+    els.xVerifyButton.textContent = "Verify Wallet And Save";
+    els.xVerifyButton.disabled = !runtime.account || !runtime.signer;
+    els.xAuthLinkStatus.hidden = false;
+    els.xAuthLinkStatus.textContent = "Sign a wallet message to prove ownership and save your recovery request.";
+
+    return;
+  }
+
+  els.xAuthName.textContent = "-";
+  els.xAuthProfileLink.textContent = "@-";
+  els.xAuthProfileLink.href = "#";
+  els.xAuthProfileLink.hidden = true;
+  els.xAuthAvatar.hidden = true;
+  els.xAuthAvatar.removeAttribute("src");
+  els.xAuthAvatar.alt = "";
+  els.xVerifyButton.textContent = "Verify Wallet And Save";
+  els.xVerifyButton.disabled = true;
+  els.xAuthLinkStatus.hidden = true;
+  els.xAuthLinkStatus.textContent = "";
+
+  if (runtime.isConnectingX) {
+    els.xAuthHint.textContent = "Complete the X approval flow to return here.";
+    els.xAuthStatus.textContent = "Finishing X sign-in...";
+    els.xAuthStatus.dataset.tone = "";
+    els.xAuthButton.textContent = "Signing in...";
+    els.xAuthButton.disabled = true;
+    return;
+  }
+
+  if (!isConfigured) {
+    els.xAuthHint.textContent = "This deployment still needs the X auth backend and callback configured.";
+    els.xAuthStatus.textContent = "X sign-in is not configured yet.";
+    els.xAuthStatus.dataset.tone = "warn";
+    els.xAuthButton.textContent = "Sign in with X";
+    els.xAuthButton.disabled = true;
+    return;
+  }
+
+  els.xAuthHint.textContent = "No claim was found for this wallet. Sign in with X to start follower recovery.";
+  els.xAuthStatus.textContent = "Not signed in.";
+  els.xAuthStatus.dataset.tone = "";
+  els.xAuthButton.textContent = "Sign in with X";
+  els.xAuthButton.disabled = false;
+}
+
 function setWalletMenuOpen(isOpen) {
   if (!els.walletMenu || !els.connectButton || !runtime.account) {
     els.walletMenu?.setAttribute("hidden", "");
@@ -165,6 +339,92 @@ async function copyWalletAddress() {
   document.execCommand("copy");
   input.remove();
   logger.log("Wallet address copied.", "success");
+}
+
+async function postXBackend(path, payload) {
+  const baseUrl = String(runtime.config?.xAuth?.backendUrl || "").trim().replace(/\/+$/u, "");
+  if (!baseUrl) {
+    throw new Error("X sign-in backend URL is not configured.");
+  }
+
+  const csrfToken = String(runtime.xSession?.csrfToken || "").trim();
+  if (!csrfToken) {
+    throw new Error("X sign-in session expired. Sign in again.");
+  }
+
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    credentials: "include",
+    cache: "no-store",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRF-Token": csrfToken,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const text = await response.text();
+  let parsed = {};
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { error: text };
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(parsed?.error || "Request failed.");
+  }
+
+  return parsed;
+}
+
+async function verifyWalletAndSaveRecovery() {
+  if (!runtime.account || !runtime.signer) {
+    throw new Error("Connect the wallet you want to recover first.");
+  }
+
+  if (!shouldOfferXRecovery()) {
+    throw new Error("Recovery is only available when this wallet has no claim entries.");
+  }
+
+  if (!runtime.xSession?.profile?.username || !runtime.xSession?.csrfToken) {
+    throw new Error("Sign in with X first.");
+  }
+
+  runtime.isSubmittingXWalletLink = true;
+  syncXAuthCard();
+
+  try {
+    const challenge = await postXBackend("/api/x/link/challenge", {
+      walletAddress: runtime.account,
+    });
+
+    if (!challenge?.challengeId || !challenge?.message) {
+      throw new Error("Recovery challenge was not created.");
+    }
+
+    const signature = await runtime.signer.signMessage(challenge.message);
+    const result = await postXBackend("/api/x/link/complete", {
+      challengeId: challenge.challengeId,
+      walletAddress: runtime.account,
+      signature,
+    });
+
+    runtime.xSession = {
+      ...runtime.xSession,
+      linkResult: result,
+    };
+    saveXSession(runtime.xSession);
+    syncXAuthCard();
+
+    const status = formatXLinkStatus(result);
+    logger.log(status, "success");
+  } finally {
+    runtime.isSubmittingXWalletLink = false;
+    syncXAuthCard();
+  }
 }
 
 async function addTokenToMetaMask() {
@@ -442,12 +702,14 @@ async function refreshRounds() {
   if (!runtime.claimCatalog?.sources?.length) {
     runtime.rounds = [];
     renderRoundList();
+    syncXAuthCard();
     return;
   }
 
   runtime.rounds = await Promise.all(runtime.claimCatalog.sources.map((source) => buildRoundView(source)));
 
   renderRoundList();
+  syncXAuthCard();
 }
 
 async function refreshPage() {
@@ -561,6 +823,37 @@ function bindEvents() {
     }
   });
 
+  els.xAuthButton?.addEventListener("click", async () => {
+    try {
+      runtime.isConnectingX = true;
+      syncXAuthCard();
+      await startXLogin(runtime.config);
+    } catch (error) {
+      runtime.isConnectingX = false;
+      syncXAuthCard();
+      reportError(error, "Start X sign-in");
+    }
+  });
+
+  els.xDisconnectButton?.addEventListener("click", async () => {
+    try {
+      await logoutXSession(runtime.config, runtime.xSession);
+      runtime.xSession = null;
+      syncXAuthCard();
+      logger.log("X account disconnected.");
+    } catch (error) {
+      reportError(error, "Disconnect X account");
+    }
+  });
+
+  els.xVerifyButton?.addEventListener("click", async () => {
+    try {
+      await verifyWalletAndSaveRecovery();
+    } catch (error) {
+      reportError(error, "Verify X recovery");
+    }
+  });
+
   els.switchNetworkButton?.addEventListener("click", async () => {
     try {
       await switchNetwork();
@@ -617,6 +910,8 @@ function bindEvents() {
 
 async function init() {
   renderRoundList();
+  syncXSessionFromStorage();
+  syncXAuthCard();
   bindEvents();
   updateToastOffset();
 
@@ -628,6 +923,23 @@ async function init() {
       runtime.configSource = loaded.source;
       runtime.readProvider = null;
       runtime.readProviderKey = null;
+      syncXSessionFromStorage();
+      syncXAuthCard();
+
+      try {
+        const xAuthResult = await completeXLoginIfPresent(runtime.config);
+        runtime.xSession = xAuthResult.session || runtime.xSession;
+        if (xAuthResult.handled) {
+          logger.log("X account connected.", "success");
+        }
+      } catch (error) {
+        clearXSession();
+        runtime.xSession = null;
+        reportError(error, "Complete X sign-in");
+      }
+
+      runtime.isConnectingX = false;
+      syncXAuthCard();
       await ensureProvider(runtime).catch(() => null);
       runtime.claimCatalog = await loadClaimCatalog(runtime.config.claimsManifestPath);
       await refreshPage();

--- a/frontend/js/pages/claim.js
+++ b/frontend/js/pages/claim.js
@@ -21,7 +21,7 @@ import {
   getAvailableWallets,
 } from "../shared/wallet.js";
 import { promptForWalletSelection } from "../shared/wallet-picker.js";
-import { loadClaimCatalog, fetchClaimSource, findClaimEntry, isMissingClaimSourceError } from "../shared/claims.js";
+import { fetchWalletClaimRounds, isClaimsApiConfigured } from "../shared/claims.js";
 import {
   getXSession,
   clearXSession,
@@ -56,6 +56,7 @@ const runtime = {
     tokenAddress: "",
     dustTokenAddress: "",
     airdropAddress: "",
+    apiBaseUrl: "",
     claimsManifestPath: "./claims/index.json",
     xAuth: {
       enabled: true,
@@ -66,7 +67,6 @@ const runtime = {
   configSource: "template",
   tokenDecimals: 18,
   tokenSymbol: "LIB",
-  claimCatalog: null,
   rounds: [],
   isConnectingWallet: false,
   isConnectingX: false,
@@ -173,7 +173,7 @@ function hasAnyOnchainClaimEntry() {
 
 function shouldOfferXRecovery() {
   if (!runtime.account) return false;
-  if (!runtime.claimCatalog?.sources?.length) return false;
+  if (!isClaimsApiConfigured(runtime.config)) return false;
   return !hasAnyOnchainClaimEntry();
 }
 
@@ -674,37 +674,10 @@ function renderRoundList() {
   });
 }
 
-async function buildRoundView(source) {
-  let artifact;
-  try {
-    artifact = await fetchClaimSource(source, runtime.claimCatalog.baseUrl, runtime.tokenDecimals);
-  } catch (error) {
-    if (isMissingClaimSourceError(error)) {
-      console.warn(
-        `[Claims] Claim file not found for epoch ${source.epoch}: ${source.file}`,
-        error,
-      );
-
-      return {
-        source,
-        artifact: null,
-        entry: null,
-        epoch: source.epoch,
-        amountRaw: 0n,
-        onchainRoot: ethers.ZeroHash,
-        deadline: 0n,
-        claimed: false,
-        status: "error",
-        errorMessage: "",
-      };
-    }
-
-    throw error;
-  }
-
-  const entry = runtime.account ? findClaimEntry(artifact, runtime.account) : null;
+async function buildRoundView(storedRound) {
+  const entry = storedRound?.entry || null;
   const amountRaw = entry ? BigInt(entry.amountRaw) : 0n;
-  const epoch = source.epoch;
+  const epoch = Number(storedRound?.epoch || 0);
 
   let onchainRoot = ethers.ZeroHash;
   let deadline = 0n;
@@ -733,7 +706,7 @@ async function buildRoundView(source) {
     status = "error";
   } else if (!epoch || !onchainRoot || onchainRoot === ethers.ZeroHash) {
     status = "not-live";
-  } else if (String(artifact.root || "").toLowerCase() !== onchainRoot.toLowerCase()) {
+  } else if (String(storedRound?.merkleRoot || "").toLowerCase() !== onchainRoot.toLowerCase()) {
     status = "mismatch";
   } else if (deadline === 0n || BigInt(Math.floor(Date.now() / 1000)) >= deadline) {
     status = "closed";
@@ -748,8 +721,8 @@ async function buildRoundView(source) {
   }
 
   return {
-    source,
-    artifact,
+    source: { epoch },
+    artifact: storedRound,
     entry,
     epoch,
     amountRaw,
@@ -762,14 +735,16 @@ async function buildRoundView(source) {
 }
 
 async function refreshRounds() {
-  if (!runtime.claimCatalog?.sources?.length) {
+  if (!runtime.account || !isClaimsApiConfigured(runtime.config)) {
     runtime.rounds = [];
     renderRoundList();
     syncXAuthCard();
     return;
   }
 
-  runtime.rounds = await Promise.all(runtime.claimCatalog.sources.map((source) => buildRoundView(source)));
+  const payload = await fetchWalletClaimRounds(runtime.config, runtime.account);
+  const storedRounds = Array.isArray(payload?.rounds) ? payload.rounds : [];
+  runtime.rounds = await Promise.all(storedRounds.map((round) => buildRoundView(round)));
 
   renderRoundList();
   syncXAuthCard();
@@ -1004,7 +979,6 @@ async function init() {
       runtime.isConnectingX = false;
       syncXAuthCard();
       await ensureProvider(runtime).catch(() => null);
-      runtime.claimCatalog = await loadClaimCatalog(runtime.config.claimsManifestPath);
       await refreshPage();
     } catch (error) {
       reportError(error, "Initialize claimant page");

--- a/frontend/js/pages/claim.js
+++ b/frontend/js/pages/claim.js
@@ -95,7 +95,6 @@ const els = {
   xAuthHint: document.getElementById("xAuthHint"),
   xAuthIdentity: document.getElementById("xAuthIdentity"),
   xAuthAvatar: document.getElementById("xAuthAvatar"),
-  xAuthName: document.getElementById("xAuthName"),
   xAuthProfileLink: document.getElementById("xAuthProfileLink"),
   xAuthStatus: document.getElementById("xAuthStatus"),
   xAuthLinkStatus: document.getElementById("xAuthLinkStatus"),
@@ -186,6 +185,40 @@ function formatXLinkStatus(linkResult) {
   return "Thanks. We received your wallet and X account and will review it.";
 }
 
+function getSignedInXAccount() {
+  return runtime.xSession?.account || null;
+}
+
+function getExistingXSubmission() {
+  return runtime.xSession?.existingSubmission || null;
+}
+
+function hasWalletOnFileForXAccount(account = getSignedInXAccount()) {
+  return Boolean(String(account?.walletAddress || "").trim());
+}
+
+function formatExistingFormWalletStatus(account = getSignedInXAccount()) {
+  const walletAddress = String(account?.walletAddress || "").trim();
+  if (!walletAddress) {
+    return "We already have a wallet on file for this X account.";
+  }
+
+  const isConnectedWalletMatch = Boolean(
+    runtime.account
+    && normalizeAddress(walletAddress) === normalizeAddress(runtime.account),
+  );
+
+  if (isConnectedWalletMatch) {
+    return `We already have this X account linked to ${walletAddress}. Use this wallet to claim when eligible rounds are available.`;
+  }
+
+  return `We already have this X account linked to ${walletAddress}. Switch to that wallet to claim.`;
+}
+
+function formatExistingRecoveryStatus() {
+  return "We already received a response for this X account.";
+}
+
 function syncXSessionFromStorage() {
   const session = getXSession();
   if (session && isXSessionExpired(session)) {
@@ -207,25 +240,24 @@ function syncXAuthCard() {
 
   const isConfigured = isXAuthConfigured(runtime.config);
   const profile = runtime.xSession?.profile || null;
+  const account = getSignedInXAccount();
+  const existingSubmission = getExistingXSubmission();
   const isSignedIn = Boolean(profile?.username);
-  const linkResult = runtime.xSession?.linkResult || null;
-  const hasLinkedWallet = Boolean(
-    linkResult
-    && runtime.account
-    && normalizeAddress(linkResult.walletAddress || "") === normalizeAddress(runtime.account),
-  );
+  const hasWalletOnFile = hasWalletOnFileForXAccount(account);
+  const hasSavedFormWallet = hasWalletOnFile && account?.walletSource === "form";
+  const hasSavedRecoveryWallet = Boolean(existingSubmission) || (hasWalletOnFile && account?.walletSource !== "form");
 
   els.xAuthIdentity.hidden = !isSignedIn;
   els.xDisconnectButton.hidden = !isSignedIn;
   els.xAuthButton.hidden = isSignedIn;
-  els.xVerifyButton.hidden = !isSignedIn;
+  els.xVerifyButton.hidden = !isSignedIn || hasWalletOnFile || Boolean(existingSubmission);
+  els.xAuthStatus.hidden = false;
 
   if (isSignedIn) {
-    els.xAuthName.textContent = profile.name || `@${profile.username}`;
     els.xAuthProfileLink.textContent = `@${profile.username}`;
     els.xAuthProfileLink.href = `https://x.com/${encodeURIComponent(profile.username)}`;
     els.xAuthProfileLink.hidden = false;
-    els.xAuthHint.textContent = "This X account can be linked to your connected wallet for follower recovery.";
+    els.xAuthHint.hidden = true;
     els.xAuthStatus.textContent = "Signed in on x.com.";
     els.xAuthStatus.dataset.tone = "";
 
@@ -239,20 +271,31 @@ function syncXAuthCard() {
       els.xAuthAvatar.alt = "";
     }
 
+    if (hasSavedFormWallet) {
+      els.xAuthHint.hidden = true;
+      els.xAuthStatus.hidden = true;
+      els.xVerifyButton.hidden = true;
+      els.xVerifyButton.disabled = true;
+      els.xAuthLinkStatus.hidden = false;
+      els.xAuthLinkStatus.textContent = formatExistingFormWalletStatus(account);
+      return;
+    }
+
+    if (hasSavedRecoveryWallet) {
+      els.xAuthHint.hidden = true;
+      els.xAuthStatus.hidden = true;
+      els.xVerifyButton.hidden = true;
+      els.xVerifyButton.disabled = true;
+      els.xAuthLinkStatus.hidden = false;
+      els.xAuthLinkStatus.textContent = formatExistingRecoveryStatus();
+      return;
+    }
+
     if (runtime.isSubmittingXWalletLink) {
       els.xVerifyButton.textContent = "Verifying...";
       els.xVerifyButton.disabled = true;
       els.xAuthLinkStatus.hidden = false;
       els.xAuthLinkStatus.textContent = "Confirm the wallet signature to save this recovery request.";
-      return;
-    }
-
-    if (hasLinkedWallet) {
-      const status = formatXLinkStatus(linkResult);
-      els.xVerifyButton.textContent = "Wallet Verified";
-      els.xVerifyButton.disabled = true;
-      els.xAuthLinkStatus.hidden = false;
-      els.xAuthLinkStatus.textContent = status;
       return;
     }
 
@@ -264,7 +307,6 @@ function syncXAuthCard() {
     return;
   }
 
-  els.xAuthName.textContent = "-";
   els.xAuthProfileLink.textContent = "@-";
   els.xAuthProfileLink.href = "#";
   els.xAuthProfileLink.hidden = true;
@@ -277,6 +319,8 @@ function syncXAuthCard() {
   els.xAuthLinkStatus.textContent = "";
 
   if (runtime.isConnectingX) {
+    els.xAuthStatus.hidden = false;
+    els.xAuthHint.hidden = false;
     els.xAuthHint.textContent = "Complete the X approval flow to return here.";
     els.xAuthStatus.textContent = "Finishing X sign-in...";
     els.xAuthStatus.dataset.tone = "";
@@ -286,6 +330,8 @@ function syncXAuthCard() {
   }
 
   if (!isConfigured) {
+    els.xAuthStatus.hidden = false;
+    els.xAuthHint.hidden = false;
     els.xAuthHint.textContent = "This deployment still needs the X auth backend and callback configured.";
     els.xAuthStatus.textContent = "X sign-in is not configured yet.";
     els.xAuthStatus.dataset.tone = "warn";
@@ -294,6 +340,8 @@ function syncXAuthCard() {
     return;
   }
 
+  els.xAuthStatus.hidden = false;
+  els.xAuthHint.hidden = false;
   els.xAuthHint.textContent = "No claim was found for this wallet. Sign in with X to start follower recovery.";
   els.xAuthStatus.textContent = "Not signed in.";
   els.xAuthStatus.dataset.tone = "";
@@ -393,6 +441,19 @@ async function verifyWalletAndSaveRecovery() {
     throw new Error("Sign in with X first.");
   }
 
+  const existingAccount = getSignedInXAccount();
+  const existingSubmission = getExistingXSubmission();
+  if (hasWalletOnFileForXAccount(existingAccount)) {
+    if (existingAccount?.walletSource === "form") {
+      throw new Error(formatExistingFormWalletStatus(existingAccount));
+    }
+    throw new Error(formatExistingRecoveryStatus());
+  }
+
+  if (existingSubmission) {
+    throw new Error(formatExistingRecoveryStatus());
+  }
+
   runtime.isSubmittingXWalletLink = true;
   syncXAuthCard();
 
@@ -414,6 +475,8 @@ async function verifyWalletAndSaveRecovery() {
 
     runtime.xSession = {
       ...runtime.xSession,
+      account: result?.account || runtime.xSession?.account || null,
+      existingSubmission: result?.existingSubmission || runtime.xSession?.existingSubmission || null,
       linkResult: result,
     };
     saveXSession(runtime.xSession);

--- a/frontend/js/shared/claims.js
+++ b/frontend/js/shared/claims.js
@@ -95,6 +95,22 @@ export async function persistAirdropRound(config, payload) {
   });
 }
 
+export async function requestAirdropFinalizeChallenge(config, payload) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  return fetchBackendJson(`${backendBaseUrl}/api/admin/airdrop-rounds/challenge`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
 export function normalizeClaimCatalog(rawCatalog) {
   const sourceRows = Array.isArray(rawCatalog)
     ? rawCatalog

--- a/frontend/js/shared/claims.js
+++ b/frontend/js/shared/claims.js
@@ -3,6 +3,98 @@ import { ethers } from "./ethers.js";
 import { normalizeAddress } from "./format.js";
 import { buildClaimRound } from "./merkle.js";
 
+function getBackendBaseUrl(configOrUrl) {
+  if (typeof configOrUrl === "string") {
+    return String(configOrUrl || "").trim().replace(/\/+$/u, "");
+  }
+
+  return String(
+    configOrUrl?.apiBaseUrl
+    || configOrUrl?.xAuth?.backendUrl
+    || "",
+  ).trim().replace(/\/+$/u, "");
+}
+
+async function fetchBackendJson(url, options = {}) {
+  const response = await fetch(url, {
+    cache: "no-store",
+    credentials: options.credentials || "same-origin",
+    ...options,
+  });
+
+  const text = await response.text();
+  let parsed = {};
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { error: text };
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(parsed?.error || `Request failed (${response.status}).`);
+  }
+
+  return parsed;
+}
+
+export function isClaimsApiConfigured(config) {
+  return Boolean(getBackendBaseUrl(config));
+}
+
+export async function fetchWalletClaimRounds(config, walletAddress) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  const normalizedWalletAddress = normalizeAddress(walletAddress);
+  if (!normalizedWalletAddress) {
+    throw new Error("Wallet address is invalid.");
+  }
+
+  return fetchBackendJson(
+    `${backendBaseUrl}/api/claims/wallet/${encodeURIComponent(normalizedWalletAddress)}`,
+  );
+}
+
+export async function fetchStoredAirdropRounds(config) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  return fetchBackendJson(`${backendBaseUrl}/api/airdrop/rounds`);
+}
+
+export async function fetchStoredClaimByEpochAndIndex(config, epoch, claimIndex) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  return fetchBackendJson(
+    `${backendBaseUrl}/api/airdrop/epochs/${encodeURIComponent(epoch)}/claims/${encodeURIComponent(claimIndex)}`,
+  );
+}
+
+export async function persistAirdropRound(config, payload) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  return fetchBackendJson(`${backendBaseUrl}/api/admin/airdrop-rounds/finalize`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
 export function normalizeClaimCatalog(rawCatalog) {
   const sourceRows = Array.isArray(rawCatalog)
     ? rawCatalog

--- a/frontend/js/shared/config.js
+++ b/frontend/js/shared/config.js
@@ -33,6 +33,7 @@ export async function loadUiConfig() {
   const overrides = savedOverrides ? JSON.parse(savedOverrides) : {};
   const loadedXAuth = loaded?.xAuth && typeof loaded.xAuth === "object" ? loaded.xAuth : {};
   const overrideXAuth = overrides?.xAuth && typeof overrides.xAuth === "object" ? overrides.xAuth : {};
+  const hasOverrideExplorerBaseUrl = Object.prototype.hasOwnProperty.call(overrides, "explorerBaseUrl");
 
   const config = {
     claimsManifestPath: "./claims/index.json",
@@ -53,7 +54,11 @@ export async function loadUiConfig() {
       || ""
     ).trim(),
     deploymentKey: String(loaded.deploymentKey || "").trim(),
-    explorerBaseUrl: String(overrides.explorerBaseUrl || loaded.explorerBaseUrl || "").trim(),
+    explorerBaseUrl: String(
+      hasOverrideExplorerBaseUrl
+        ? overrides.explorerBaseUrl
+        : (loaded.explorerBaseUrl || "")
+    ).trim(),
     xAuth: {
       enabled: overrideXAuth.enabled ?? loadedXAuth.enabled ?? true,
       redirectUri: String(overrideXAuth.redirectUri || loadedXAuth.redirectUri || loaded.xRedirectUri || "").trim(),

--- a/frontend/js/shared/config.js
+++ b/frontend/js/shared/config.js
@@ -36,17 +36,35 @@ export async function loadUiConfig() {
 
   const config = {
     claimsManifestPath: "./claims/index.json",
+    apiBaseUrl: "",
+    deploymentKey: "",
     ...loaded,
     ...overrides,
     tokenAddress: normalizeAddress(overrides.tokenAddress || loaded.tokenAddress || ""),
     dustTokenAddress: normalizeAddress(overrides.dustTokenAddress || loaded.dustTokenAddress || ""),
     airdropAddress: normalizeAddress(overrides.airdropAddress || loaded.airdropAddress || ""),
     claimsManifestPath: String(overrides.claimsManifestPath || loaded.claimsManifestPath || "./claims/index.json"),
+    apiBaseUrl: String(
+      overrides.apiBaseUrl
+      || loaded.apiBaseUrl
+      || overrideXAuth.backendUrl
+      || loadedXAuth.backendUrl
+      || loaded.xBackendUrl
+      || ""
+    ).trim(),
+    deploymentKey: String(loaded.deploymentKey || "").trim(),
     explorerBaseUrl: String(overrides.explorerBaseUrl || loaded.explorerBaseUrl || "").trim(),
     xAuth: {
       enabled: overrideXAuth.enabled ?? loadedXAuth.enabled ?? true,
       redirectUri: String(overrideXAuth.redirectUri || loadedXAuth.redirectUri || loaded.xRedirectUri || "").trim(),
-      backendUrl: String(overrideXAuth.backendUrl || loadedXAuth.backendUrl || loaded.xBackendUrl || "").trim(),
+      backendUrl: String(
+        overrideXAuth.backendUrl
+        || loadedXAuth.backendUrl
+        || overrides.apiBaseUrl
+        || loaded.apiBaseUrl
+        || loaded.xBackendUrl
+        || ""
+      ).trim(),
     },
   };
 
@@ -74,6 +92,7 @@ export function saveAddressOverrides(overrides) {
       tokenAddress: normalizeAddress(overrides.tokenAddress || ""),
       dustTokenAddress: normalizeAddress(overrides.dustTokenAddress || ""),
       claimsManifestPath: String(overrides.claimsManifestPath || "./claims/index.json"),
+      apiBaseUrl: String(overrides.apiBaseUrl || "").trim(),
     }),
   );
 }

--- a/frontend/js/shared/config.js
+++ b/frontend/js/shared/config.js
@@ -31,6 +31,8 @@ export async function loadUiConfig() {
 
   const savedOverrides = window.localStorage.getItem(STORAGE_KEY);
   const overrides = savedOverrides ? JSON.parse(savedOverrides) : {};
+  const loadedXAuth = loaded?.xAuth && typeof loaded.xAuth === "object" ? loaded.xAuth : {};
+  const overrideXAuth = overrides?.xAuth && typeof overrides.xAuth === "object" ? overrides.xAuth : {};
 
   const config = {
     claimsManifestPath: "./claims/index.json",
@@ -41,6 +43,11 @@ export async function loadUiConfig() {
     airdropAddress: normalizeAddress(overrides.airdropAddress || loaded.airdropAddress || ""),
     claimsManifestPath: String(overrides.claimsManifestPath || loaded.claimsManifestPath || "./claims/index.json"),
     explorerBaseUrl: String(overrides.explorerBaseUrl || loaded.explorerBaseUrl || "").trim(),
+    xAuth: {
+      enabled: overrideXAuth.enabled ?? loadedXAuth.enabled ?? true,
+      redirectUri: String(overrideXAuth.redirectUri || loadedXAuth.redirectUri || loaded.xRedirectUri || "").trim(),
+      backendUrl: String(overrideXAuth.backendUrl || loadedXAuth.backendUrl || loaded.xBackendUrl || "").trim(),
+    },
   };
 
   config.chainId = Number(config.chainId);

--- a/frontend/js/shared/constants.js
+++ b/frontend/js/shared/constants.js
@@ -9,6 +9,8 @@ export function toChainIdHex(chainId) {
 
 export const STORAGE_KEY = "liberdus-airdrop-ui-config";
 export const WALLET_SESSION_KEY = "liberdus-airdrop-wallet-session";
+export const X_AUTH_PENDING_KEY = "liberdus-airdrop-x-auth-pending";
+export const X_AUTH_SESSION_KEY = "liberdus-airdrop-x-auth-session";
 export const UI_ROOT = new URL("../../", import.meta.url);
 export const CHAIN_NAME_BY_ID = {
   1: "Ethereum",

--- a/frontend/js/shared/x-auth.js
+++ b/frontend/js/shared/x-auth.js
@@ -96,13 +96,59 @@ function normalizeProfile(payload) {
   };
 }
 
+function normalizeAccount(account) {
+  if (!account || typeof account !== "object") {
+    return null;
+  }
+
+  return {
+    id: Number(account.id || 0) || null,
+    xUserId: String(account.xUserId || "").trim(),
+    username: String(account.username || "").trim(),
+    walletAddress: String(account.walletAddress || "").trim(),
+    walletSource: String(account.walletSource || "").trim(),
+    isFollower: Boolean(account.isFollower),
+    needsRecovery: Boolean(account.needsRecovery),
+    firstSeenFollowingAt: account.firstSeenFollowingAt || null,
+    lastSeenFollowingAt: account.lastSeenFollowingAt || null,
+    snapshotsSeenCount: Number(account.snapshotsSeenCount || 0),
+  };
+}
+
+function normalizeExistingSubmission(submission) {
+  if (!submission || typeof submission !== "object") {
+    return null;
+  }
+
+  return {
+    id: String(submission.id || "").trim(),
+    xUserId: String(submission.xUserId || "").trim(),
+    usernameAtSubmission: String(submission.usernameAtSubmission || "").trim(),
+    walletAddress: String(submission.walletAddress || "").trim(),
+    wasKnownFollower: Boolean(submission.wasKnownFollower),
+    wasRecoveryCandidate: Boolean(submission.wasRecoveryCandidate),
+    status: String(submission.status || "").trim(),
+    submittedAt: submission.submittedAt || null,
+  };
+}
+
 function buildSession(result, profile, previousSession = null) {
   const previousLinkResult = previousSession?.profile?.id === profile.id ? previousSession.linkResult || null : null;
+  const previousAccount = previousSession?.profile?.id === profile.id ? previousSession.account || null : null;
+  const previousExistingSubmission = previousSession?.profile?.id === profile.id
+    ? previousSession.existingSubmission || null
+    : null;
+  const hasAccountField = Object.prototype.hasOwnProperty.call(result || {}, "account");
+  const hasExistingSubmissionField = Object.prototype.hasOwnProperty.call(result || {}, "existingSubmission");
   return {
     expiresAt: result?.expiresAt || null,
     csrfToken: String(result?.csrfToken || ""),
     profile,
     authenticatedAt: result?.authenticatedAt || new Date().toISOString(),
+    account: hasAccountField ? normalizeAccount(result.account) : previousAccount,
+    existingSubmission: hasExistingSubmissionField
+      ? normalizeExistingSubmission(result.existingSubmission)
+      : previousExistingSubmission,
     linkResult: previousLinkResult,
   };
 }
@@ -215,6 +261,13 @@ export async function completeXLoginIfPresent(config = {}) {
       return {
         handled,
         session: previousSession,
+      };
+    }
+
+    if (!hasCompletionSignal && !previousSession) {
+      return {
+        handled,
+        session: null,
       };
     }
 

--- a/frontend/js/shared/x-auth.js
+++ b/frontend/js/shared/x-auth.js
@@ -1,0 +1,243 @@
+import { X_AUTH_SESSION_KEY } from "./constants.js";
+
+const SESSION_EXPIRY_WINDOW_MS = 60_000;
+const AUTH_COMPLETE_QUERY_PARAM = "x_auth";
+const AUTH_COMPLETE_QUERY_VALUE = "complete";
+const AUTH_ERROR_QUERY_PARAM = "x_error";
+
+function getSessionStorage() {
+  if (!window.sessionStorage) {
+    throw new Error("This browser does not support sessionStorage.");
+  }
+
+  return window.sessionStorage;
+}
+
+function readSessionJson(key) {
+  try {
+    const storage = getSessionStorage();
+    const rawValue = storage.getItem(key);
+    return rawValue ? JSON.parse(rawValue) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionJson(key, value) {
+  const storage = getSessionStorage();
+  storage.setItem(key, JSON.stringify(value));
+}
+
+function removeSessionValue(key) {
+  try {
+    getSessionStorage().removeItem(key);
+  } catch {
+    // Ignore storage cleanup failures.
+  }
+}
+
+async function parseJsonResponse(response) {
+  const text = await response.text();
+  if (!text) return {};
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}
+
+function describeErrorPayload(payload) {
+  if (!payload || typeof payload !== "object") {
+    return "Unexpected response from X recovery backend.";
+  }
+
+  if (typeof payload.error === "string" && payload.error.trim()) {
+    return payload.error.trim();
+  }
+
+  if (typeof payload.detail === "string" && payload.detail.trim()) {
+    return payload.detail.trim();
+  }
+
+  return "Unexpected response from X recovery backend.";
+}
+
+function cleanupAuthQueryParams() {
+  const currentUrl = new URL(window.location.href);
+  [AUTH_COMPLETE_QUERY_PARAM, AUTH_ERROR_QUERY_PARAM].forEach((key) => {
+    currentUrl.searchParams.delete(key);
+  });
+  window.history.replaceState({}, document.title, currentUrl.toString());
+}
+
+function getNormalizedXAuthConfig(config = {}) {
+  const xAuth = config?.xAuth && typeof config.xAuth === "object" ? config.xAuth : {};
+  return {
+    enabled: xAuth.enabled !== false,
+    backendUrl: String(xAuth.backendUrl || "").trim().replace(/\/+$/u, ""),
+    redirectUri: String(xAuth.redirectUri || "").trim() || `${window.location.origin}${window.location.pathname}`,
+  };
+}
+
+function normalizeProfile(payload) {
+  const user = payload?.data || payload;
+  if (!user?.id || !user?.username) {
+    throw new Error("X did not return a valid user profile.");
+  }
+
+  return {
+    id: String(user.id),
+    name: String(user.name || user.username),
+    username: String(user.username),
+    profileImageUrl: String(user.profile_image_url || user.profileImageUrl || ""),
+    verified: Boolean(user.verified),
+    verifiedType: String(user.verified_type || user.verifiedType || ""),
+  };
+}
+
+function buildSession(result, profile, previousSession = null) {
+  const previousLinkResult = previousSession?.profile?.id === profile.id ? previousSession.linkResult || null : null;
+  return {
+    expiresAt: result?.expiresAt || null,
+    csrfToken: String(result?.csrfToken || ""),
+    profile,
+    authenticatedAt: result?.authenticatedAt || new Date().toISOString(),
+    linkResult: previousLinkResult,
+  };
+}
+
+async function fetchBackendSession(backendUrl, { required = false } = {}) {
+  const response = await fetch(`${backendUrl}/api/x/session`, {
+    credentials: "include",
+    cache: "no-store",
+  });
+
+  const payload = await parseJsonResponse(response);
+  if (response.status === 401) {
+    if (required) {
+      throw new Error(`X sign-in failed: ${describeErrorPayload(payload)}`);
+    }
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`X sign-in failed: ${describeErrorPayload(payload)}`);
+  }
+
+  if (!payload?.profile?.username || !payload?.csrfToken) {
+    throw new Error("X sign-in failed: missing authenticated X profile.");
+  }
+
+  return payload;
+}
+
+export function getXSession() {
+  const session = readSessionJson(X_AUTH_SESSION_KEY);
+  if (!session?.profile?.username || !session?.csrfToken) {
+    return null;
+  }
+
+  return session;
+}
+
+export function clearXSession() {
+  removeSessionValue(X_AUTH_SESSION_KEY);
+}
+
+export function saveXSession(session) {
+  if (!session) {
+    clearXSession();
+    return;
+  }
+
+  writeSessionJson(X_AUTH_SESSION_KEY, session);
+}
+
+export function isXSessionExpired(session = getXSession()) {
+  if (!session?.expiresAt) {
+    return false;
+  }
+
+  return Date.now() >= (Number(session.expiresAt) - SESSION_EXPIRY_WINDOW_MS);
+}
+
+export function isXAuthConfigured(config = {}) {
+  const xAuth = getNormalizedXAuthConfig(config);
+  return xAuth.enabled && Boolean(xAuth.backendUrl);
+}
+
+export async function startXLogin(config = {}) {
+  const xAuth = getNormalizedXAuthConfig(config);
+  if (!xAuth.enabled || !xAuth.backendUrl) {
+    throw new Error("X sign-in is not configured.");
+  }
+
+  const startUrl = new URL(`${xAuth.backendUrl}/api/x/start`);
+  startUrl.searchParams.set("return_uri", xAuth.redirectUri);
+  window.location.assign(startUrl.toString());
+}
+
+export async function logoutXSession(config = {}, session = getXSession()) {
+  const xAuth = getNormalizedXAuthConfig(config);
+  const csrfToken = String(session?.csrfToken || "").trim();
+
+  if (xAuth.enabled && xAuth.backendUrl && csrfToken) {
+    await fetch(`${xAuth.backendUrl}/api/x/logout`, {
+      method: "POST",
+      credentials: "include",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": csrfToken,
+      },
+      body: "{}",
+    }).catch(() => null);
+  }
+
+  clearXSession();
+}
+
+export async function completeXLoginIfPresent(config = {}) {
+  const params = new URLSearchParams(window.location.search);
+  const hasCompletionSignal = params.get(AUTH_COMPLETE_QUERY_PARAM) === AUTH_COMPLETE_QUERY_VALUE;
+  const authError = params.get(AUTH_ERROR_QUERY_PARAM);
+  const handled = hasCompletionSignal || Boolean(authError);
+  const previousSession = getXSession();
+
+  try {
+    if (authError) {
+      throw new Error(authError);
+    }
+
+    const xAuth = getNormalizedXAuthConfig(config);
+    if (!xAuth.enabled || !xAuth.backendUrl) {
+      return {
+        handled,
+        session: previousSession,
+      };
+    }
+
+    const authResult = await fetchBackendSession(xAuth.backendUrl, { required: hasCompletionSignal });
+    if (!authResult) {
+      clearXSession();
+      return {
+        handled,
+        session: null,
+      };
+    }
+
+    const profile = normalizeProfile(authResult.profile);
+    const session = buildSession(authResult, profile, previousSession);
+    saveXSession(session);
+
+    return {
+      handled,
+      session,
+    };
+  } finally {
+    if (handled) {
+      cleanupAuthQueryParams();
+    }
+  }
+}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -724,19 +724,11 @@ select {
 .x-auth-profile {
   min-width: 0;
   display: grid;
-  gap: 4px;
+  gap: 0;
 }
 
-.x-auth-name,
 .x-auth-status {
   margin: 0;
-}
-
-.x-auth-name {
-  color: #fff6df;
-  font-family: var(--display);
-  font-size: 1.1rem;
-  line-height: 1.1;
 }
 
 .x-auth-link,
@@ -746,7 +738,8 @@ select {
 
 .x-auth-link {
   color: var(--accent-strong);
-  font-size: 0.9rem;
+  font-size: 1rem;
+  line-height: 1.2;
   text-decoration: underline;
   overflow-wrap: anywhere;
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -683,6 +683,98 @@ select {
   margin-top: 18px;
 }
 
+.x-auth-card {
+  display: grid;
+  gap: 18px;
+  padding: 18px;
+  border: 1px solid rgba(251, 175, 64, 0.16);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 38%),
+    linear-gradient(180deg, rgba(13, 30, 82, 0.92), rgba(6, 17, 52, 0.96));
+}
+
+.x-auth-copy {
+  display: grid;
+  gap: 10px;
+}
+
+.x-auth-shell {
+  display: grid;
+  gap: 14px;
+}
+
+.x-auth-identity {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.x-auth-avatar {
+  width: 52px;
+  min-width: 52px;
+  height: 52px;
+  min-height: 52px;
+  border-radius: 50%;
+  border: 1px solid rgba(251, 175, 64, 0.2);
+  object-fit: cover;
+  background: rgba(251, 175, 64, 0.08);
+}
+
+.x-auth-profile {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.x-auth-name,
+.x-auth-status {
+  margin: 0;
+}
+
+.x-auth-name {
+  color: #fff6df;
+  font-family: var(--display);
+  font-size: 1.1rem;
+  line-height: 1.1;
+}
+
+.x-auth-link,
+.x-auth-status {
+  font-family: var(--mono);
+}
+
+.x-auth-link {
+  color: var(--accent-strong);
+  font-size: 0.9rem;
+  text-decoration: underline;
+  overflow-wrap: anywhere;
+}
+
+.x-auth-status {
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.55;
+}
+
+.x-auth-status[data-tone="success"] {
+  color: var(--success);
+}
+
+.x-auth-status[data-tone="warn"] {
+  color: var(--accent-strong);
+}
+
+.x-auth-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.x-auth-actions button {
+  min-width: 176px;
+}
+
 .claim-title {
   max-width: none;
   font-size: clamp(2.1rem, 8vw, 3.1rem);
@@ -1630,6 +1722,7 @@ code {
     align-items: stretch;
   }
 
+  .x-auth-identity,
   .claim-topbar {
     flex-direction: column;
     align-items: stretch;
@@ -1709,6 +1802,10 @@ code {
   }
 
   .claim-lookup-actions button {
+    width: 100%;
+  }
+
+  .x-auth-actions button {
     width: 100%;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@openzeppelin/contracts": "^5.4.0",
         "better-sqlite3": "^12.9.0",
-        "csv-parse": "^6.2.1"
+        "csv-parse": "^6.2.1",
+        "pm2": "^6.0.14"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
@@ -1395,6 +1396,290 @@
       "integrity": "sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==",
       "license": "MIT"
     },
+    "node_modules/@pm2/agent": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-2.1.1.tgz",
+      "integrity": "sha512-0V9ckHWd/HSC8BgAbZSoq8KXUG81X97nSkAxmhKDhmF8vanyaoc1YXwc2KVkbWz82Rg4gjd2n9qiT3i7bdvGrQ==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "async": "~3.2.0",
+        "chalk": "~3.0.0",
+        "dayjs": "~1.8.24",
+        "debug": "~4.3.1",
+        "eventemitter2": "~5.0.1",
+        "fast-json-patch": "^3.1.0",
+        "fclone": "~1.0.11",
+        "pm2-axon": "~4.0.1",
+        "pm2-axon-rpc": "~0.7.0",
+        "proxy-agent": "~6.4.0",
+        "semver": "~7.5.0",
+        "ws": "~7.5.10"
+      }
+    },
+    "node_modules/@pm2/agent/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/@pm2/agent/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@pm2/agent/node_modules/dayjs": {
+      "version": "1.8.36",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.36.tgz",
+      "integrity": "sha512-3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw==",
+      "license": "MIT"
+    },
+    "node_modules/@pm2/agent/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pm2/agent/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@pm2/agent/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@pm2/agent/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pm2/blessed": {
+      "version": "0.1.81",
+      "resolved": "https://registry.npmjs.org/@pm2/blessed/-/blessed-0.1.81.tgz",
+      "integrity": "sha512-ZcNHqQjMuNRcQ7Z1zJbFIQZO/BDKV3KbiTckWdfbUaYhj7uNmUwb+FbdDWSCkvxNr9dBJQwvV17o6QBkAvgO0g==",
+      "license": "MIT",
+      "bin": {
+        "blessed": "bin/tput.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@pm2/io": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-6.1.0.tgz",
+      "integrity": "sha512-IxHuYURa3+FQ6BKePlgChZkqABUKFYH6Bwbw7V/pWU1pP6iR1sCI26l7P9ThUEB385ruZn/tZS3CXDUF5IA1NQ==",
+      "license": "Apache-2",
+      "dependencies": {
+        "async": "~2.6.1",
+        "debug": "~4.3.1",
+        "eventemitter2": "^6.3.1",
+        "require-in-the-middle": "^5.0.0",
+        "semver": "~7.5.4",
+        "shimmer": "^1.2.0",
+        "signal-exit": "^3.0.3",
+        "tslib": "1.9.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@pm2/io/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/@pm2/io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pm2/io/node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
+    },
+    "node_modules/@pm2/io/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@pm2/io/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@pm2/io/node_modules/tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@pm2/js-api": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.8.0.tgz",
+      "integrity": "sha512-nmWzrA/BQZik3VBz+npRcNIu01kdBhWL0mxKmP1ciF/gTcujPTQqt027N9fc1pK9ERM8RipFhymw7RcmCyOEYA==",
+      "license": "Apache-2",
+      "dependencies": {
+        "async": "^2.6.3",
+        "debug": "~4.3.1",
+        "eventemitter2": "^6.3.1",
+        "extrareqp2": "^1.0.0",
+        "ws": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@pm2/js-api/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/@pm2/js-api/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pm2/js-api/node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
+      "license": "MIT"
+    },
+    "node_modules/@pm2/js-api/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pm2/pm2-version-check": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@pm2/pm2-version-check/-/pm2-version-check-1.0.4.tgz",
+      "integrity": "sha512-SXsM27SGH3yTWKc2fKR4SYNxsmnvuBQ9dd6QHtEWmiZ/VqaOYPAIlS8+vMcn27YLtAEBGvNRSh3TPNvtjZgfqA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1"
+      }
+    },
     "node_modules/@scure/base": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
@@ -1654,6 +1939,12 @@
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -1978,6 +2269,21 @@
         "node": ">=0.4.2"
       }
     },
+    "node_modules/amp": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/amp/-/amp-0.3.1.tgz",
+      "integrity": "sha512-OwIuC4yZaRogHKiuU5WlMR5Xk/jAcpPtawWL05Gj8Lvm2F6mwoJt4O/bHI+DHwG79vWd+8OFYM4/BzYqyRd3qw==",
+      "license": "MIT"
+    },
+    "node_modules/amp-message": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/amp-message/-/amp-message-0.1.2.tgz",
+      "integrity": "sha512-JqutcFwoU1+jhv7ArgW38bqrE+LQdcRv4NxNw0mp0JHQyB6tXesWRjtYKlDgHRY2o3JE5UTaBGUK8kSWUdxWUg==",
+      "license": "MIT",
+      "dependencies": {
+        "amp": "0.3.1"
+      }
+    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -1992,7 +2298,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2028,7 +2333,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2038,6 +2342,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.0.0-node10",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.0.0-node10.tgz",
+      "integrity": "sha512-BRrU0Bo1X9dFGw6KgGz6hWrqQuOlVEDOzkb0QSLZY9sXHqA7pNj7yHPVJRz7y/rj4EOJ3d/D5uxH+ee9leYgsg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/antlr4ts": {
@@ -2052,7 +2365,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2074,7 +2386,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-back": {
@@ -2127,6 +2438,18 @@
       "peer": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/astral-regex": {
@@ -2235,6 +2558,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/basic-ftp": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -2261,7 +2593,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2303,6 +2634,12 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
       "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bodec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bodec/-/bodec-0.1.0.tgz",
+      "integrity": "sha512-Ylo+MAo5BDUq1KA3f3R/MFhh+g8cnHmo8bz3YPGhI1znrMaf77ol1sfvYJzsw3nTE+Y2GryfDxBaR+AqpAkEHQ==",
       "license": "MIT"
     },
     "node_modules/boxen": {
@@ -2355,7 +2692,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2446,7 +2782,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/buffer-xor": {
@@ -2617,6 +2952,12 @@
         "node": "*"
       }
     },
+    "node_modules/charm": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+      "integrity": "sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==",
+      "license": "MIT/X11"
+    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -2768,6 +3109,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/cli-tableau": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cli-tableau/-/cli-tableau-2.0.1.tgz",
+      "integrity": "sha512-he+WTicka9cl0Fg/y+YyxcN6/bfQ/1O3QmgxRXDhABKqLzvoOSM4fMzp39uMyLBulAFuywD2N7UaoQE7WaADxQ==",
+      "dependencies": {
+        "chalk": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/cli-tableau/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2784,7 +3149,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2797,7 +3161,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colors": {
@@ -3109,6 +3472,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/croner": {
+      "version": "4.1.97",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-4.1.97.tgz",
+      "integrity": "sha512-/f6gpQuxDaqXu+1kwQYSckUglPaOrHdbIlBAu0YuW8/Cdb45XwXYNUBXg3r/9Mo6n540Kn/smKcZWko5x99KrQ==",
+      "license": "MIT"
+    },
     "node_modules/crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
@@ -3126,6 +3495,27 @@
       "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
       "license": "MIT"
     },
+    "node_modules/culvert": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/culvert/-/culvert-0.1.2.tgz",
+      "integrity": "sha512-yi1x3EAWKjQTreYWeSd98431AV+IEE0qoDyOoaHJ7KJ21gv6HtBXHVLX74opVSGqcR8/AbjJBHAHpcOy2bj5Gg==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.15",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.15.tgz",
+      "integrity": "sha512-MC+DfnSWiM9APs7fpiurHGCoeIx0Gdl6QZBy+5lu8MbYKN5FZEXqOgrundfibdfhGZ15o9hzmZ2xJjZnbvgKXQ==",
+      "license": "MIT"
+    },
     "node_modules/death": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
@@ -3137,7 +3527,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3227,6 +3616,73 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/degenerator/node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/degenerator/node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/degenerator/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/degenerator/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -3403,9 +3859,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3455,7 +3909,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3517,9 +3970,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3822,6 +4273,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/eventemitter2": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
+      "integrity": "sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg==",
+      "license": "MIT"
+    },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -3841,6 +4298,15 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/extrareqp2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/extrareqp2/-/extrareqp2-1.0.0.tgz",
+      "integrity": "sha512-Gum0g1QYb6wpPJCVypWP3bbIuaibcFiJcpuPM10YSXp/tzqi84x9PJageob+eN4xVRIOto4wjSGNLyMD54D2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3868,6 +4334,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -3906,6 +4378,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fclone": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
+      "integrity": "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==",
+      "license": "MIT"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -3916,7 +4394,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3970,7 +4447,6 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -4070,7 +4546,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4085,9 +4560,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4163,6 +4636,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ghost-testrpc": {
@@ -4265,6 +4752,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/git-node-fs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/git-node-fs/-/git-node-fs-1.0.0.tgz",
+      "integrity": "sha512-bLQypt14llVXBg0S0u8q8HmU7g9p3ysH+NvVlae5vILuUvs759665HvmR5+wb04KjHyjFcDRxdYb4kyNnluMUQ==",
+      "license": "MIT"
+    },
+    "node_modules/git-sha1": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/git-sha1/-/git-sha1-0.1.2.tgz",
+      "integrity": "sha512-2e/nZezdVlyCopOCYHeW0onkbZg7xP1Ad6pndPy1rCygeRykefUS6r7oA5cJRGEFvseiaz5a/qUHFVX1dd6Isg==",
+      "license": "MIT"
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -4296,7 +4795,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4671,7 +5169,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4806,9 +5303,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4884,6 +5379,28 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http-response-object": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
@@ -4921,7 +5438,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -5035,11 +5551,19 @@
         "fp-ts": "^1.0.0"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -5062,11 +5586,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5086,7 +5624,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5111,7 +5648,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -5173,6 +5709,18 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/js-git": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/js-git/-/js-git-0.7.8.tgz",
+      "integrity": "sha512-+E5ZH/HeRnoc/LW0AmAyhU+mNcWBzAKE+30+IDMLSLbbK+Tdt02AdkOKq9u15rlJsDEGFqtgckc8ZM59LhhiUA==",
+      "license": "MIT",
+      "dependencies": {
+        "bodec": "^0.1.0",
+        "culvert": "^0.1.2",
+        "git-sha1": "^0.1.2",
+        "pako": "^0.2.5"
+      }
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -5184,7 +5732,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5215,9 +5762,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
+      "devOptional": true,
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5331,7 +5877,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -5401,6 +5946,15 @@
       "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -5732,12 +6286,23 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "license": "ISC"
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -5766,6 +6331,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/needle": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -5773,6 +6364,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/node-abi": {
       "version": "3.89.0",
@@ -5857,7 +6457,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6013,6 +6612,66 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -6045,7 +6704,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -6100,13 +6758,24 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidusage": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-3.0.2.tgz",
+      "integrity": "sha512-g0VU+y08pKw5M8EZ2rIGiEBaB8wrQMjYGFfW2QVIfyT8V+fq8YFLkvlz4bz5ljvFDJYNFCWT3PWqcRr2FKO81w==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pify": {
@@ -6119,6 +6788,228 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pm2": {
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/pm2/-/pm2-6.0.14.tgz",
+      "integrity": "sha512-wX1FiFkzuT2H/UUEA8QNXDAA9MMHDsK/3UHj6Dkd5U7kxyigKDA5gyDw78ycTQZAuGCLWyUX5FiXEuVQWafukA==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@pm2/agent": "~2.1.1",
+        "@pm2/blessed": "0.1.81",
+        "@pm2/io": "~6.1.0",
+        "@pm2/js-api": "~0.8.0",
+        "@pm2/pm2-version-check": "^1.0.4",
+        "ansis": "4.0.0-node10",
+        "async": "3.2.6",
+        "chokidar": "3.6.0",
+        "cli-tableau": "2.0.1",
+        "commander": "2.15.1",
+        "croner": "4.1.97",
+        "dayjs": "1.11.15",
+        "debug": "4.4.3",
+        "enquirer": "2.3.6",
+        "eventemitter2": "5.0.1",
+        "fclone": "1.0.11",
+        "js-yaml": "4.1.1",
+        "mkdirp": "1.0.4",
+        "needle": "2.4.0",
+        "pidusage": "3.0.2",
+        "pm2-axon": "~4.0.1",
+        "pm2-axon-rpc": "~0.7.1",
+        "pm2-deploy": "~1.0.2",
+        "pm2-multimeter": "^0.1.2",
+        "promptly": "2.2.0",
+        "semver": "7.7.2",
+        "source-map-support": "0.5.21",
+        "sprintf-js": "1.1.2",
+        "vizion": "~2.2.1"
+      },
+      "bin": {
+        "pm2": "bin/pm2",
+        "pm2-dev": "bin/pm2-dev",
+        "pm2-docker": "bin/pm2-docker",
+        "pm2-runtime": "bin/pm2-runtime"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "pm2-sysmonit": "^1.2.8"
+      }
+    },
+    "node_modules/pm2-axon": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pm2-axon/-/pm2-axon-4.0.1.tgz",
+      "integrity": "sha512-kES/PeSLS8orT8dR5jMlNl+Yu4Ty3nbvZRmaAtROuVm9nYYGiaoXqqKQqQYzWQzMYWUKHMQTvBlirjE5GIIxqg==",
+      "license": "MIT",
+      "dependencies": {
+        "amp": "~0.3.1",
+        "amp-message": "~0.1.1",
+        "debug": "^4.3.1",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=5"
+      }
+    },
+    "node_modules/pm2-axon-rpc": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/pm2-axon-rpc/-/pm2-axon-rpc-0.7.1.tgz",
+      "integrity": "sha512-FbLvW60w+vEyvMjP/xom2UPhUN/2bVpdtLfKJeYM3gwzYhoTEEChCOICfFzxkxuoEleOlnpjie+n1nue91bDQw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=5"
+      }
+    },
+    "node_modules/pm2-deploy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pm2-deploy/-/pm2-deploy-1.0.2.tgz",
+      "integrity": "sha512-YJx6RXKrVrWaphEYf++EdOOx9EH18vM8RSZN/P1Y+NokTKqYAca/ejXwVLyiEpNju4HPZEk3Y2uZouwMqUlcgg==",
+      "license": "MIT",
+      "dependencies": {
+        "run-series": "^1.1.8",
+        "tv4": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pm2-multimeter": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/pm2-multimeter/-/pm2-multimeter-0.1.2.tgz",
+      "integrity": "sha512-S+wT6XfyKfd7SJIBqRgOctGxaBzUOmVQzTAS+cg04TsEUObJVreha7lvCfX8zzGVr871XwCSnHUU7DQQ5xEsfA==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "charm": "~0.1.1"
+      }
+    },
+    "node_modules/pm2-sysmonit": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/pm2-sysmonit/-/pm2-sysmonit-1.2.8.tgz",
+      "integrity": "sha512-ACOhlONEXdCTVwKieBIQLSi2tQZ8eKinhcr9JpZSUAL8Qy0ajIgRtsLxG/lwPOW3JEKqPyw/UaHmTWhUzpP4kA==",
+      "license": "Apache",
+      "optional": true,
+      "dependencies": {
+        "async": "^3.2.0",
+        "debug": "^4.3.1",
+        "pidusage": "^2.0.21",
+        "systeminformation": "^5.7",
+        "tx2": "~1.0.4"
+      }
+    },
+    "node_modules/pm2-sysmonit/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pm2-sysmonit/node_modules/pidusage": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-2.0.21.tgz",
+      "integrity": "sha512-cv3xAQos+pugVX+BfXpHsbyz/dLzX+lr44zNMsYiGxUw+kV5sgQCIcLd1z+0vq+KyC7dJ+/ts2PsfgWfSC3WXA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pm2/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/pm2/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/pm2/node_modules/commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "license": "MIT"
+    },
+    "node_modules/pm2/node_modules/enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/pm2/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pm2/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/pm2/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pm2/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -6204,6 +7095,15 @@
         "asap": "~2.0.6"
       }
     },
+    "node_modules/promptly": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
+      "integrity": "sha512-aC9j+BZsRSSzEsXBNBwDnAxujdx19HycZoKgRgzWnS8eOHg1asuf9heuLprfbe739zY3IdUQx+Egv6Jn135WHA==",
+      "license": "MIT",
+      "dependencies": {
+        "read": "^1.0.4"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6218,6 +7118,53 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.3",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -6327,6 +7274,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/readable-stream": {
@@ -6470,6 +7429,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
+      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-in-the-middle/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -6560,6 +7554,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/run-series": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
+      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6584,8 +7598,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/sc-istanbul": {
       "version": "0.4.6",
@@ -6925,6 +7947,12 @@
         "node": "*"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -7004,6 +8032,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -7086,6 +8120,53 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/solc": {
@@ -7318,7 +8399,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -7329,7 +8409,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7464,13 +8543,24 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sync-request": {
@@ -7498,6 +8588,33 @@
       "peer": true,
       "dependencies": {
         "get-port": "^3.1.0"
+      }
+    },
+    "node_modules/systeminformation": {
+      "version": "5.31.5",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
+      "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/table": {
@@ -7728,7 +8845,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7835,9 +8951,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsort": {
       "version": "0.0.1",
@@ -7856,6 +8970,34 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==",
+      "license": [
+        {
+          "type": "Public Domain",
+          "url": "http://geraintluff.github.io/tv4/LICENSE.txt"
+        },
+        {
+          "type": "MIT",
+          "url": "http://jsonary.com/LICENSE.txt"
+        }
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/tx2": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tx2/-/tx2-1.0.5.tgz",
+      "integrity": "sha512-sJ24w0y03Md/bxzK4FU8J8JveYYUbSs2FViLJ2D/8bytSiyPRbuE3DyL/9UKYXTZlV3yXq0L8GLlhobTnekCVg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1"
       }
     },
     "node_modules/type-check": {
@@ -8162,6 +9304,30 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/vizion": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vizion/-/vizion-2.2.1.tgz",
+      "integrity": "sha512-sfAcO2yeSU0CSPFI/DmZp3FsFE9T+8913nv1xWBOyzODv13fwkn6Vl7HqxGpkr9F608M+8SuFId3s+BlZqfXww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^2.6.3",
+        "git-node-fs": "^1.0.0",
+        "ini": "^1.3.5",
+        "js-git": "^0.7.8"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/vizion/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/web3-utils": {
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.10.4.tgz",
@@ -8413,6 +9579,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "liberdus-airdrop",
       "version": "1.0.0",
       "dependencies": {
-        "@openzeppelin/contracts": "^5.4.0"
+        "@openzeppelin/contracts": "^5.4.0",
+        "better-sqlite3": "^12.9.0",
+        "csv-parse": "^6.2.1"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
@@ -2213,6 +2215,26 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -2220,6 +2242,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2232,6 +2268,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/blakejs": {
@@ -2360,6 +2416,30 @@
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -2566,6 +2646,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "2.0.0",
@@ -3034,6 +3120,12 @@
         "node": "*"
       }
     },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
+    },
     "node_modules/death": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
@@ -3072,6 +3164,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -3090,9 +3197,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -3143,6 +3248,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -3240,6 +3354,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -3711,6 +3834,15 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3773,6 +3905,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3889,6 +4027,12 @@
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz",
       "integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -4120,6 +4264,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "8.1.0",
@@ -4780,6 +4930,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4836,16 +5006,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/interpret": {
       "version": "1.4.0",
@@ -5397,6 +5564,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -5428,9 +5607,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5448,6 +5625,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mnemonist": {
       "version": "0.38.5",
@@ -5556,6 +5739,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/ndjson": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
@@ -5584,6 +5773,30 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "2.0.2",
@@ -5710,7 +5923,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5919,6 +6131,33 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -5991,6 +6230,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
@@ -6056,11 +6305,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -6292,7 +6564,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6734,6 +7005,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7075,7 +7391,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -7240,6 +7555,34 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/then-request": {
@@ -7502,6 +7845,18 @@
       "integrity": "sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -7787,7 +8142,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -8025,7 +8379,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "verify:airdrop:bsc:mainnet": "hardhat run scripts/verify-airdrop.js --network bsc",
     "fund:owner:local": "hardhat fund-owner-wallet --network localhost",
     "merkle": "node scripts/generate-merkle.js",
-    "generate:test-claims": "node scripts/generate-test-claims.js --start-epoch 1"
+    "generate:test-claims": "node scripts/generate-test-claims.js --start-epoch 1",
+    "xauth:local": "node scripts/server.js"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,12 @@
     "followers:import": "node backend/import-x-followers.js",
     "recovery-candidates:import": "node backend/import-recovery-candidates.js",
     "recovery-submissions:import": "node backend/import-recovery-submissions.js",
-    "xauth:local": "node backend/server.js"
+    "xauth:local": "node backend/server.js",
+    "pm2:start": "pm2 start backend/pm2.config.cjs --update-env",
+    "pm2:restart": "pm2 restart backend/pm2.config.cjs --update-env",
+    "pm2:stop": "pm2 stop backend/pm2.config.cjs",
+    "pm2:delete": "pm2 delete backend/pm2.config.cjs",
+    "pm2:status": "pm2 status"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
@@ -31,6 +36,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "^5.4.0",
     "better-sqlite3": "^12.9.0",
-    "csv-parse": "^6.2.1"
+    "csv-parse": "^6.2.1",
+    "pm2": "^6.0.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "merkle": "node scripts/generate-merkle.js",
     "generate:test-claims": "node scripts/generate-test-claims.js --start-epoch 1",
     "accounts:import": "node backend/import-accounts.js",
+    "claim-rounds:import": "node backend/import-claim-rounds.js",
     "followers:import": "node backend/import-x-followers.js",
     "recovery-candidates:import": "node backend/import-recovery-candidates.js",
     "recovery-submissions:import": "node backend/import-recovery-submissions.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "fund:owner:local": "hardhat fund-owner-wallet --network localhost",
     "merkle": "node scripts/generate-merkle.js",
     "generate:test-claims": "node scripts/generate-test-claims.js --start-epoch 1",
-    "xauth:local": "node scripts/server.js"
+    "accounts:import": "node backend/import-accounts.js",
+    "followers:import": "node backend/import-x-followers.js",
+    "recovery-candidates:import": "node backend/import-recovery-candidates.js",
+    "recovery-submissions:import": "node backend/import-recovery-submissions.js",
+    "xauth:local": "node backend/server.js"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
@@ -24,6 +28,8 @@
     "hardhat": "^2.28.0"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.4.0"
+    "@openzeppelin/contracts": "^5.4.0",
+    "better-sqlite3": "^12.9.0",
+    "csv-parse": "^6.2.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -20,7 +20,7 @@ module.exports = defineConfig({
     {
       command: "npm run node",
       port: 8545,
-      reuseExistingServer: false,
+      reuseExistingServer: !process.env.CI,
       stdout: "pipe",
       stderr: "pipe",
       timeout: 120_000,

--- a/scripts/deploy-local.js
+++ b/scripts/deploy-local.js
@@ -1,3 +1,4 @@
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 const hre = require("hardhat");
@@ -53,6 +54,7 @@ async function main() {
     tokenAddress: await token.getAddress(),
     dustTokenAddress: await dustToken.getAddress(),
     airdropAddress: await airdrop.getAddress(),
+    deploymentKey: `local:${crypto.randomUUID()}`,
     generatedAt: new Date().toISOString(),
   };
 
@@ -71,6 +73,7 @@ async function main() {
   console.log(`Token:       ${config.tokenAddress}`);
   console.log(`Dust token:  ${config.dustTokenAddress}`);
   console.log(`Airdrop:     ${config.airdropAddress}`);
+  console.log(`Deployment key: ${config.deploymentKey}`);
   console.log(`Frontend config: ${configLocalPath}`);
 }
 

--- a/scripts/deploy-local.js
+++ b/scripts/deploy-local.js
@@ -2,6 +2,27 @@ const fs = require("node:fs");
 const path = require("node:path");
 const hre = require("hardhat");
 
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeConfig(baseValue, nextValue) {
+  if (!isPlainObject(baseValue) || !isPlainObject(nextValue)) {
+    return nextValue;
+  }
+
+  const merged = { ...baseValue };
+  for (const [key, value] of Object.entries(nextValue)) {
+    merged[key] = key in merged ? mergeConfig(merged[key], value) : value;
+  }
+  return merged;
+}
+
+function loadJsonIfExists(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
 async function main() {
   const { ethers } = hre;
   const [deployer] = await ethers.getSigners();
@@ -36,15 +57,21 @@ async function main() {
   };
 
   const frontendDir = path.join(__dirname, "..", "frontend");
+  const configLocalPath = path.join(frontendDir, "config.local.json");
+  const configLocalTemplatePath = path.join(frontendDir, "config.local.template.json");
+  const existingConfig = loadJsonIfExists(configLocalPath)
+    || loadJsonIfExists(configLocalTemplatePath)
+    || {};
   fs.mkdirSync(frontendDir, { recursive: true });
-  fs.writeFileSync(path.join(frontendDir, "config.local.json"), `${JSON.stringify(config, null, 2)}\n`);
+  const mergedConfig = mergeConfig(existingConfig, config);
+  fs.writeFileSync(configLocalPath, `${JSON.stringify(mergedConfig, null, 2)}\n`);
 
   console.log("Local deployment complete.");
   console.log(`Deployer:    ${config.deployer}`);
   console.log(`Token:       ${config.tokenAddress}`);
   console.log(`Dust token:  ${config.dustTokenAddress}`);
   console.log(`Airdrop:     ${config.airdropAddress}`);
-  console.log(`Frontend config: ${path.join(frontendDir, "config.local.json")}`);
+  console.log(`Frontend config: ${configLocalPath}`);
 }
 
 main().catch((error) => {

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,0 +1,1203 @@
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const http = require("node:http");
+const path = require("node:path");
+
+const dotenv = require("dotenv");
+const { ethers } = require("ethers");
+
+dotenv.config({ path: path.join(__dirname, "..", ".env"), quiet: true });
+
+const HOST = process.env.X_AUTH_HOST || "127.0.0.1";
+const PORT = Number.parseInt(process.env.X_AUTH_PORT || "8787", 10);
+const DEFAULT_ALLOWED_ORIGIN = "http://127.0.0.1:5502";
+const DEFAULT_FRONTEND_RETURN_URL = "http://127.0.0.1:5502/frontend/";
+const DEFAULT_FOLLOWER_SNAPSHOT_FILE = path.join("cache", "x", "liberdus-followers.json");
+const DEFAULT_RECOVERY_CANDIDATES_FILE = path.join("cache", "x", "missing-address-usernames.json");
+const DEFAULT_RECOVERY_STORE_FILE = path.join("cache", "x", "recovery-links.json");
+const REQUEST_TOKEN_URL = "https://api.x.com/oauth/request_token";
+const AUTHORIZE_URL = "https://api.x.com/oauth/authorize";
+const ACCESS_TOKEN_URL = "https://api.x.com/oauth/access_token";
+const VERIFY_CREDENTIALS_URL = "https://api.x.com/1.1/account/verify_credentials.json";
+const AUTH_COMPLETE_QUERY_PARAM = "x_auth";
+const AUTH_COMPLETE_QUERY_VALUE = "complete";
+const AUTH_ERROR_QUERY_PARAM = "x_error";
+const AUTH_SESSION_COOKIE_NAME = "liberdus_x_session";
+const AUTH_INIT_COOKIE_NAME = "liberdus_x_oauth_init";
+const AUTH_SESSION_TTL_MS = 15 * 60 * 1000;
+const REQUEST_TOKEN_TTL_MS = 10 * 60 * 1000;
+const CHALLENGE_TTL_MS = 10 * 60 * 1000;
+const MAX_JSON_BODY_BYTES = 32 * 1024;
+const RATE_LIMITS = {
+  start: { limit: 12, windowMs: 10 * 60 * 1000 },
+  callback: { limit: 24, windowMs: 10 * 60 * 1000 },
+  session: { limit: 120, windowMs: 60 * 1000 },
+  challenge: { limit: 20, windowMs: 10 * 60 * 1000 },
+  complete: { limit: 20, windowMs: 10 * 60 * 1000 },
+  logout: { limit: 40, windowMs: 10 * 60 * 1000 },
+  health: { limit: 30, windowMs: 60 * 1000 },
+};
+
+const authSessions = new Map();
+const requestTokens = new Map();
+const linkChallenges = new Map();
+const rateLimits = new Map();
+
+class HttpError extends Error {
+  constructor(statusCode, message, options = {}) {
+    super(message);
+    this.name = "HttpError";
+    this.statusCode = statusCode;
+    this.expose = options.expose !== false;
+    this.headers = options.headers || {};
+  }
+}
+
+function getRepoRoot() {
+  return path.resolve(__dirname, "..");
+}
+
+function resolveRepoPath(filePath) {
+  return path.resolve(getRepoRoot(), filePath);
+}
+
+function getApiKey() {
+  return String(
+    process.env.X_API_KEY
+    || process.env.X_CONSUMER_KEY
+    || process.env.X_APP_KEY
+    || "",
+  ).trim();
+}
+
+function getApiSecret() {
+  return String(
+    process.env.X_API_SECRET
+    || process.env.X_API_SECRET_KEY
+    || process.env.X_CONSUMER_SECRET
+    || process.env.X_APP_SECRET
+    || "",
+  ).trim();
+}
+
+function getCallbackUrl() {
+  return String(process.env.X_OAUTH1_CALLBACK_URL || "").trim();
+}
+
+function getAllowedOrigins() {
+  const rawValue = String(process.env.X_AUTH_ALLOWED_ORIGINS || DEFAULT_ALLOWED_ORIGIN);
+  return rawValue
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function normalizeUrlString(rawValue) {
+  const value = String(rawValue || "").trim();
+  if (!value) return "";
+
+  const normalized = new URL(value);
+  normalized.hash = "";
+  return normalized.toString();
+}
+
+function getDefaultFrontendReturnUrl() {
+  return normalizeUrlString(process.env.X_FRONTEND_RETURN_URL || DEFAULT_FRONTEND_RETURN_URL);
+}
+
+function getAllowedReturnUrls() {
+  const rawValue = String(process.env.X_FRONTEND_RETURN_URLS || getDefaultFrontendReturnUrl());
+  return rawValue
+    .split(",")
+    .map((value) => normalizeUrlString(value))
+    .filter(Boolean);
+}
+
+function validateReturnUri(returnUri) {
+  const normalized = normalizeUrlString(returnUri || getDefaultFrontendReturnUrl());
+  if (!normalized) {
+    throw new HttpError(400, "Frontend return URI is required.");
+  }
+
+  if (!getAllowedReturnUrls().includes(normalized)) {
+    throw new HttpError(400, "Frontend return URI is not allowed.");
+  }
+
+  return normalized;
+}
+
+function getFollowerSnapshotPath() {
+  return resolveRepoPath(process.env.X_FOLLOWER_SNAPSHOT_FILE || DEFAULT_FOLLOWER_SNAPSHOT_FILE);
+}
+
+function getRecoveryCandidatesPath() {
+  return resolveRepoPath(process.env.X_RECOVERY_CANDIDATES_FILE || DEFAULT_RECOVERY_CANDIDATES_FILE);
+}
+
+function getRecoveryStorePath() {
+  return resolveRepoPath(process.env.X_RECOVERY_STORE_FILE || DEFAULT_RECOVERY_STORE_FILE);
+}
+
+function getCookieSecureMode() {
+  return String(process.env.X_AUTH_COOKIE_SECURE || "auto").trim().toLowerCase();
+}
+
+function shouldUseSecureCookies() {
+  const mode = getCookieSecureMode();
+  if (mode === "true") return true;
+  if (mode === "false") return false;
+
+  try {
+    return new URL(getDefaultFrontendReturnUrl()).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function shouldTrustProxy() {
+  return /^true$/iu.test(String(process.env.X_AUTH_TRUST_PROXY || "").trim());
+}
+
+function normalizeUsername(username) {
+  return String(username || "").trim().replace(/^@+/u, "").toLowerCase();
+}
+
+function readJsonIfExists(filePath, fallbackValue) {
+  try {
+    if (!fs.existsSync(filePath)) return fallbackValue;
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return fallbackValue;
+  }
+}
+
+function ensureDirectory(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function writeJsonFile(filePath, value) {
+  ensureDirectory(filePath);
+  const tempPath = `${filePath}.${crypto.randomUUID()}.tmp`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(tempPath, filePath);
+}
+
+function loadFollowerUsernames() {
+  const snapshot = readJsonIfExists(getFollowerSnapshotPath(), {});
+  const followers = Array.isArray(snapshot?.followers) ? snapshot.followers : [];
+  return new Set(
+    followers
+      .map((follower) => normalizeUsername(follower?.username))
+      .filter(Boolean),
+  );
+}
+
+function loadRecoveryCandidateUsernames() {
+  const rawValue = readJsonIfExists(getRecoveryCandidatesPath(), []);
+  const usernames = Array.isArray(rawValue)
+    ? rawValue
+    : Array.isArray(rawValue?.usernames)
+      ? rawValue.usernames
+      : [];
+
+  return new Set(usernames.map((username) => normalizeUsername(username)).filter(Boolean));
+}
+
+function loadRecoveryStore() {
+  const loaded = readJsonIfExists(getRecoveryStorePath(), null);
+  if (loaded && typeof loaded === "object" && Array.isArray(loaded.records)) {
+    return loaded;
+  }
+
+  return {
+    version: 1,
+    updatedAt: null,
+    records: [],
+  };
+}
+
+function saveRecoveryStore(store) {
+  store.updatedAt = new Date().toISOString();
+  writeJsonFile(getRecoveryStorePath(), store);
+}
+
+const followerUsernames = loadFollowerUsernames();
+const recoveryCandidateUsernames = loadRecoveryCandidateUsernames();
+const recoveryStore = loadRecoveryStore();
+
+function createRandomToken(bytes = 32) {
+  return crypto.randomBytes(bytes).toString("hex");
+}
+
+function hashValue(value) {
+  return crypto.createHash("sha256").update(String(value || ""), "utf8").digest("hex");
+}
+
+function secureEquals(left, right) {
+  const leftBuffer = Buffer.from(String(left || ""), "utf8");
+  const rightBuffer = Buffer.from(String(right || ""), "utf8");
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function parseCookies(request) {
+  const rawCookie = String(request.headers.cookie || "");
+  if (!rawCookie) return {};
+
+  return rawCookie.split(";").reduce((cookies, chunk) => {
+    const separatorIndex = chunk.indexOf("=");
+    if (separatorIndex < 0) return cookies;
+    const name = chunk.slice(0, separatorIndex).trim();
+    const value = chunk.slice(separatorIndex + 1).trim();
+    if (!name) return cookies;
+    cookies[name] = decodeURIComponent(value);
+    return cookies;
+  }, {});
+}
+
+function appendSetCookie(response, cookieValue) {
+  const existing = response.getHeader("Set-Cookie");
+  if (!existing) {
+    response.setHeader("Set-Cookie", [cookieValue]);
+    return;
+  }
+
+  response.setHeader("Set-Cookie", Array.isArray(existing) ? [...existing, cookieValue] : [existing, cookieValue]);
+}
+
+function serializeCookie(name, value, options = {}) {
+  const segments = [`${name}=${encodeURIComponent(value)}`];
+  segments.push(`Path=${options.path || "/"}`);
+  if (typeof options.maxAge === "number") {
+    segments.push(`Max-Age=${Math.max(0, Math.floor(options.maxAge))}`);
+  }
+  if (options.httpOnly !== false) {
+    segments.push("HttpOnly");
+  }
+  if (options.sameSite) {
+    segments.push(`SameSite=${options.sameSite}`);
+  }
+  if (options.secure) {
+    segments.push("Secure");
+  }
+  return segments.join("; ");
+}
+
+function setCookie(response, name, value, options = {}) {
+  appendSetCookie(response, serializeCookie(name, value, options));
+}
+
+function clearCookie(response, name, options = {}) {
+  appendSetCookie(response, serializeCookie(name, "", {
+    ...options,
+    maxAge: 0,
+  }));
+}
+
+function getClientIp(request) {
+  if (shouldTrustProxy()) {
+    const forwarded = String(request.headers["x-forwarded-for"] || "").split(",")[0].trim();
+    if (forwarded) return forwarded;
+  }
+
+  return String(request.socket?.remoteAddress || "");
+}
+
+function normalizeIpAddress(ipAddress) {
+  const value = String(ipAddress || "").trim();
+  if (value.startsWith("::ffff:")) {
+    return value.slice(7);
+  }
+  return value;
+}
+
+function isLoopbackAddress(ipAddress) {
+  const normalized = normalizeIpAddress(ipAddress);
+  return normalized === "127.0.0.1" || normalized === "::1" || normalized === "localhost";
+}
+
+function getUserAgent(request) {
+  return String(request.headers["user-agent"] || "").trim();
+}
+
+function setStandardHeaders(response) {
+  response.setHeader("Referrer-Policy", "no-referrer");
+  response.setHeader("X-Content-Type-Options", "nosniff");
+  response.setHeader("Permissions-Policy", "interest-cohort=()");
+  response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+  response.setHeader("Cross-Origin-Resource-Policy", "same-site");
+}
+
+function getCorsOrigin(origin) {
+  if (!origin) return "";
+  return getAllowedOrigins().includes(origin) ? origin : "";
+}
+
+function setCorsHeaders(request, response) {
+  const origin = getCorsOrigin(String(request.headers.origin || ""));
+  if (!origin) return false;
+
+  response.setHeader("Access-Control-Allow-Origin", origin);
+  response.setHeader("Access-Control-Allow-Credentials", "true");
+  response.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  response.setHeader("Access-Control-Allow-Headers", "Content-Type, X-CSRF-Token");
+  response.setHeader("Access-Control-Max-Age", "600");
+  response.setHeader("Vary", "Origin, Access-Control-Request-Headers");
+  return true;
+}
+
+function requireAllowedOrigin(request, response) {
+  const origin = String(request.headers.origin || "").trim();
+  if (!origin) {
+    throw new HttpError(403, "Origin is required.");
+  }
+
+  if (!setCorsHeaders(request, response)) {
+    throw new HttpError(403, "Origin is not allowed.");
+  }
+}
+
+function writeJson(response, statusCode, value, headers = {}) {
+  response.writeHead(statusCode, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store, private, max-age=0",
+    Pragma: "no-cache",
+    "Content-Security-Policy": "default-src 'none'; base-uri 'none'; frame-ancestors 'none'",
+    ...headers,
+  });
+  response.end(`${JSON.stringify(value)}\n`);
+}
+
+function redirect(response, location) {
+  response.writeHead(302, {
+    Location: location,
+    "Cache-Control": "no-store, private, max-age=0",
+    Pragma: "no-cache",
+  });
+  response.end();
+}
+
+function readJsonRequest(request) {
+  return new Promise((resolve, reject) => {
+    let rawBody = "";
+
+    request.on("data", (chunk) => {
+      rawBody += chunk;
+      if (Buffer.byteLength(rawBody, "utf8") > MAX_JSON_BODY_BYTES) {
+        reject(new HttpError(413, "Request body is too large."));
+        request.destroy();
+      }
+    });
+
+    request.on("end", () => {
+      if (!rawBody) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(rawBody));
+      } catch {
+        reject(new HttpError(400, "Request body must be valid JSON."));
+      }
+    });
+
+    request.on("error", reject);
+  });
+}
+
+async function parseTextResponse(response) {
+  return response.text();
+}
+
+function parseFormEncoded(text) {
+  const params = new URLSearchParams(text);
+  return Object.fromEntries(params.entries());
+}
+
+function percentEncode(value) {
+  return encodeURIComponent(String(value))
+    .replace(/[!'()*]/gu, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`);
+}
+
+function buildNormalizedParameterString(params) {
+  return [...params]
+    .map(([key, value]) => [percentEncode(key), percentEncode(value)])
+    .sort((left, right) => {
+      if (left[0] === right[0]) return left[1].localeCompare(right[1]);
+      return left[0].localeCompare(right[0]);
+    })
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+}
+
+function createSigningKey(consumerSecret, tokenSecret = "") {
+  return `${percentEncode(consumerSecret)}&${percentEncode(tokenSecret)}`;
+}
+
+function buildSignature({ method, url, params, consumerSecret, tokenSecret = "" }) {
+  const normalizedUrl = new URL(url);
+  normalizedUrl.search = "";
+  normalizedUrl.hash = "";
+
+  const baseString = [
+    method.toUpperCase(),
+    percentEncode(normalizedUrl.toString()),
+    percentEncode(buildNormalizedParameterString(params)),
+  ].join("&");
+
+  return crypto
+    .createHmac("sha1", createSigningKey(consumerSecret, tokenSecret))
+    .update(baseString)
+    .digest("base64");
+}
+
+function createOAuthHeader(params) {
+  const headerValue = [...params.entries()]
+    .filter(([key]) => key.startsWith("oauth_"))
+    .sort((left, right) => left[0].localeCompare(right[0]))
+    .map(([key, value]) => `${percentEncode(key)}="${percentEncode(value)}"`)
+    .join(", ");
+
+  return `OAuth ${headerValue}`;
+}
+
+function buildOAuthParams(overrides = {}) {
+  return new Map(Object.entries({
+    oauth_consumer_key: getApiKey(),
+    oauth_nonce: createRandomToken(16),
+    oauth_signature_method: "HMAC-SHA1",
+    oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
+    oauth_version: "1.0",
+    ...overrides,
+  }));
+}
+
+async function oauthRequest({ method, url, oauthOverrides = {}, requestParams = new Map(), tokenSecret = "" }) {
+  const apiKey = getApiKey();
+  const apiSecret = getApiSecret();
+  if (!apiKey || !apiSecret) {
+    throw new HttpError(500, "Missing X API key or API secret in .env.", { expose: false });
+  }
+
+  const oauthParams = buildOAuthParams(oauthOverrides);
+  const signatureParams = new Map([...oauthParams.entries(), ...requestParams.entries()]);
+  oauthParams.set("oauth_signature", buildSignature({
+    method,
+    url,
+    params: signatureParams,
+    consumerSecret: apiSecret,
+    tokenSecret,
+  }));
+
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Authorization: createOAuthHeader(oauthParams),
+      "Content-Length": "0",
+    },
+  });
+
+  const text = await parseTextResponse(response);
+  if (!response.ok) {
+    console.error(`[OAuth 1.0a ${method} ${url}] HTTP ${response.status}: ${text}`);
+    throw new HttpError(502, "X rejected the authentication request.", { expose: false });
+  }
+
+  return parseFormEncoded(text);
+}
+
+async function verifyCredentials(accessToken, accessTokenSecret) {
+  const apiKey = getApiKey();
+  const apiSecret = getApiSecret();
+  const oauthParams = buildOAuthParams({
+    oauth_consumer_key: apiKey,
+    oauth_token: accessToken,
+  });
+  oauthParams.set("oauth_signature", buildSignature({
+    method: "GET",
+    url: VERIFY_CREDENTIALS_URL,
+    params: oauthParams,
+    consumerSecret: apiSecret,
+    tokenSecret: accessTokenSecret,
+  }));
+
+  const response = await fetch(VERIFY_CREDENTIALS_URL, {
+    method: "GET",
+    headers: {
+      Authorization: createOAuthHeader(oauthParams),
+    },
+  });
+
+  const text = await parseTextResponse(response);
+  if (!response.ok) {
+    console.error(`[OAuth 1.0a GET ${VERIFY_CREDENTIALS_URL}] HTTP ${response.status}: ${text}`);
+    throw new HttpError(502, "X user identity lookup failed.", { expose: false });
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new HttpError(502, "X identity lookup returned invalid JSON.", { expose: false });
+  }
+}
+
+function pruneExpiredState() {
+  const now = Date.now();
+
+  for (const [sessionId, session] of authSessions.entries()) {
+    if (session.expiresAtMs <= now) {
+      authSessions.delete(sessionId);
+    }
+  }
+
+  for (const [requestToken, pending] of requestTokens.entries()) {
+    if (pending.expiresAtMs <= now) {
+      requestTokens.delete(requestToken);
+    }
+  }
+
+  for (const [challengeId, challenge] of linkChallenges.entries()) {
+    if (challenge.expiresAtMs <= now) {
+      linkChallenges.delete(challengeId);
+    }
+  }
+
+  for (const [key, bucket] of rateLimits.entries()) {
+    if (bucket.resetAtMs <= now) {
+      rateLimits.delete(key);
+    }
+  }
+}
+
+function consumeRateLimit(request, name) {
+  const policy = RATE_LIMITS[name];
+  if (!policy) return;
+
+  pruneExpiredState();
+
+  const key = `${name}:${normalizeIpAddress(getClientIp(request)) || "unknown"}`;
+  const now = Date.now();
+  const bucket = rateLimits.get(key);
+
+  if (!bucket || bucket.resetAtMs <= now) {
+    rateLimits.set(key, {
+      count: 1,
+      resetAtMs: now + policy.windowMs,
+    });
+    return;
+  }
+
+  if (bucket.count >= policy.limit) {
+    throw new HttpError(429, "Too many requests. Try again shortly.", {
+      headers: {
+        "Retry-After": String(Math.max(1, Math.ceil((bucket.resetAtMs - now) / 1000))),
+      },
+    });
+  }
+
+  bucket.count += 1;
+}
+
+function requireWalletAddress(walletAddress) {
+  const normalized = String(walletAddress || "").trim();
+  if (!normalized) {
+    throw new HttpError(400, "Wallet address is required.");
+  }
+
+  try {
+    return ethers.getAddress(normalized);
+  } catch {
+    throw new HttpError(400, "Wallet address is invalid.");
+  }
+}
+
+function deleteAuthSession(sessionId) {
+  authSessions.delete(sessionId);
+  for (const [challengeId, challenge] of linkChallenges.entries()) {
+    if (challenge.sessionId === sessionId) {
+      linkChallenges.delete(challengeId);
+    }
+  }
+}
+
+function getRequiredSessionFromCookie(request, response) {
+  pruneExpiredState();
+
+  const cookies = parseCookies(request);
+  const sessionId = String(cookies[AUTH_SESSION_COOKIE_NAME] || "").trim();
+  if (!sessionId) {
+    throw new HttpError(401, "X session expired. Sign in again.");
+  }
+
+  const session = authSessions.get(sessionId);
+  if (!session) {
+    clearCookie(response, AUTH_SESSION_COOKIE_NAME, {
+      path: "/api/x/",
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+    });
+    throw new HttpError(401, "X session expired. Sign in again.");
+  }
+
+  if (session.expiresAtMs <= Date.now()) {
+    deleteAuthSession(sessionId);
+    clearCookie(response, AUTH_SESSION_COOKIE_NAME, {
+      path: "/api/x/",
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+    });
+    throw new HttpError(401, "X session expired. Sign in again.");
+  }
+
+  const userAgentHash = hashValue(getUserAgent(request));
+  if (!secureEquals(session.userAgentHash, userAgentHash)) {
+    deleteAuthSession(sessionId);
+    clearCookie(response, AUTH_SESSION_COOKIE_NAME, {
+      path: "/api/x/",
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+    });
+    throw new HttpError(401, "X session could not be verified. Sign in again.");
+  }
+
+  return session;
+}
+
+function requireCsrf(request, session) {
+  const csrfToken = String(request.headers["x-csrf-token"] || "").trim();
+  if (!csrfToken || !secureEquals(session.csrfToken, csrfToken)) {
+    throw new HttpError(403, "Request could not be verified.");
+  }
+}
+
+function buildWalletLinkMessage({ profile, walletAddress, challengeId, issuedAt }) {
+  return [
+    "Liberdus follower recovery",
+    "",
+    `x.com username: @${profile.username}`,
+    `X user ID: ${profile.id}`,
+    `Wallet: ${walletAddress}`,
+    `Challenge: ${challengeId}`,
+    `Issued at: ${issuedAt}`,
+    "",
+    "Sign this message to prove wallet ownership for follower reward recovery.",
+  ].join("\n");
+}
+
+function upsertRecoveryRecord(record) {
+  const existingIndex = recoveryStore.records.findIndex(
+    (entry) => String(entry.xUserId || "").trim() === String(record.xUserId || "").trim()
+      && String(entry.walletAddress || "").toLowerCase() === String(record.walletAddress || "").toLowerCase(),
+  );
+
+  if (existingIndex >= 0) {
+    recoveryStore.records[existingIndex] = {
+      ...recoveryStore.records[existingIndex],
+      ...record,
+      updatedAt: new Date().toISOString(),
+    };
+    return recoveryStore.records[existingIndex];
+  }
+
+  const nextRecord = {
+    ...record,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  recoveryStore.records.push(nextRecord);
+  return nextRecord;
+}
+
+function appendAuthQuery(returnUri, key, value) {
+  const redirectUrl = new URL(returnUri);
+  redirectUrl.searchParams.set(key, value);
+  return redirectUrl.toString();
+}
+
+function appendErrorRedirect(returnUri, errorMessage) {
+  return appendAuthQuery(returnUri, AUTH_ERROR_QUERY_PARAM, errorMessage);
+}
+
+function appendCompleteRedirect(returnUri) {
+  return appendAuthQuery(returnUri, AUTH_COMPLETE_QUERY_PARAM, AUTH_COMPLETE_QUERY_VALUE);
+}
+
+function normalizeIdentityFromOAuth1(accessTokenResponse, verifiedCredentials = null) {
+  const screenName = String(
+    accessTokenResponse.screen_name
+    || accessTokenResponse.screenName
+    || verifiedCredentials?.screen_name
+    || verifiedCredentials?.screenName
+    || "",
+  ).trim();
+  const userId = String(
+    accessTokenResponse.user_id
+    || accessTokenResponse.userId
+    || verifiedCredentials?.id_str
+    || verifiedCredentials?.id
+    || "",
+  ).trim();
+  const name = String(
+    verifiedCredentials?.name
+    || screenName,
+  ).trim();
+
+  if (!screenName || !userId) {
+    throw new HttpError(502, "Could not determine the authenticated X user.", { expose: false });
+  }
+
+  return {
+    id: userId,
+    username: screenName,
+    name: name || screenName,
+    profile_image_url: String(
+      verifiedCredentials?.profile_image_url_https
+      || verifiedCredentials?.profile_image_url
+      || "",
+    ).trim(),
+    verified: Boolean(verifiedCredentials?.verified),
+    verified_type: String(verifiedCredentials?.verified_type || ""),
+  };
+}
+
+function getHealthPayload(request) {
+  const basePayload = { ok: true };
+  if (!isLoopbackAddress(getClientIp(request))) {
+    return basePayload;
+  }
+
+  return {
+    ...basePayload,
+    apiKeyConfigured: Boolean(getApiKey()),
+    apiSecretConfigured: Boolean(getApiSecret()),
+    callbackUrl: getCallbackUrl(),
+    defaultFrontendReturnUrl: getDefaultFrontendReturnUrl(),
+    allowedOrigins: getAllowedOrigins(),
+    allowedReturnUrls: getAllowedReturnUrls(),
+    followerSnapshotPath: getFollowerSnapshotPath(),
+    followerSnapshotCount: followerUsernames.size,
+    recoveryCandidatesPath: getRecoveryCandidatesPath(),
+    recoveryCandidateCount: recoveryCandidateUsernames.size,
+    recoveryStorePath: getRecoveryStorePath(),
+    recoveryRecordCount: recoveryStore.records.length,
+    activeAuthSessions: authSessions.size,
+    activeRequestTokens: requestTokens.size,
+    activeChallenges: linkChallenges.size,
+  };
+}
+
+function getPublicErrorMessage(error, fallback = "Request failed.") {
+  if (error instanceof HttpError && error.expose) {
+    return error.message;
+  }
+  return fallback;
+}
+
+async function handleStart(request, response) {
+  const callbackUrl = getCallbackUrl();
+  if (!callbackUrl) {
+    throw new HttpError(500, "Missing X_OAUTH1_CALLBACK_URL in .env.", { expose: false });
+  }
+
+  const requestUrl = new URL(request.url, `http://${request.headers.host}`);
+  const returnUri = validateReturnUri(requestUrl.searchParams.get("return_uri") || getDefaultFrontendReturnUrl());
+  const initNonce = createRandomToken(24);
+  const userAgentHash = hashValue(getUserAgent(request));
+
+  const requestTokenResponse = await oauthRequest({
+    method: "POST",
+    url: REQUEST_TOKEN_URL,
+    oauthOverrides: {
+      oauth_callback: callbackUrl,
+    },
+  });
+
+  if (!requestTokenResponse.oauth_token || !requestTokenResponse.oauth_token_secret) {
+    throw new HttpError(502, "X did not return request-token credentials.", { expose: false });
+  }
+
+  requestTokens.set(requestTokenResponse.oauth_token, {
+    tokenSecret: requestTokenResponse.oauth_token_secret,
+    returnUri,
+    initNonce,
+    userAgentHash,
+    createdAt: new Date().toISOString(),
+    expiresAtMs: Date.now() + REQUEST_TOKEN_TTL_MS,
+  });
+
+  setCookie(response, AUTH_INIT_COOKIE_NAME, initNonce, {
+    httpOnly: true,
+    sameSite: "Lax",
+    secure: shouldUseSecureCookies(),
+    maxAge: Math.ceil(REQUEST_TOKEN_TTL_MS / 1000),
+    path: "/api/x/callback",
+  });
+
+  const authorizeUrl = new URL(AUTHORIZE_URL);
+  authorizeUrl.searchParams.set("oauth_token", requestTokenResponse.oauth_token);
+  redirect(response, authorizeUrl.toString());
+}
+
+async function handleCallback(request, response) {
+  const requestUrl = new URL(request.url, `http://${request.headers.host}`);
+  const oauthToken = String(requestUrl.searchParams.get("oauth_token") || "").trim();
+  const oauthVerifier = String(requestUrl.searchParams.get("oauth_verifier") || "").trim();
+  const deniedToken = String(requestUrl.searchParams.get("denied") || "").trim();
+  const cookies = parseCookies(request);
+
+  if (deniedToken) {
+    const deniedRequest = requestTokens.get(deniedToken);
+    const returnUri = deniedRequest?.returnUri || getDefaultFrontendReturnUrl();
+    requestTokens.delete(deniedToken);
+    clearCookie(response, AUTH_INIT_COOKIE_NAME, {
+      path: "/api/x/callback",
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+    });
+    redirect(response, appendErrorRedirect(returnUri, "X authorization was denied."));
+    return;
+  }
+
+  if (!oauthToken || !oauthVerifier) {
+    throw new HttpError(400, "Callback did not include oauth_token and oauth_verifier.");
+  }
+
+  pruneExpiredState();
+  const pending = requestTokens.get(oauthToken);
+  if (!pending) {
+    clearCookie(response, AUTH_INIT_COOKIE_NAME, {
+      path: "/api/x/callback",
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+    });
+    redirect(response, appendErrorRedirect(getDefaultFrontendReturnUrl(), "X sign-in session expired. Start again."));
+    return;
+  }
+
+  requestTokens.delete(oauthToken);
+
+  const initNonce = String(cookies[AUTH_INIT_COOKIE_NAME] || "").trim();
+  if (!initNonce || !secureEquals(initNonce, pending.initNonce)) {
+    clearCookie(response, AUTH_INIT_COOKIE_NAME, {
+      path: "/api/x/callback",
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+    });
+    redirect(response, appendErrorRedirect(pending.returnUri, "X sign-in session could not be verified. Start again."));
+    return;
+  }
+
+  const callbackUserAgentHash = hashValue(getUserAgent(request));
+  if (!secureEquals(callbackUserAgentHash, pending.userAgentHash)) {
+    clearCookie(response, AUTH_INIT_COOKIE_NAME, {
+      path: "/api/x/callback",
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+    });
+    redirect(response, appendErrorRedirect(pending.returnUri, "X sign-in session could not be verified. Start again."));
+    return;
+  }
+
+  try {
+    const accessTokenResponse = await oauthRequest({
+      method: "POST",
+      url: ACCESS_TOKEN_URL,
+      oauthOverrides: {
+        oauth_token: oauthToken,
+        oauth_verifier: oauthVerifier,
+      },
+      tokenSecret: pending.tokenSecret,
+    });
+
+    let verifiedCredentials = null;
+    if (!accessTokenResponse.screen_name || !accessTokenResponse.user_id) {
+      verifiedCredentials = await verifyCredentials(
+        accessTokenResponse.oauth_token,
+        accessTokenResponse.oauth_token_secret,
+      );
+    }
+
+    const profile = normalizeIdentityFromOAuth1(accessTokenResponse, verifiedCredentials);
+    const sessionId = createRandomToken(32);
+    const csrfToken = createRandomToken(24);
+    const authenticatedAt = new Date().toISOString();
+    const expiresAtMs = Date.now() + AUTH_SESSION_TTL_MS;
+
+    authSessions.set(sessionId, {
+      sessionId,
+      csrfToken,
+      profile,
+      authenticatedAt,
+      expiresAtMs,
+      userAgentHash: callbackUserAgentHash,
+    });
+
+    clearCookie(response, AUTH_INIT_COOKIE_NAME, {
+      path: "/api/x/callback",
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+    });
+    setCookie(response, AUTH_SESSION_COOKIE_NAME, sessionId, {
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+      maxAge: Math.ceil(AUTH_SESSION_TTL_MS / 1000),
+      path: "/api/x/",
+    });
+    redirect(response, appendCompleteRedirect(pending.returnUri));
+  } catch (error) {
+    clearCookie(response, AUTH_INIT_COOKIE_NAME, {
+      path: "/api/x/callback",
+      sameSite: "Lax",
+      secure: shouldUseSecureCookies(),
+    });
+    console.error("[OAuth 1.0a callback]", error);
+    redirect(response, appendErrorRedirect(pending.returnUri, "Could not complete X sign-in. Start again."));
+  }
+}
+
+async function handleSessionLookup(request, response) {
+  const session = getRequiredSessionFromCookie(request, response);
+
+  writeJson(response, 200, {
+    profile: session.profile,
+    authenticatedAt: session.authenticatedAt,
+    expiresAt: session.expiresAtMs,
+    csrfToken: session.csrfToken,
+  });
+}
+
+async function handleLinkChallenge(request, response) {
+  const session = getRequiredSessionFromCookie(request, response);
+  requireCsrf(request, session);
+
+  const body = await readJsonRequest(request);
+  const walletAddress = requireWalletAddress(body.walletAddress);
+  const challengeId = createRandomToken(18);
+  const issuedAt = new Date().toISOString();
+  const message = buildWalletLinkMessage({
+    profile: session.profile,
+    walletAddress,
+    challengeId,
+    issuedAt,
+  });
+
+  for (const [existingId, challenge] of linkChallenges.entries()) {
+    if (challenge.sessionId === session.sessionId && challenge.walletAddress === walletAddress) {
+      linkChallenges.delete(existingId);
+    }
+  }
+
+  linkChallenges.set(challengeId, {
+    challengeId,
+    sessionId: session.sessionId,
+    walletAddress,
+    message,
+    issuedAt,
+    expiresAtMs: Date.now() + CHALLENGE_TTL_MS,
+  });
+
+  writeJson(response, 200, {
+    challengeId,
+    message,
+    expiresAt: Date.now() + CHALLENGE_TTL_MS,
+  });
+}
+
+async function handleLinkComplete(request, response) {
+  const session = getRequiredSessionFromCookie(request, response);
+  requireCsrf(request, session);
+
+  const body = await readJsonRequest(request);
+  const challengeId = String(body.challengeId || "").trim();
+  const walletAddress = requireWalletAddress(body.walletAddress);
+  const signature = String(body.signature || "").trim();
+
+  if (!challengeId || !signature) {
+    throw new HttpError(400, "Request must include challengeId and signature.");
+  }
+
+  pruneExpiredState();
+  const challenge = linkChallenges.get(challengeId);
+  if (!challenge) {
+    throw new HttpError(400, "Wallet challenge expired. Start again.");
+  }
+
+  if (challenge.sessionId !== session.sessionId) {
+    throw new HttpError(403, "Wallet challenge does not match the signed-in X account.");
+  }
+
+  if (challenge.walletAddress !== walletAddress) {
+    throw new HttpError(400, "Wallet challenge does not match the requested wallet.");
+  }
+
+  let recoveredAddress;
+  try {
+    recoveredAddress = ethers.verifyMessage(challenge.message, signature);
+  } catch {
+    throw new HttpError(400, "Wallet signature is invalid.");
+  }
+
+  if (ethers.getAddress(recoveredAddress) !== walletAddress) {
+    throw new HttpError(400, "Wallet signature did not match the connected wallet.");
+  }
+
+  linkChallenges.delete(challengeId);
+
+  const normalizedUsername = normalizeUsername(session.profile.username);
+  const isKnownFollower = followerUsernames.has(normalizedUsername);
+  const isRecoveryCandidate = recoveryCandidateUsernames.has(normalizedUsername);
+  const savedRecord = upsertRecoveryRecord({
+    id: crypto.randomUUID(),
+    xUserId: String(session.profile.id),
+    xUsername: String(session.profile.username),
+    xName: String(session.profile.name || session.profile.username),
+    walletAddress,
+    profileImageUrl: String(session.profile.profile_image_url || session.profile.profileImageUrl || ""),
+    verified: Boolean(session.profile.verified),
+    verifiedType: String(session.profile.verified_type || session.profile.verifiedType || ""),
+    authenticatedAt: session.authenticatedAt,
+    challengeId,
+    signedMessage: challenge.message,
+    signature,
+    isKnownFollower,
+    isRecoveryCandidate,
+    source: "x-follow-recovery",
+  });
+
+  saveRecoveryStore(recoveryStore);
+
+  writeJson(response, 200, {
+    recordId: savedRecord.id,
+    walletAddress: savedRecord.walletAddress,
+    xUsername: savedRecord.xUsername,
+    xUserId: savedRecord.xUserId,
+    isKnownFollower: savedRecord.isKnownFollower,
+    isRecoveryCandidate: savedRecord.isRecoveryCandidate,
+    savedAt: savedRecord.updatedAt,
+  });
+}
+
+async function handleLogout(request, response) {
+  let session = null;
+  try {
+    session = getRequiredSessionFromCookie(request, response);
+    requireCsrf(request, session);
+  } catch (error) {
+    if (!(error instanceof HttpError) || error.statusCode !== 401) {
+      throw error;
+    }
+  }
+
+  if (session) {
+    deleteAuthSession(session.sessionId);
+  }
+
+  clearCookie(response, AUTH_SESSION_COOKIE_NAME, {
+    path: "/api/x/",
+    sameSite: "Lax",
+    secure: shouldUseSecureCookies(),
+  });
+
+  writeJson(response, 200, { ok: true });
+}
+
+function handleOptions(request, response) {
+  if (!setCorsHeaders(request, response)) {
+    throw new HttpError(403, "Origin is not allowed.");
+  }
+
+  response.writeHead(204, {
+    "Cache-Control": "no-store, private, max-age=0",
+    Pragma: "no-cache",
+  });
+  response.end();
+}
+
+function handleError(response, error) {
+  const statusCode = error instanceof HttpError ? error.statusCode : 500;
+  const headers = error instanceof HttpError ? error.headers : {};
+  if (!(error instanceof HttpError) || statusCode >= 500) {
+    console.error("[X auth server]", error);
+  }
+  writeJson(response, statusCode, {
+    error: getPublicErrorMessage(error, "Request failed."),
+  }, headers);
+}
+
+const server = http.createServer(async (request, response) => {
+  setStandardHeaders(response);
+
+  try {
+    if (request.method === "OPTIONS") {
+      handleOptions(request, response);
+      return;
+    }
+
+    if (request.method === "GET" && request.url.startsWith("/health")) {
+      consumeRateLimit(request, "health");
+      pruneExpiredState();
+      writeJson(response, 200, getHealthPayload(request));
+      return;
+    }
+
+    if (request.method === "GET" && request.url.startsWith("/api/x/start")) {
+      consumeRateLimit(request, "start");
+      await handleStart(request, response);
+      return;
+    }
+
+    if (request.method === "GET" && request.url.startsWith("/api/x/callback")) {
+      consumeRateLimit(request, "callback");
+      await handleCallback(request, response);
+      return;
+    }
+
+    if (request.method === "GET" && request.url.startsWith("/api/x/session")) {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "session");
+      await handleSessionLookup(request, response);
+      return;
+    }
+
+    if (request.method === "POST" && request.url === "/api/x/link/challenge") {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "challenge");
+      await handleLinkChallenge(request, response);
+      return;
+    }
+
+    if (request.method === "POST" && request.url === "/api/x/link/complete") {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "complete");
+      await handleLinkComplete(request, response);
+      return;
+    }
+
+    if (request.method === "POST" && request.url === "/api/x/logout") {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "logout");
+      await handleLogout(request, response);
+      return;
+    }
+
+    writeJson(response, 404, { error: "Not found." });
+  } catch (error) {
+    handleError(response, error);
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`X auth server listening at http://${HOST}:${PORT}`);
+  console.log(`Allowed origins: ${getAllowedOrigins().join(", ")}`);
+  console.log(`Allowed return URLs: ${getAllowedReturnUrls().join(", ")}`);
+  console.log(`API key configured: ${getApiKey() ? "yes" : "no"}`);
+  console.log(`API secret configured: ${getApiSecret() ? "yes" : "no"}`);
+  console.log(`OAuth 1 callback URL: ${getCallbackUrl() || "(missing)"}`);
+  console.log(`Default frontend return URL: ${getDefaultFrontendReturnUrl()}`);
+  console.log(`Secure cookies: ${shouldUseSecureCookies() ? "yes" : "no"}`);
+  console.log(`Follower snapshot usernames loaded: ${followerUsernames.size}`);
+  console.log(`Recovery candidate usernames loaded: ${recoveryCandidateUsernames.size}`);
+  console.log(`Recovery store path: ${getRecoveryStorePath()}`);
+});


### PR DESCRIPTION
## Summary
- add the X recovery flow for claimants, including wallet verification and backend account/recovery storage
- move follower/recovery account data and airdrop rounds/claims into SQLite, with deployment-key namespacing for rounds
- harden admin round finalization with owner-wallet challenge signing and document server deployment with PM2

## Testing
- `node --check backend/server.js`
- `node --check backend/lib/db.js`
- `node --check backend/lib/airdrop-round-store.js`
- `node --check backend/import-claim-rounds.js`
- `node --check scripts/deploy-local.js`
- `node --experimental-default-type=module --check frontend/js/pages/claim.js`
- `node --experimental-default-type=module --check frontend/js/pages/admin.js`
- `node --experimental-default-type=module --check frontend/js/shared/claims.js`
- `node --experimental-default-type=module --check frontend/js/shared/config.js`
- `git diff --check`
- local backend smoke tests for `/health`, `/api/airdrop/rounds`, `/api/claims/wallet/:address`, and `/api/admin/airdrop-rounds/challenge`
