### PR TITLE
Update admin airdrop round workflow

### DIFF
--- a/backend/lib/airdrop-round-store.js
+++ b/backend/lib/airdrop-round-store.js
@@ -15,7 +15,8 @@ function normalizeRoundRecord(row) {
   return {
     id: Number(row.id),
     deploymentKey: String(row.deployment_key || "").trim(),
-    epoch: Number(row.epoch),
+    status: String(row.status || "draft").trim(),
+    epoch: row.epoch == null ? null : Number(row.epoch),
     merkleRoot: String(row.merkle_root || "").trim(),
     deadline: Number(row.deadline || 0),
     claimCount: Number(row.claim_count || 0),
@@ -36,11 +37,17 @@ function normalizeClaimRecord(row) {
   if (!row) return null;
 
   return {
+    id: Number(row.claim_id ?? row.id),
     roundId: Number(row.round_id),
     index: String(row.claim_index),
     account: ethers.getAddress(String(row.wallet_address || "").trim()),
     amountRaw: String(row.amount_raw || "0"),
     proof: JSON.parse(String(row.proof_json || "[]")),
+    usernameDisplay: String(row.username_display || "").trim() || null,
+    claimedAt: normalizeIsoDate(row.claimed_at),
+    claimedTxHash: String(row.claimed_tx_hash || "").trim() || null,
+    createdAt: normalizeIsoDate(row.claim_created_at ?? row.created_at),
+    updatedAt: normalizeIsoDate(row.claim_updated_at ?? row.updated_at),
   };
 }
 
@@ -53,22 +60,72 @@ function normalizeDeploymentKey(value) {
   return normalized;
 }
 
+function normalizeClaimInsertRecord(roundId, claim, timestamp) {
+  return {
+    roundId,
+    claimIndex: Number(claim.index),
+    walletAddress: ethers.getAddress(String(claim.account || "").trim()).toLowerCase(),
+    amountRaw: String(claim.amountRaw || "0"),
+    proofJson: JSON.stringify(Array.isArray(claim.proof) ? claim.proof : []),
+    claimedAt: normalizeIsoDate(claim.claimedAt),
+    claimedTxHash: String(claim.claimedTxHash || "").trim().toLowerCase() || null,
+    createdAt: normalizeIsoDate(claim.createdAt, timestamp),
+    updatedAt: normalizeIsoDate(claim.updatedAt, timestamp),
+  };
+}
+
 function createAirdropRoundStore(db) {
+  const claimSelect = `
+    c.id AS claim_id,
+    c.round_id,
+    c.claim_index,
+    c.wallet_address,
+    c.amount_raw,
+    c.proof_json,
+    c.claimed_at,
+    c.claimed_tx_hash,
+    c.created_at AS claim_created_at,
+    c.updated_at AS claim_updated_at,
+    (
+      SELECT xa.username_display
+      FROM x_accounts xa
+      WHERE LOWER(xa.wallet_address) = LOWER(c.wallet_address)
+      ORDER BY datetime(xa.updated_at) DESC, xa.id DESC
+      LIMIT 1
+    ) AS username_display
+  `;
+
   const statements = {
+    getRoundByIdAndDeployment: db.prepare(`
+      SELECT *
+      FROM airdrop_rounds
+      WHERE id = ?
+        AND deployment_key = ?
+      LIMIT 1
+    `),
     getRoundByDeploymentAndEpoch: db.prepare(`
       SELECT *
       FROM airdrop_rounds
       WHERE deployment_key = ?
         AND epoch = ?
+      LIMIT 1
     `),
-    getRoundById: db.prepare(`
+    getMatchingDraft: db.prepare(`
       SELECT *
       FROM airdrop_rounds
-      WHERE id = ?
+      WHERE deployment_key = ?
+        AND status = 'draft'
+        AND LOWER(merkle_root) = LOWER(?)
+        AND deadline = ?
+        AND claim_count = ?
+        AND total_amount_raw = ?
+      ORDER BY datetime(updated_at) DESC, id DESC
+      LIMIT 1
     `),
     insertRound: db.prepare(`
       INSERT INTO airdrop_rounds (
         deployment_key,
+        status,
         epoch,
         merkle_root,
         deadline,
@@ -85,6 +142,7 @@ function createAirdropRoundStore(db) {
         updated_at
       ) VALUES (
         @deploymentKey,
+        @status,
         @epoch,
         @merkleRoot,
         @deadline,
@@ -104,6 +162,8 @@ function createAirdropRoundStore(db) {
     updateRound: db.prepare(`
       UPDATE airdrop_rounds
       SET deployment_key = @deploymentKey,
+          status = @status,
+          epoch = @epoch,
           merkle_root = @merkleRoot,
           deadline = @deadline,
           claim_count = @claimCount,
@@ -129,52 +189,93 @@ function createAirdropRoundStore(db) {
         wallet_address,
         amount_raw,
         proof_json,
-        created_at
+        claimed_at,
+        claimed_tx_hash,
+        created_at,
+        updated_at
       ) VALUES (
         @roundId,
         @claimIndex,
         @walletAddress,
         @amountRaw,
         @proofJson,
-        @createdAt
+        @claimedAt,
+        @claimedTxHash,
+        @createdAt,
+        @updatedAt
       )
     `),
     listRounds: db.prepare(`
       SELECT *
       FROM airdrop_rounds
       WHERE deployment_key = ?
-      ORDER BY epoch DESC, id DESC
+      ORDER BY
+        CASE WHEN status = 'draft' THEN 0 ELSE 1 END,
+        COALESCE(epoch, 0) DESC,
+        datetime(updated_at) DESC,
+        id DESC
     `),
     listWalletRounds: db.prepare(`
       SELECT
         r.*,
-        c.round_id,
-        c.claim_index,
-        c.wallet_address,
-        c.amount_raw,
-        c.proof_json
+        ${claimSelect}
       FROM airdrop_claims c
       INNER JOIN airdrop_rounds r
         ON r.id = c.round_id
       WHERE r.deployment_key = ?
+        AND r.status = 'deployed'
         AND LOWER(c.wallet_address) = LOWER(?)
       ORDER BY r.epoch DESC, r.id DESC
     `),
     getClaimByEpochAndIndex: db.prepare(`
       SELECT
         r.*,
-        c.round_id,
-        c.claim_index,
-        c.wallet_address,
-        c.amount_raw,
-        c.proof_json
+        ${claimSelect}
       FROM airdrop_claims c
       INNER JOIN airdrop_rounds r
         ON r.id = c.round_id
       WHERE r.deployment_key = ?
+        AND r.status = 'deployed'
         AND r.epoch = ?
         AND c.claim_index = ?
       LIMIT 1
+    `),
+    listClaimsByRound: db.prepare(`
+      SELECT
+        r.*,
+        ${claimSelect}
+      FROM airdrop_claims c
+      INNER JOIN airdrop_rounds r
+        ON r.id = c.round_id
+      WHERE r.deployment_key = ?
+        AND r.id = ?
+      ORDER BY c.claim_index ASC, c.id ASC
+    `),
+    getClaimById: db.prepare(`
+      SELECT
+        r.*,
+        ${claimSelect}
+      FROM airdrop_claims c
+      INNER JOIN airdrop_rounds r
+        ON r.id = c.round_id
+      WHERE r.deployment_key = ?
+        AND c.id = ?
+      LIMIT 1
+    `),
+    listClaimsByWallet: db.prepare(`
+      SELECT
+        r.*,
+        ${claimSelect}
+      FROM airdrop_claims c
+      INNER JOIN airdrop_rounds r
+        ON r.id = c.round_id
+      WHERE r.deployment_key = ?
+        AND LOWER(c.wallet_address) = LOWER(?)
+      ORDER BY
+        CASE WHEN r.status = 'draft' THEN 0 ELSE 1 END,
+        COALESCE(r.epoch, 0) DESC,
+        c.claim_index ASC,
+        c.id ASC
     `),
     getStats: db.prepare(`
       SELECT
@@ -191,26 +292,45 @@ function createAirdropRoundStore(db) {
     `),
   };
 
-  const upsertRound = db.transaction((round) => {
+  function replaceClaimsForRound(roundId, claims, timestamp) {
+    statements.deleteClaimsByRoundId.run(roundId);
+    for (const claim of claims) {
+      statements.insertClaim.run(normalizeClaimInsertRecord(roundId, claim, timestamp));
+    }
+  }
+
+  const saveDraftRound = db.transaction((round) => {
     const deploymentKey = normalizeDeploymentKey(round.deploymentKey);
-    const existing = normalizeRoundRecord(
-      statements.getRoundByDeploymentAndEpoch.get(deploymentKey, round.epoch),
-    );
     const updatedAt = normalizeIsoDate(round.updatedAt, new Date().toISOString());
+    const normalizedMerkleRoot = String(round.merkleRoot || "").trim().toLowerCase();
+    const normalizedDeadline = Number(round.deadline || 0);
+    const normalizedClaimCount = Number(round.claimCount || 0);
+    const normalizedTotalAmountRaw = String(round.totalAmountRaw || "0");
+    const existing = normalizeRoundRecord(
+      statements.getMatchingDraft.get(
+        deploymentKey,
+        normalizedMerkleRoot,
+        normalizedDeadline,
+        normalizedClaimCount,
+        normalizedTotalAmountRaw,
+      ),
+    );
+
     const baseRecord = {
       deploymentKey,
-      epoch: Number(round.epoch),
-      merkleRoot: String(round.merkleRoot || "").trim().toLowerCase(),
-      deadline: Number(round.deadline || 0),
-      claimCount: Number(round.claimCount || 0),
-      totalAmountRaw: String(round.totalAmountRaw || "0"),
+      status: "draft",
+      epoch: null,
+      merkleRoot: normalizedMerkleRoot,
+      deadline: normalizedDeadline,
+      claimCount: normalizedClaimCount,
+      totalAmountRaw: normalizedTotalAmountRaw,
       decimals: Number(round.decimals || 18),
       chainId: Number(round.chainId || 0),
       contractAddress: ethers.getAddress(String(round.contractAddress || "").trim()).toLowerCase(),
-      sourceKind: String(round.sourceKind || "manual").trim(),
-      startTxHash: String(round.startTxHash || "").trim().toLowerCase() || null,
-      startBlockNumber: round.startBlockNumber == null ? null : Number(round.startBlockNumber),
-      startBlockHash: String(round.startBlockHash || "").trim().toLowerCase() || null,
+      sourceKind: String(round.sourceKind || "admin-draft").trim(),
+      startTxHash: null,
+      startBlockNumber: null,
+      startBlockHash: null,
       createdAt: existing?.createdAt || updatedAt,
       updatedAt,
     };
@@ -227,29 +347,69 @@ function createAirdropRoundStore(db) {
       roundId = existing.id;
     }
 
-    statements.deleteClaimsByRoundId.run(roundId);
-    for (const claim of round.claims) {
-      statements.insertClaim.run({
-        roundId,
-        claimIndex: Number(claim.index),
-        walletAddress: ethers.getAddress(String(claim.account || "").trim()).toLowerCase(),
-        amountRaw: String(claim.amountRaw || "0"),
-        proofJson: JSON.stringify(Array.isArray(claim.proof) ? claim.proof : []),
-        createdAt: updatedAt,
-      });
+    replaceClaimsForRound(roundId, round.claims, updatedAt);
+    return normalizeRoundRecord(statements.getRoundByIdAndDeployment.get(roundId, deploymentKey));
+  });
+
+  const finalizeRoundDeployment = db.transaction((roundId, deploymentKey, deployment) => {
+    const existing = normalizeRoundRecord(
+      statements.getRoundByIdAndDeployment.get(Number(roundId), normalizeDeploymentKey(deploymentKey)),
+    );
+
+    if (!existing) {
+      throw new Error("Stored airdrop round was not found.");
     }
 
-    return normalizeRoundRecord(statements.getRoundById.get(roundId));
+    const normalizedEpoch = Number(deployment.epoch);
+    const conflictingRound = normalizeRoundRecord(
+      statements.getRoundByDeploymentAndEpoch.get(existing.deploymentKey, normalizedEpoch),
+    );
+    if (conflictingRound && conflictingRound.id !== existing.id) {
+      throw new Error(`Epoch ${normalizedEpoch} is already linked to another stored round.`);
+    }
+
+    const updatedAt = normalizeIsoDate(deployment.updatedAt, new Date().toISOString());
+    statements.updateRound.run({
+      id: existing.id,
+      deploymentKey: existing.deploymentKey,
+      status: "deployed",
+      epoch: normalizedEpoch,
+      merkleRoot: String(deployment.merkleRoot || existing.merkleRoot).trim().toLowerCase(),
+      deadline: Number(deployment.deadline || existing.deadline),
+      claimCount: existing.claimCount,
+      totalAmountRaw: existing.totalAmountRaw,
+      decimals: existing.decimals,
+      chainId: Number(deployment.chainId || existing.chainId || 0),
+      contractAddress: ethers.getAddress(String(deployment.contractAddress || existing.contractAddress).trim()).toLowerCase(),
+      sourceKind: String(deployment.sourceKind || existing.sourceKind || "admin-draft").trim(),
+      startTxHash: String(deployment.startTxHash || "").trim().toLowerCase() || null,
+      startBlockNumber: deployment.startBlockNumber == null ? null : Number(deployment.startBlockNumber),
+      startBlockHash: String(deployment.startBlockHash || "").trim().toLowerCase() || null,
+      createdAt: existing.createdAt,
+      updatedAt,
+    });
+
+    return normalizeRoundRecord(statements.getRoundByIdAndDeployment.get(existing.id, existing.deploymentKey));
   });
 
   return {
-    upsertRound(round) {
-      return upsertRound(round);
+    saveDraftRound(round) {
+      return saveDraftRound(round);
+    },
+
+    finalizeRoundDeployment(roundId, deploymentKey, deployment) {
+      return finalizeRoundDeployment(roundId, deploymentKey, deployment);
     },
 
     listRounds(deploymentKey) {
       const normalizedDeploymentKey = normalizeDeploymentKey(deploymentKey);
       return statements.listRounds.all(normalizedDeploymentKey).map((row) => normalizeRoundRecord(row));
+    },
+
+    getRoundById(roundId, deploymentKey) {
+      return normalizeRoundRecord(
+        statements.getRoundByIdAndDeployment.get(Number(roundId), normalizeDeploymentKey(deploymentKey)),
+      );
     },
 
     getWalletRounds(walletAddress, deploymentKey) {
@@ -279,6 +439,35 @@ function createAirdropRoundStore(db) {
         ...normalizeRoundRecord(row),
         entry: normalizeClaimRecord(row),
       };
+    },
+
+    listClaimsByRound(roundId, deploymentKey) {
+      const normalizedDeploymentKey = normalizeDeploymentKey(deploymentKey);
+      return statements.listClaimsByRound.all(normalizedDeploymentKey, Number(roundId)).map((row) => ({
+        round: normalizeRoundRecord(row),
+        entry: normalizeClaimRecord(row),
+      }));
+    },
+
+    getClaimById(claimId, deploymentKey) {
+      const normalizedDeploymentKey = normalizeDeploymentKey(deploymentKey);
+      const row = statements.getClaimById.get(normalizedDeploymentKey, Number(claimId));
+      if (!row) {
+        return null;
+      }
+
+      return {
+        round: normalizeRoundRecord(row),
+        entry: normalizeClaimRecord(row),
+      };
+    },
+
+    findClaimsByWallet(walletAddress, deploymentKey) {
+      const normalizedDeploymentKey = normalizeDeploymentKey(deploymentKey);
+      return statements.listClaimsByWallet.all(normalizedDeploymentKey, walletAddress).map((row) => ({
+        round: normalizeRoundRecord(row),
+        entry: normalizeClaimRecord(row),
+      }));
     },
 
     getStats(deploymentKey = null) {

--- a/backend/lib/db.js
+++ b/backend/lib/db.js
@@ -4,7 +4,7 @@ const path = require("node:path");
 const Database = require("better-sqlite3");
 
 const DEFAULT_DB_PATH = path.join("data", "liberdus.sqlite");
-const BASE_SCHEMA_VERSION = 1;
+const CURRENT_SCHEMA_VERSION = 2;
 function getRepoRoot() {
   return path.resolve(__dirname, "..", "..");
 }
@@ -87,7 +87,8 @@ function createAirdropSchema(db) {
     CREATE TABLE IF NOT EXISTS airdrop_rounds (
       id INTEGER PRIMARY KEY,
       deployment_key TEXT NOT NULL,
-      epoch INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'deployed')),
+      epoch INTEGER,
       merkle_root TEXT NOT NULL,
       deadline INTEGER NOT NULL DEFAULT 0,
       claim_count INTEGER NOT NULL DEFAULT 0,
@@ -104,29 +105,43 @@ function createAirdropSchema(db) {
     );
 
     CREATE UNIQUE INDEX IF NOT EXISTS idx_airdrop_rounds_deployment_epoch
-      ON airdrop_rounds(deployment_key, epoch);
+      ON airdrop_rounds(deployment_key, epoch)
+      WHERE epoch IS NOT NULL;
 
     CREATE INDEX IF NOT EXISTS idx_airdrop_rounds_deployment_merkle_root
       ON airdrop_rounds(deployment_key, LOWER(merkle_root));
 
     CREATE INDEX IF NOT EXISTS idx_airdrop_rounds_deployment_contract_epoch
-      ON airdrop_rounds(deployment_key, LOWER(contract_address), epoch);
+      ON airdrop_rounds(deployment_key, LOWER(contract_address), epoch)
+      WHERE epoch IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_airdrop_rounds_deployment_status
+      ON airdrop_rounds(deployment_key, status, updated_at DESC, id DESC);
 
     CREATE TABLE IF NOT EXISTS airdrop_claims (
+      id INTEGER PRIMARY KEY,
       round_id INTEGER NOT NULL REFERENCES airdrop_rounds(id) ON DELETE CASCADE,
       claim_index INTEGER NOT NULL,
       wallet_address TEXT NOT NULL,
       amount_raw TEXT NOT NULL,
       proof_json TEXT NOT NULL,
+      claimed_at TEXT,
+      claimed_tx_hash TEXT,
       created_at TEXT NOT NULL,
-      PRIMARY KEY (round_id, claim_index)
+      updated_at TEXT NOT NULL
     );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_airdrop_claims_round_index
+      ON airdrop_claims(round_id, claim_index);
 
     CREATE UNIQUE INDEX IF NOT EXISTS idx_airdrop_claims_round_wallet
       ON airdrop_claims(round_id, LOWER(wallet_address));
 
     CREATE INDEX IF NOT EXISTS idx_airdrop_claims_wallet_lookup
       ON airdrop_claims(LOWER(wallet_address));
+
+    CREATE INDEX IF NOT EXISTS idx_airdrop_claims_round_lookup
+      ON airdrop_claims(round_id, claim_index, id);
   `);
 }
 
@@ -144,8 +159,11 @@ function dropKnownTablesAndIndexes(db) {
     DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_epoch;
     DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_merkle_root;
     DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_contract_epoch;
+    DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_status;
+    DROP INDEX IF EXISTS idx_airdrop_claims_round_index;
     DROP INDEX IF EXISTS idx_airdrop_claims_round_wallet;
     DROP INDEX IF EXISTS idx_airdrop_claims_wallet_lookup;
+    DROP INDEX IF EXISTS idx_airdrop_claims_round_lookup;
     DROP TABLE IF EXISTS airdrop_claims;
     DROP TABLE IF EXISTS airdrop_rounds;
     DROP TABLE IF EXISTS airdrop_claims_legacy;
@@ -191,27 +209,154 @@ function hasCurrentSchema(db) {
   `).all().map((row) => row.name);
 
   const airdropRoundColumns = getTableColumnNames(db, "airdrop_rounds");
+  const airdropClaimColumns = getTableColumnNames(db, "airdrop_claims");
 
   return tableNames.includes("x_accounts")
     && tableNames.includes("recovery_submissions")
     && tableNames.includes("airdrop_rounds")
     && tableNames.includes("airdrop_claims")
-    && airdropRoundColumns.includes("deployment_key");
+    && airdropRoundColumns.includes("deployment_key")
+    && airdropRoundColumns.includes("status")
+    && airdropClaimColumns.includes("id")
+    && airdropClaimColumns.includes("updated_at");
 }
 
 function resetToCurrentSchema(db) {
   dropKnownTablesAndIndexes(db);
   initializeSchema(db);
-  setSchemaVersion(db, BASE_SCHEMA_VERSION);
+  setSchemaVersion(db, CURRENT_SCHEMA_VERSION);
+}
+
+function migrateAirdropSchemaV2(db) {
+  const roundColumns = getTableColumnNames(db, "airdrop_rounds");
+  const claimColumns = getTableColumnNames(db, "airdrop_claims");
+
+  if (
+    roundColumns.includes("status")
+    && claimColumns.includes("id")
+    && claimColumns.includes("updated_at")
+  ) {
+    return;
+  }
+
+  if (!roundColumns.includes("deployment_key")) {
+    db.exec(`
+      DROP INDEX IF EXISTS idx_airdrop_rounds_merkle_root;
+      DROP INDEX IF EXISTS idx_airdrop_rounds_contract_epoch;
+      DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_epoch;
+      DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_merkle_root;
+      DROP INDEX IF EXISTS idx_airdrop_rounds_deployment_contract_epoch;
+      DROP INDEX IF EXISTS idx_airdrop_claims_round_wallet;
+      DROP INDEX IF EXISTS idx_airdrop_claims_wallet_lookup;
+      DROP TABLE IF EXISTS airdrop_claims;
+      DROP TABLE IF EXISTS airdrop_rounds;
+    `);
+    createAirdropSchema(db);
+    return;
+  }
+
+  db.exec(`
+    ALTER TABLE airdrop_rounds RENAME TO airdrop_rounds_legacy_v1;
+    ALTER TABLE airdrop_claims RENAME TO airdrop_claims_legacy_v1;
+  `);
+  createAirdropSchema(db);
+
+  db.exec(`
+    INSERT INTO airdrop_rounds (
+      id,
+      deployment_key,
+      status,
+      epoch,
+      merkle_root,
+      deadline,
+      claim_count,
+      total_amount_raw,
+      decimals,
+      chain_id,
+      contract_address,
+      source_kind,
+      start_tx_hash,
+      start_block_number,
+      start_block_hash,
+      created_at,
+      updated_at
+    )
+    SELECT
+      id,
+      deployment_key,
+      'deployed',
+      epoch,
+      merkle_root,
+      deadline,
+      claim_count,
+      total_amount_raw,
+      decimals,
+      chain_id,
+      contract_address,
+      source_kind,
+      start_tx_hash,
+      start_block_number,
+      start_block_hash,
+      created_at,
+      updated_at
+    FROM airdrop_rounds_legacy_v1;
+
+    INSERT INTO airdrop_claims (
+      round_id,
+      claim_index,
+      wallet_address,
+      amount_raw,
+      proof_json,
+      claimed_at,
+      claimed_tx_hash,
+      created_at,
+      updated_at
+    )
+    SELECT
+      round_id,
+      claim_index,
+      wallet_address,
+      amount_raw,
+      proof_json,
+      NULL,
+      NULL,
+      created_at,
+      created_at
+    FROM airdrop_claims_legacy_v1;
+
+    DROP TABLE IF EXISTS airdrop_claims_legacy_v1;
+    DROP TABLE IF EXISTS airdrop_rounds_legacy_v1;
+  `);
 }
 
 function migrateSchema(db) {
   if (hasCurrentSchema(db)) {
-    setSchemaVersion(db, BASE_SCHEMA_VERSION);
+    setSchemaVersion(db, CURRENT_SCHEMA_VERSION);
     return;
   }
 
-  resetToCurrentSchema(db);
+  const hasAccountTables = tableExists(db, "x_accounts") && tableExists(db, "recovery_submissions");
+  const hasAirdropTables = tableExists(db, "airdrop_rounds") && tableExists(db, "airdrop_claims");
+
+  if (!hasAccountTables && !hasAirdropTables) {
+    initializeSchema(db);
+    setSchemaVersion(db, CURRENT_SCHEMA_VERSION);
+    return;
+  }
+
+  if (!hasAccountTables) {
+    resetToCurrentSchema(db);
+    return;
+  }
+
+  if (!hasAirdropTables) {
+    createAirdropSchema(db);
+    setSchemaVersion(db, CURRENT_SCHEMA_VERSION);
+    return;
+  }
+
+  migrateAirdropSchemaV2(db);
+  setSchemaVersion(db, CURRENT_SCHEMA_VERSION);
 }
 
 function openDatabase() {

--- a/backend/server.js
+++ b/backend/server.js
@@ -34,7 +34,7 @@ const AUTH_INIT_COOKIE_NAME = "liberdus_x_oauth_init";
 const AUTH_SESSION_TTL_MS = 15 * 60 * 1000;
 const REQUEST_TOKEN_TTL_MS = 10 * 60 * 1000;
 const CHALLENGE_TTL_MS = 10 * 60 * 1000;
-const ADMIN_FINALIZE_CHALLENGE_TTL_MS = 10 * 60 * 1000;
+const ADMIN_ROUND_SAVE_CHALLENGE_TTL_MS = 10 * 60 * 1000;
 const MAX_JSON_BODY_BYTES = 32 * 1024;
 const RATE_LIMITS = {
   start: { limit: 12, windowMs: 10 * 60 * 1000 },
@@ -46,15 +46,17 @@ const RATE_LIMITS = {
   walletClaims: { limit: 120, windowMs: 60 * 1000 },
   rounds: { limit: 120, windowMs: 60 * 1000 },
   claimLookup: { limit: 120, windowMs: 60 * 1000 },
-  adminChallenge: { limit: 20, windowMs: 10 * 60 * 1000 },
-  finalizeRound: { limit: 20, windowMs: 10 * 60 * 1000 },
+  roundClaims: { limit: 120, windowMs: 60 * 1000 },
+  adminDraftChallenge: { limit: 20, windowMs: 10 * 60 * 1000 },
+  saveRound: { limit: 20, windowMs: 10 * 60 * 1000 },
+  deployRound: { limit: 20, windowMs: 10 * 60 * 1000 },
   health: { limit: 30, windowMs: 60 * 1000 },
 };
 
 const authSessions = new Map();
 const requestTokens = new Map();
 const linkChallenges = new Map();
-const adminFinalizeChallenges = new Map();
+const adminRoundSaveChallenges = new Map();
 const rateLimits = new Map();
 
 class HttpError extends Error {
@@ -539,9 +541,9 @@ function pruneExpiredState() {
     }
   }
 
-  for (const [challengeId, challenge] of adminFinalizeChallenges.entries()) {
+  for (const [challengeId, challenge] of adminRoundSaveChallenges.entries()) {
     if (challenge.expiresAtMs <= now) {
-      adminFinalizeChallenges.delete(challengeId);
+      adminRoundSaveChallenges.delete(challengeId);
     }
   }
 
@@ -676,10 +678,10 @@ function buildWalletLinkMessage({ profile, walletAddress, challengeId, issuedAt 
   ].join("\n");
 }
 
-function buildAdminFinalizeMessage({
+function buildAdminRoundSaveMessage({
   walletAddress,
-  txHash,
   merkleRoot,
+  deadline,
   challengeId,
   issuedAt,
   chainId,
@@ -687,18 +689,18 @@ function buildAdminFinalizeMessage({
   deploymentKey,
 }) {
   return [
-    "Liberdus admin airdrop finalize",
+    "Liberdus admin airdrop draft save",
     "",
     `Wallet: ${walletAddress}`,
     `Chain ID: ${chainId}`,
     `Contract: ${contractAddress}`,
     `Deployment key: ${deploymentKey}`,
-    `Transaction hash: ${txHash}`,
     `Merkle root: ${merkleRoot}`,
+    `Deadline: ${deadline}`,
     `Challenge: ${challengeId}`,
     `Issued at: ${issuedAt}`,
     "",
-    "Sign this message to authorize saving the finalized airdrop round to the backend.",
+    "Sign this message to authorize saving this airdrop draft to the backend.",
   ].join("\n");
 }
 
@@ -790,8 +792,10 @@ function serializeAirdropRoundSummary(round) {
   if (!round) return null;
 
   return {
+    id: Number(round.id || 0),
     deploymentKey: String(round.deploymentKey || "").trim(),
-    epoch: Number(round.epoch || 0),
+    status: String(round.status || "").trim(),
+    epoch: round.epoch == null ? null : Number(round.epoch),
     merkleRoot: String(round.merkleRoot || "").trim(),
     deadline: Number(round.deadline || 0),
     claimCount: Number(round.claimCount || 0),
@@ -808,19 +812,29 @@ function serializeAirdropRoundSummary(round) {
   };
 }
 
+function serializeAirdropClaimEntry(entry) {
+  if (!entry) return null;
+
+  return {
+    id: Number(entry.id || 0),
+    index: String(entry.index || ""),
+    account: String(entry.account || "").trim(),
+    amountRaw: String(entry.amountRaw || "0"),
+    proof: Array.isArray(entry.proof) ? [...entry.proof] : [],
+    usernameDisplay: String(entry.usernameDisplay || "").trim() || null,
+    claimedAt: entry.claimedAt || null,
+    claimedTxHash: String(entry.claimedTxHash || "").trim() || null,
+    createdAt: entry.createdAt || null,
+    updatedAt: entry.updatedAt || null,
+  };
+}
+
 function serializeAirdropWalletRound(round) {
   if (!round) return null;
 
   return {
     ...serializeAirdropRoundSummary(round),
-    entry: round.entry
-      ? {
-        index: String(round.entry.index || ""),
-        account: String(round.entry.account || "").trim(),
-        amountRaw: String(round.entry.amountRaw || "0"),
-        proof: Array.isArray(round.entry.proof) ? [...round.entry.proof] : [],
-      }
-      : null,
+    entry: serializeAirdropClaimEntry(round.entry),
   };
 }
 
@@ -849,16 +863,16 @@ function getRequiredDeploymentKey() {
   return deploymentKey;
 }
 
-function getRequiredAdminChallenge(body) {
+function getRequiredAdminRoundSaveChallenge(body) {
   const challengeId = String(body?.challengeId || "").trim();
   if (!challengeId) {
-    throw new HttpError(400, "Admin finalize request must include challengeId.");
+    throw new HttpError(400, "Admin round save request must include challengeId.");
   }
 
   pruneExpiredState();
-  const challenge = adminFinalizeChallenges.get(challengeId);
+  const challenge = adminRoundSaveChallenges.get(challengeId);
   if (!challenge) {
-    throw new HttpError(400, "Admin finalize challenge expired. Start again.");
+    throw new HttpError(400, "Admin round save challenge expired. Start again.");
   }
 
   return challenge;
@@ -1112,6 +1126,15 @@ async function handleRoundsLookup(response) {
   });
 }
 
+function serializeAirdropClaimRecord(record) {
+  if (!record) return null;
+
+  return {
+    round: serializeAirdropRoundSummary(record.round),
+    entry: serializeAirdropClaimEntry(record.entry),
+  };
+}
+
 async function handleClaimByEpochAndIndexLookup(response, epoch, claimIndex) {
   const normalizedEpoch = Number.parseInt(String(epoch || "").trim(), 10);
   const normalizedClaimIndex = Number.parseInt(String(claimIndex || "").trim(), 10);
@@ -1135,29 +1158,67 @@ async function handleClaimByEpochAndIndexLookup(response, epoch, claimIndex) {
 
   writeJson(response, 200, {
     round: serializeAirdropRoundSummary(claim),
-    entry: serializeAirdropWalletRound(claim).entry,
+    entry: serializeAirdropClaimEntry(claim.entry),
   });
 }
 
-async function handleAdminFinalizeChallenge(request, response) {
+async function handleRoundClaimsLookup(response, roundId) {
+  const normalizedRoundId = Number.parseInt(String(roundId || "").trim(), 10);
+  if (!Number.isInteger(normalizedRoundId) || normalizedRoundId <= 0) {
+    throw new HttpError(400, "Round ID must be a positive integer.");
+  }
+
+  const claims = airdropRoundStore.listClaimsByRound(normalizedRoundId, getRequiredDeploymentKey());
+  writeJson(response, 200, {
+    claims: claims.map((record) => serializeAirdropClaimRecord(record)),
+  });
+}
+
+async function handleClaimByIdLookup(response, claimId) {
+  const normalizedClaimId = Number.parseInt(String(claimId || "").trim(), 10);
+  if (!Number.isInteger(normalizedClaimId) || normalizedClaimId <= 0) {
+    throw new HttpError(400, "Claim ID must be a positive integer.");
+  }
+
+  const claim = airdropRoundStore.getClaimById(normalizedClaimId, getRequiredDeploymentKey());
+  if (!claim) {
+    throw new HttpError(404, "Claim was not found.");
+  }
+
+  writeJson(response, 200, serializeAirdropClaimRecord(claim));
+}
+
+async function handleClaimWalletLookup(response, walletAddress) {
+  const normalizedWalletAddress = requireWalletAddress(walletAddress);
+  const claims = airdropRoundStore.findClaimsByWallet(normalizedWalletAddress, getRequiredDeploymentKey());
+  writeJson(response, 200, {
+    walletAddress: normalizedWalletAddress,
+    claims: claims.map((record) => serializeAirdropClaimRecord(record)),
+  });
+}
+
+async function handleAdminDraftChallenge(request, response) {
   const body = await readJsonRequest(request);
   const walletAddress = requireWalletAddress(body.walletAddress);
-  const txHash = requireBytes32Hex(body.txHash, "Transaction hash");
   const merkleRoot = requireBytes32Hex(body.merkleRoot, "Merkle root");
+  const deadline = Number.parseInt(String(body.deadline || "").trim(), 10);
+  if (!Number.isInteger(deadline) || deadline <= 0) {
+    throw new HttpError(400, "Deadline must be a positive integer.");
+  }
   const chainConfig = requireChainConfig(appConfig);
   const currentOwner = await fetchAirdropOwner(chainConfig);
 
   if (ethers.getAddress(currentOwner) !== walletAddress) {
-    throw new HttpError(403, "Only the current contract owner can save finalized rounds.");
+    throw new HttpError(403, "Only the current contract owner can save airdrop drafts.");
   }
 
   const challengeId = createRandomToken(18);
   const issuedAt = new Date().toISOString();
   const deploymentKey = getRequiredDeploymentKey();
-  const message = buildAdminFinalizeMessage({
+  const message = buildAdminRoundSaveMessage({
     walletAddress,
-    txHash,
     merkleRoot,
+    deadline,
     challengeId,
     issuedAt,
     chainId: chainConfig.chainId,
@@ -1165,109 +1226,153 @@ async function handleAdminFinalizeChallenge(request, response) {
     deploymentKey,
   });
 
-  adminFinalizeChallenges.set(challengeId, {
+  adminRoundSaveChallenges.set(challengeId, {
     challengeId,
     walletAddress,
-    txHash,
     merkleRoot,
+    deadline,
     deploymentKey,
     message,
     issuedAt,
-    expiresAtMs: Date.now() + ADMIN_FINALIZE_CHALLENGE_TTL_MS,
+    expiresAtMs: Date.now() + ADMIN_ROUND_SAVE_CHALLENGE_TTL_MS,
   });
 
   writeJson(response, 200, {
     challengeId,
     message,
-    expiresAt: Date.now() + ADMIN_FINALIZE_CHALLENGE_TTL_MS,
+    expiresAt: Date.now() + ADMIN_ROUND_SAVE_CHALLENGE_TTL_MS,
     walletAddress,
   });
 }
 
-async function handleFinalizeAirdropRound(request, response) {
+async function handleSaveAirdropRound(request, response) {
   const body = await readJsonRequest(request);
   const rawClaims = Array.isArray(body.claims)
     ? body.claims
     : Array.isArray(body.round?.claims)
       ? body.round.claims
       : null;
-  const txHash = String(body.txHash || body.transactionHash || "").trim();
+  const deadline = Number.parseInt(String(body.deadline || body.round?.deadline || "").trim(), 10);
   const decimals = Number.parseInt(String(body.decimals || body.round?.decimals || appConfig.tokenDecimals || "18").trim(), 10);
 
   if (!rawClaims?.length) {
     throw new HttpError(400, "Claims payload is required.");
   }
 
+  if (!Number.isInteger(deadline) || deadline <= 0) {
+    throw new HttpError(400, "Round deadline must be a positive integer.");
+  }
+
   if (!Number.isInteger(decimals) || decimals < 0) {
     throw new HttpError(400, "Token decimals must be a non-negative integer.");
   }
 
-  const challenge = getRequiredAdminChallenge(body);
+  const challenge = getRequiredAdminRoundSaveChallenge(body);
   const signedWalletAddress = requireWalletAddress(body.walletAddress);
   const signature = String(body.signature || "").trim();
-  const expectedTxHash = requireBytes32Hex(txHash, "Transaction hash");
   if (!signature) {
-    throw new HttpError(400, "Admin finalize request must include a wallet signature.");
+    throw new HttpError(400, "Admin round save request must include a wallet signature.");
   }
 
   const builtRound = buildClaimRound(rawClaims, decimals);
   const expectedMerkleRoot = String(builtRound.root || "").trim().toLowerCase();
 
   if (challenge.walletAddress !== signedWalletAddress) {
-    throw new HttpError(403, "Admin finalize challenge does not match the signing wallet.");
-  }
-
-  if (challenge.txHash !== expectedTxHash) {
-    throw new HttpError(400, "Admin finalize challenge does not match the transaction hash.");
+    throw new HttpError(403, "Admin round save challenge does not match the signing wallet.");
   }
 
   if (challenge.merkleRoot !== expectedMerkleRoot) {
-    throw new HttpError(400, "Admin finalize challenge does not match the Merkle root.");
+    throw new HttpError(400, "Admin round save challenge does not match the Merkle root.");
+  }
+
+  if (challenge.deadline !== deadline) {
+    throw new HttpError(400, "Admin round save challenge does not match the deadline.");
   }
 
   if (challenge.deploymentKey !== getRequiredDeploymentKey()) {
-    throw new HttpError(400, "Admin finalize challenge does not match the active deployment.");
+    throw new HttpError(400, "Admin round save challenge does not match the active deployment.");
   }
 
   let recoveredAddress;
   try {
     recoveredAddress = ethers.verifyMessage(challenge.message, signature);
   } catch {
-    throw new HttpError(400, "Admin finalize signature is invalid.");
+    throw new HttpError(400, "Admin round save signature is invalid.");
   }
 
   if (ethers.getAddress(recoveredAddress) !== signedWalletAddress) {
-    throw new HttpError(403, "Admin finalize signature did not match the supplied wallet.");
+    throw new HttpError(403, "Admin round save signature did not match the supplied wallet.");
   }
 
   const chainConfig = requireChainConfig(appConfig);
   const currentOwner = await fetchAirdropOwner(chainConfig);
   if (ethers.getAddress(currentOwner) !== signedWalletAddress) {
-    throw new HttpError(403, "Only the current contract owner can save finalized rounds.");
+    throw new HttpError(403, "Only the current contract owner can save airdrop drafts.");
   }
 
-  const verifiedRound = await verifyAirdropStartTransaction(chainConfig, txHash, builtRound.root);
-  adminFinalizeChallenges.delete(challenge.challengeId);
-  const savedRound = airdropRoundStore.upsertRound({
+  adminRoundSaveChallenges.delete(challenge.challengeId);
+  const savedRound = airdropRoundStore.saveDraftRound({
     deploymentKey: getRequiredDeploymentKey(),
-    epoch: verifiedRound.epoch,
-    merkleRoot: verifiedRound.merkleRoot,
-    deadline: verifiedRound.deadline,
+    merkleRoot: expectedMerkleRoot,
+    deadline,
     claimCount: builtRound.claimCount,
     totalAmountRaw: builtRound.totalAmountRaw,
     decimals: builtRound.decimals,
     chainId: chainConfig.chainId,
     contractAddress: chainConfig.airdropAddress,
-    sourceKind: "admin-finalized",
-    startTxHash: verifiedRound.txHash,
-    startBlockNumber: verifiedRound.blockNumber,
-    startBlockHash: verifiedRound.blockHash,
+    sourceKind: "admin-draft",
     claims: builtRound.claims,
     updatedAt: new Date().toISOString(),
   });
 
   writeJson(response, 200, {
     round: serializeAirdropRoundSummary(savedRound),
+  });
+}
+
+async function handleDeployStoredAirdropRound(request, response, roundId) {
+  const body = await readJsonRequest(request);
+  const txHash = requireBytes32Hex(body.txHash || body.transactionHash, "Transaction hash");
+  const deploymentKey = getRequiredDeploymentKey();
+  const storedRound = airdropRoundStore.getRoundById(roundId, deploymentKey);
+
+  if (!storedRound) {
+    throw new HttpError(404, "Stored airdrop round was not found.");
+  }
+
+  if (storedRound.status === "deployed") {
+    if (storedRound.startTxHash && storedRound.startTxHash !== txHash) {
+      throw new HttpError(409, "This round was already deployed with a different transaction hash.");
+    }
+
+    writeJson(response, 200, {
+      round: serializeAirdropRoundSummary(storedRound),
+    });
+    return;
+  }
+
+  const chainConfig = requireChainConfig(appConfig);
+  const verifiedRound = await verifyAirdropStartTransaction(chainConfig, txHash, storedRound.merkleRoot);
+
+  if (verifiedRound.deadline !== storedRound.deadline) {
+    throw new HttpError(400, "The deployed round deadline did not match the saved draft.");
+  }
+
+  const deployedRound = airdropRoundStore.finalizeRoundDeployment(roundId, deploymentKey, {
+    epoch: verifiedRound.epoch,
+    merkleRoot: verifiedRound.merkleRoot,
+    deadline: verifiedRound.deadline,
+    chainId: chainConfig.chainId,
+    contractAddress: chainConfig.airdropAddress,
+    sourceKind: "admin-draft",
+    startTxHash: verifiedRound.txHash,
+    startBlockNumber: verifiedRound.blockNumber,
+    startBlockHash: verifiedRound.blockHash,
+    updatedAt: new Date().toISOString(),
+  });
+
+  writeJson(response, 200, {
+    round: serializeAirdropRoundSummary(deployedRound),
   });
 }
 
@@ -1503,6 +1608,14 @@ const server = http.createServer(async (request, response) => {
       return;
     }
 
+    const roundClaimsMatch = pathname.match(/^\/api\/airdrop\/rounds\/(\d+)\/claims$/u);
+    if (request.method === "GET" && roundClaimsMatch) {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "roundClaims");
+      await handleRoundClaimsLookup(response, roundClaimsMatch[1]);
+      return;
+    }
+
     const claimLookupMatch = pathname.match(/^\/api\/airdrop\/epochs\/(\d+)\/claims\/(\d+)$/u);
     if (request.method === "GET" && claimLookupMatch) {
       requireAllowedOrigin(request, response);
@@ -1511,17 +1624,40 @@ const server = http.createServer(async (request, response) => {
       return;
     }
 
-    if (request.method === "POST" && pathname === "/api/admin/airdrop-rounds/challenge") {
+    const claimByIdMatch = pathname.match(/^\/api\/airdrop\/claims\/(\d+)$/u);
+    if (request.method === "GET" && claimByIdMatch) {
       requireAllowedOrigin(request, response);
-      consumeRateLimit(request, "adminChallenge");
-      await handleAdminFinalizeChallenge(request, response);
+      consumeRateLimit(request, "claimLookup");
+      await handleClaimByIdLookup(response, claimByIdMatch[1]);
       return;
     }
 
-    if (request.method === "POST" && pathname === "/api/admin/airdrop-rounds/finalize") {
+    if (request.method === "GET" && pathname === "/api/airdrop/claims") {
       requireAllowedOrigin(request, response);
-      consumeRateLimit(request, "finalizeRound");
-      await handleFinalizeAirdropRound(request, response);
+      consumeRateLimit(request, "claimLookup");
+      await handleClaimWalletLookup(response, requestUrl.searchParams.get("walletAddress"));
+      return;
+    }
+
+    if (request.method === "POST" && pathname === "/api/admin/airdrop-rounds/save-challenge") {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "adminDraftChallenge");
+      await handleAdminDraftChallenge(request, response);
+      return;
+    }
+
+    if (request.method === "POST" && pathname === "/api/admin/airdrop-rounds/save") {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "saveRound");
+      await handleSaveAirdropRound(request, response);
+      return;
+    }
+
+    const deployRoundMatch = pathname.match(/^\/api\/admin\/airdrop-rounds\/(\d+)\/deploy$/u);
+    if (request.method === "POST" && deployRoundMatch) {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "deployRound");
+      await handleDeployStoredAirdropRound(request, response, deployRoundMatch[1]);
       return;
     }
 

--- a/e2e/tests/admin/access-control.spec.js
+++ b/e2e/tests/admin/access-control.spec.js
@@ -7,8 +7,9 @@ test("non-owner wallet stays gated from admin controls", async ({ page, mockWall
   await connectViaWalletPicker(page);
 
   await expect(page.locator("#accountRole")).toHaveText("Connected wallet");
-  await expect(page.getByText("This page only unlocks for the current owner address.")).toBeVisible();
+  await expect(page.getByText("This page only unlocks for the current owner or pending owner address.")).toBeVisible();
   await expect(page.locator("#adminShell")).toBeHidden();
+  await expect(page.locator("#pendingOwnerShell")).toBeHidden();
   await expect(page.locator("#ownershipShell")).toBeHidden();
 });
 

--- a/e2e/tests/admin/claim-lookup.spec.js
+++ b/e2e/tests/admin/claim-lookup.spec.js
@@ -1,0 +1,21 @@
+const { expect, test } = require("../../fixtures/testWithMockWallet");
+const { connectViaWalletPicker, startAirdropFromUpload } = require("../helpers");
+
+test("admin can inspect round claims and lookup claims by wallet", async ({ page, e2eClaimsFile, mockWallet }) => {
+  await page.goto("admin.html");
+  await connectViaWalletPicker(page);
+  await startAirdropFromUpload(page, e2eClaimsFile);
+
+  await page.getByRole("button", { name: "Rounds", exact: true }).click();
+  await page.getByRole("button", { name: "View Claims" }).first().click();
+
+  await expect(page.locator("#selectedRoundLabel")).toContainText("Epoch 1");
+  await expect(page.locator("#roundClaimsBody")).toContainText("125 LIB");
+  await expect(page.locator("#roundClaimsBody tr").first().locator("td").first()).toHaveText("0");
+
+  await page.getByRole("button", { name: "Lookups", exact: true }).click();
+  await page.locator("#claimLookupInput").fill(mockWallet.accounts.claimant);
+  await page.getByRole("button", { name: "Lookup Claim(s)" }).click();
+  await expect(page.locator("#claimLookupBody")).toContainText("125 LIB");
+  await expect(page.locator("#claimLookupBody tr").first().locator("td").nth(1)).toHaveText("0");
+});

--- a/e2e/tests/admin/epoch-management.spec.js
+++ b/e2e/tests/admin/epoch-management.spec.js
@@ -10,6 +10,7 @@ test("admin can update an epoch deadline and the update inputs stay synchronized
   await page.goto("admin.html");
   await connectViaWalletPicker(page);
   await startAirdropFromUpload(page, e2eClaimsFile);
+  await page.getByRole("button", { name: "Contract", exact: true }).click();
 
   const nextDeadlineUnix = await page.evaluate(() => {
     const nextDeadline = Math.floor(Date.now() / 1000) + (4 * 60 * 60);
@@ -27,6 +28,7 @@ test("admin can update an epoch deadline and the update inputs stay synchronized
   await expect(page.getByText("Update deadline complete.")).toBeVisible();
   await expect(page.locator("#epochListBody")).toContainText("Active");
 
+  await page.getByRole("button", { name: "Lookups", exact: true }).click();
   await page.locator("#queryEpochInput").fill("1");
   await page.getByRole("button", { name: "Fetch Epoch Data" }).click();
   await expect(page.locator("#epochQueryResult")).toContainText(`"deadline": "${nextDeadlineUnix}"`);
@@ -36,6 +38,7 @@ test("admin rejects an epoch deadline update when the new deadline is already in
   await page.goto("admin.html");
   await connectViaWalletPicker(page);
   await startAirdropFromUpload(page, e2eClaimsFile);
+  await page.getByRole("button", { name: "Contract", exact: true }).click();
 
   const latestBlock = await hardhatChain.rpcCall("eth_getBlockByNumber", ["latest", false]);
   const chainTimestamp = Number.parseInt(latestBlock.timestamp, 16);
@@ -50,6 +53,7 @@ test("admin rejects an epoch deadline update when the new deadline is already in
   await page.getByRole("button", { name: "Update Deadline" }).click();
   await expect(page.getByText("Update deadline: Deadline must be in the future.")).toBeVisible();
 
+  await page.getByRole("button", { name: "Lookups", exact: true }).click();
   await page.locator("#queryEpochInput").fill("1");
   await page.getByRole("button", { name: "Fetch Epoch Data" }).click();
   await expect(page.locator("#epochQueryResult")).not.toContainText(`"deadline": "${pastDeadlineUnix}"`);

--- a/e2e/tests/admin/ownership.spec.js
+++ b/e2e/tests/admin/ownership.spec.js
@@ -5,6 +5,7 @@ test("ownership transfer can be accepted by the pending owner", async ({ page, m
   await page.goto("admin.html");
   await connectViaWalletPicker(page);
 
+  await page.getByRole("button", { name: "Contract", exact: true }).click();
   await expect(page.locator("#ownershipShell")).toBeVisible();
   await page.locator("#transferOwnershipAddress").fill(mockWallet.accounts.claimant);
   await page.getByRole("button", { name: "Transfer Ownership" }).click();
@@ -12,10 +13,12 @@ test("ownership transfer can be accepted by the pending owner", async ({ page, m
   await expect(page.locator("#ownershipPendingOwner")).toContainText(/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/i);
 
   await mockWallet.setAccount(page, mockWallet.accounts.claimant);
-  await expect(page.locator("#ownershipShell")).toBeVisible();
-  await expect(page.locator("#acceptOwnershipButton")).toBeEnabled();
+  await expect(page.locator("#accountRole")).toHaveText("Pending owner connected");
+  await expect(page.locator("#adminShell")).toBeHidden();
+  await expect(page.locator("#pendingOwnerShell")).toBeVisible();
+  await expect(page.locator("#pendingAcceptOwnershipButton")).toBeEnabled();
 
-  await page.getByRole("button", { name: "Accept Ownership" }).click();
+  await page.locator("#pendingAcceptOwnershipButton").click();
   await expect(page.getByText("Accept ownership complete.")).toBeVisible();
   await expect(page.locator("#ownerAddress")).toContainText(/0x70997970c51812dc3a010c7d01b50e0d17dc79c8/i);
   await expect(page.locator("#accountRole")).toHaveText("Owner connected");

--- a/e2e/tests/admin/start-airdrop.spec.js
+++ b/e2e/tests/admin/start-airdrop.spec.js
@@ -1,7 +1,7 @@
 const { expect, test } = require("../../fixtures/testWithMockWallet");
 const { connectViaWalletPicker, setFutureDeadline } = require("../helpers");
 
-test("@smoke admin claims builder can prepare and start a matching airdrop", async ({ page, mockWallet }) => {
+test("@smoke admin claims builder can save and deploy a matching airdrop draft", async ({ page, mockWallet }) => {
   await page.goto("admin.html");
   await connectViaWalletPicker(page);
 
@@ -25,12 +25,13 @@ test("@smoke admin claims builder can prepare and start a matching airdrop", asy
   await setFutureDeadline(page, "#startDeadlineInput");
   await expect(page.locator("#startDeadlineUnix")).not.toHaveValue("");
 
-  await page.getByRole("button", { name: "Fund Contract" }).click();
+  await page.getByRole("button", { name: "Save Round to DB" }).click();
+  await expect(page.locator("#selectedRoundLabel")).toContainText("Draft");
+  await page.getByRole("button", { name: "Fund Total" }).first().click();
   await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
-
-  await page.getByRole("button", { name: "Start New Airdrop" }).click();
+  await page.getByRole("button", { name: "Deploy" }).first().click();
   await expect(page.locator("#currentEpoch")).toHaveText("1");
-  await expect(page.getByRole("button", { name: "Start New Airdrop" })).toBeDisabled();
-  await expect(page.locator("#startRootWarning")).toContainText("already started successfully");
+  await expect(page.locator("#epochListBody")).toContainText("DB + Chain");
+  await page.getByRole("button", { name: "Prepare" }).click();
   await expect(page.locator("#epochListBody")).toContainText("Active");
 });

--- a/e2e/tests/admin/upload-existing-file.spec.js
+++ b/e2e/tests/admin/upload-existing-file.spec.js
@@ -14,13 +14,16 @@ test("admin can upload an existing claims file and gets a duplicate-root warning
   await expect(page.locator("#uploadPreviewBody")).toContainText("90 LIB");
 
   await setFutureDeadline(page, "#startDeadlineInput");
-  await page.getByRole("button", { name: "Fund Contract" }).click();
+  await page.getByRole("button", { name: "Save Round to DB" }).click();
+  await page.getByRole("button", { name: "Fund Total" }).first().click();
   await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
-  await page.getByRole("button", { name: "Start New Airdrop" }).click();
+  await page.getByRole("button", { name: "Deploy" }).first().click();
   await expect(page.locator("#currentEpoch")).toHaveText("1");
+  await expect(page.locator("#epochListBody")).toContainText("DB + Chain");
+  await page.getByRole("button", { name: "Prepare" }).click();
 
   await page.getByRole("button", { name: "Clear Claims" }).click();
   await page.locator("#uploadClaimsFileInput").setInputFiles(e2eClaimsFile);
   await expect(page.getByText("Claims file loaded.")).toBeVisible();
-  await expect(page.locator("#startRootWarning")).toContainText("Merkle root already exists");
+  await expect(page.locator("#startRootWarning")).toContainText("already exists on chain");
 });

--- a/e2e/tests/claim/availability-and-ordering.spec.js
+++ b/e2e/tests/claim/availability-and-ordering.spec.js
@@ -25,6 +25,7 @@ test("claimant no longer sees a round after the owner disables it", async ({ pag
   await connectViaWalletPicker(page);
 
   await startAirdropFromUpload(page, e2eClaimsFile);
+  await page.getByRole("button", { name: "Contract", exact: true }).click();
   await page.locator("#updateEpochInput").fill("1");
   await page.getByRole("button", { name: "Disable Epoch" }).click();
   await expect(page.getByText("Disable epoch complete.")).toBeVisible();

--- a/e2e/tests/claim/claim-flow.spec.js
+++ b/e2e/tests/claim/claim-flow.spec.js
@@ -1,17 +1,10 @@
 const { expect, test, toHexChainId } = require("../../fixtures/testWithMockWallet");
-const { connectViaWalletPicker, setFutureDeadline } = require("../helpers");
+const { connectViaWalletPicker, startAirdropFromUpload } = require("../helpers");
 
 test("@smoke claimant can claim from the wrong network after wallet switch", async ({ page, e2eClaimsFile, mockWallet }) => {
   await page.goto("admin.html");
   await connectViaWalletPicker(page);
-
-  await page.locator("#uploadClaimsFileInput").setInputFiles(e2eClaimsFile);
-  await expect(page.getByText("Claims file loaded.")).toBeVisible();
-  await setFutureDeadline(page, "#startDeadlineInput");
-  await page.getByRole("button", { name: "Fund Contract" }).click();
-  await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
-  await page.getByRole("button", { name: "Start New Airdrop" }).click();
-  await expect(page.locator("#currentEpoch")).toHaveText("1");
+  await startAirdropFromUpload(page, e2eClaimsFile);
 
   await mockWallet.setAccount(page, mockWallet.accounts.claimant);
   await mockWallet.setChainId(page, toHexChainId(31337));
@@ -37,13 +30,7 @@ test("@smoke claimant can claim from the wrong network after wallet switch", asy
 test("claimant outsider sees the generic empty state", async ({ page, e2eClaimsFile, mockWallet }) => {
   await page.goto("admin.html");
   await connectViaWalletPicker(page);
-
-  await page.locator("#uploadClaimsFileInput").setInputFiles(e2eClaimsFile);
-  await setFutureDeadline(page, "#startDeadlineInput");
-  await page.getByRole("button", { name: "Fund Contract" }).click();
-  await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
-  await page.getByRole("button", { name: "Start New Airdrop" }).click();
-  await expect(page.locator("#currentEpoch")).toHaveText("1");
+  await startAirdropFromUpload(page, e2eClaimsFile);
 
   await mockWallet.setAccount(page, mockWallet.accounts.outsider);
   await page.goto("index.html");

--- a/e2e/tests/claim/errors.spec.js
+++ b/e2e/tests/claim/errors.spec.js
@@ -6,6 +6,7 @@ test("claimant sees an underfunded airdrop error when the contract balance is dr
   await connectViaWalletPicker(page);
   await startAirdropFromUpload(page, e2eClaimsFile);
 
+  await page.getByRole("button", { name: "Contract", exact: true }).click();
   await page.locator("#withdrawRecipient").fill(mockWallet.accounts.owner);
   await page.locator("#withdrawAmount").fill("100");
   await page.getByRole("button", { name: "Withdraw" }).click();

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -43,7 +43,13 @@ async function startAirdropFromUpload(page, claimsFile, { deadlineSelector = "#s
   await page.getByRole("button", { name: "Fund Total" }).first().click();
   await page.getByText("Fund airdrop complete.").waitFor();
   await page.getByRole("button", { name: "Deploy" }).first().click();
-  await expect(page.locator("#currentEpoch")).toHaveText(String(currentEpoch + 1));
+  await page.getByText(`Draft deployed as epoch ${currentEpoch + 1}.`).waitFor();
+  try {
+    await expect(page.locator("#currentEpoch")).toHaveText(String(currentEpoch + 1), { timeout: 10000 });
+  } catch {
+    await page.getByRole("button", { name: "Refresh" }).click();
+    await expect(page.locator("#currentEpoch")).toHaveText(String(currentEpoch + 1));
+  }
   await expect(page.locator("#epochListBody")).toContainText("DB + Chain");
   await page.getByRole("button", { name: "Prepare" }).click();
 }

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -39,10 +39,13 @@ async function startAirdropFromUpload(page, claimsFile, { deadlineSelector = "#s
 
   await page.locator("#uploadClaimsFileInput").setInputFiles(claimsFile);
   await setFutureDeadline(page, deadlineSelector);
-  await page.getByRole("button", { name: "Fund Contract" }).click();
+  await page.getByRole("button", { name: "Save Round to DB" }).click();
+  await page.getByRole("button", { name: "Fund Total" }).first().click();
   await page.getByText("Fund airdrop complete.").waitFor();
-  await page.getByRole("button", { name: "Start New Airdrop" }).click();
+  await page.getByRole("button", { name: "Deploy" }).first().click();
   await expect(page.locator("#currentEpoch")).toHaveText(String(currentEpoch + 1));
+  await expect(page.locator("#epochListBody")).toContainText("DB + Chain");
+  await page.getByRole("button", { name: "Prepare" }).click();
 }
 
 module.exports = {

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -84,8 +84,32 @@
           </article>
         </div>
 
-        <p id="adminGateMessage" class="hint">Connect the owner wallet to view admin controls.</p>
+        <p id="adminGateMessage" class="hint">Connect the owner or pending owner wallet to view admin controls.</p>
         <button id="switchNetworkGateButton" type="button" class="ghost" hidden>Switch to Configured Network</button>
+      </section>
+
+      <section id="pendingOwnerShell" class="frame" hidden>
+        <div class="panel-title-row">
+          <div>
+            <h2>Accept Ownership</h2>
+            <p class="hint">This wallet is the pending owner. Accept ownership here to unlock the full admin workspace.</p>
+          </div>
+        </div>
+
+        <div class="detail-list">
+          <article class="detail-item">
+            <h3>Current Owner</h3>
+            <p id="pendingOwnershipCurrentOwner">-</p>
+          </article>
+          <article class="detail-item">
+            <h3>Pending Owner</h3>
+            <p id="pendingOwnershipPendingOwner">-</p>
+          </article>
+        </div>
+
+        <div class="button-row">
+          <button id="pendingAcceptOwnershipButton" type="button">Accept Ownership</button>
+        </div>
       </section>
 
       <div id="adminShell" hidden>

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -89,308 +89,399 @@
       </section>
 
       <div id="adminShell" hidden>
-        <section class="frame status-panel">
+        <section class="frame admin-tabs-shell">
           <div class="panel-title-row">
             <div>
-              <h2>Contract Status</h2>
+              <h2>Admin Workspace</h2>
+              <p class="hint">Save rounds to the database first, then deploy them from the rounds tab when you are ready. Drafts do not reserve an epoch.</p>
             </div>
             <button id="refreshButton" type="button" class="ghost">Refresh</button>
           </div>
 
-          <div class="status-grid">
-            <article><h3>Current Epoch</h3><p id="currentEpoch">-</p></article>
-            <article><h3>Token</h3><p id="tokenSummary">-</p></article>
-            <article><h3>Wallet Token Balance</h3><p id="walletTokenBalance">-</p></article>
-            <article><h3>Airdrop Token Balance</h3><p id="airdropTokenBalance">-</p></article>
+          <div class="detail-list admin-summary-list">
+            <article class="detail-item">
+              <h3>Latest Epoch</h3>
+              <p id="currentEpoch">-</p>
+            </article>
+            <article class="detail-item">
+              <h3>Token</h3>
+              <p id="tokenSummary">-</p>
+            </article>
+            <article class="detail-item">
+              <h3>Wallet LIB</h3>
+              <p id="walletTokenBalance">-</p>
+            </article>
+            <article class="detail-item">
+              <h3>Airdrop LIB</h3>
+              <p id="airdropTokenBalance">-</p>
+            </article>
+          </div>
+
+          <div class="admin-tabs" role="tablist" aria-label="Admin sections">
+            <button type="button" class="admin-tab-button" data-admin-tab="prepare" aria-selected="true">Prepare</button>
+            <button type="button" class="admin-tab-button" data-admin-tab="rounds" aria-selected="false">Rounds</button>
+            <button type="button" class="admin-tab-button" data-admin-tab="contract" aria-selected="false">Contract</button>
+            <button type="button" class="admin-tab-button" data-admin-tab="lookups" aria-selected="false">Lookups</button>
           </div>
         </section>
 
-        <section class="frame">
-          <div class="panel-title-row">
-            <div>
-              <h2>Prepare New Airdrop</h2>
-            </div>
-          </div>
-
-          <div class="builder-shell">
-            <div class="subsection-header">
+        <div class="admin-tab-panel" data-admin-panel="prepare">
+          <section class="frame">
+            <div class="panel-title-row">
               <div>
-                <h3>Build Claims JSON</h3>
-                <p class="hint">Create the raw claims list here, then start the airdrop. After the transaction confirms, the verified round is stored in the backend automatically.</p>
+                <h2>Prepare New Airdrop</h2>
+                <p class="hint">Build or upload a claims set here, save it to the database, then fund and deploy the saved draft from the rounds tab.</p>
               </div>
             </div>
 
-            <form id="claimsBuilderForm" class="form-grid builder-form" autocomplete="off">
+            <div class="builder-shell">
+              <div class="subsection-header">
+                <div>
+                  <h3>Build Claims JSON</h3>
+                  <p class="hint">Create the raw claims list here. Saving the draft first protects the proofs if the page refreshes before deployment.</p>
+                </div>
+              </div>
+
+              <form id="claimsBuilderForm" class="form-grid builder-form" autocomplete="off">
+                <label>
+                  <span>Download File Name</span>
+                  <input id="builderFileNameInput" type="text" placeholder="round-1.claims.json">
+                </label>
+                <div class="full-width button-row">
+                  <button id="loadBuilderButton" type="button">Use Built Claims</button>
+                  <button id="downloadBuilderButton" type="button" class="secondary">Download JSON</button>
+                  <button id="clearBuilderButton" type="button" class="ghost">Clear Table</button>
+                </div>
+                <p class="hint full-width">Indexes are assigned automatically when the JSON is generated. Enter token amounts in human units.</p>
+              </form>
+
+              <div class="detail-list builder-summary-list">
+                <article class="detail-item">
+                  <h3>Wallets</h3>
+                  <p id="builderClaimCount">-</p>
+                </article>
+                <article class="detail-item">
+                  <h3>Total</h3>
+                  <p id="builderClaimTotal">-</p>
+                </article>
+                <article class="detail-item">
+                  <h3>Merkle Root</h3>
+                  <p id="builderMerkleRoot">-</p>
+                </article>
+              </div>
+
+              <div class="table-wrap builder-table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Index</th>
+                      <th>Wallet</th>
+                      <th>Amount</th>
+                      <th>Action</th>
+                    </tr>
+                  </thead>
+                  <tbody id="claimsBuilderBody">
+                    <tr><td colspan="4" class="empty-row">Add wallet rows to build a claims JSON file.</td></tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <div class="button-row builder-table-actions">
+                <button id="addBuilderRowButton" type="button" class="ghost">Add Row</button>
+                <p id="builderValidationMessage" class="form-warning builder-inline-warning" hidden></p>
+              </div>
+
+              <div class="builder-divider" aria-hidden="true"></div>
+
+              <div class="subsection-header">
+                <div>
+                  <h3>Upload Existing Claims JSON</h3>
+                  <p class="hint">Use this when the raw claims list was prepared outside the admin page.</p>
+                </div>
+              </div>
+            </div>
+
+            <form id="startAirdropForm" class="form-grid">
+              <label class="full-width">
+                <span>Claims JSON</span>
+                <input id="uploadClaimsFileInput" type="file" accept=".json,application/json">
+              </label>
+              <label class="full-width">
+                <span>Merkle Root</span>
+                <input id="startRootInput" type="text" placeholder="Upload or build a claims JSON file" readonly>
+              </label>
+              <p id="startRootWarning" class="form-warning full-width" hidden></p>
               <label>
-                <span>Download File Name</span>
-                <input id="builderFileNameInput" type="text" placeholder="round-1.claims.json">
+                <span>Deadline (local time)</span>
+                <input id="startDeadlineInput" type="datetime-local">
+              </label>
+              <label>
+                <span>Deadline (UTC)</span>
+                <input id="startDeadlineUtcInput" type="datetime-local">
+              </label>
+              <label>
+                <span>Unix Deadline</span>
+                <input id="startDeadlineUnix" type="text" readonly>
               </label>
               <div class="full-width button-row">
-                <button id="loadBuilderButton" type="button">Use Built Claims</button>
-                <button id="downloadBuilderButton" type="button" class="secondary">Download JSON</button>
-                <button id="clearBuilderButton" type="button" class="ghost">Clear Table</button>
+                <button id="startAirdropButton" type="submit">Save Round to DB</button>
+                <button id="clearUploadedButton" type="button" class="ghost" disabled>Clear Claims</button>
               </div>
-              <p class="hint full-width">Indexes are assigned automatically when the JSON is generated. Enter token amounts in human units.</p>
             </form>
 
-            <div class="detail-list builder-summary-list">
-              <article class="detail-item">
-                <h3>Wallets</h3>
-                <p id="builderClaimCount">-</p>
-              </article>
-              <article class="detail-item">
-                <h3>Total</h3>
-                <p id="builderClaimTotal">-</p>
-              </article>
-              <article class="detail-item">
-                <h3>Merkle Root</h3>
-                <p id="builderMerkleRoot">-</p>
-              </article>
-            </div>
-
-            <div class="table-wrap builder-table-wrap">
+            <div class="table-wrap upload-preview-wrap">
               <table>
                 <thead>
                   <tr>
                     <th>Index</th>
                     <th>Wallet</th>
                     <th>Amount</th>
-                    <th>Action</th>
                   </tr>
                 </thead>
-                <tbody id="claimsBuilderBody">
-                  <tr><td colspan="4" class="empty-row">Add wallet rows to build a claims JSON file.</td></tr>
+                <tbody id="uploadPreviewBody">
+                  <tr><td colspan="3" class="empty-row">Upload or build a claims JSON file to preview it.</td></tr>
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <td colspan="2" id="uploadedClaimCount" class="table-footer-label">-</td>
+                    <td class="table-footer-value">
+                      <div class="table-footer-actions">
+                        <span id="uploadedClaimTotal">-</span>
+                      </div>
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </section>
+        </div>
+
+        <div class="admin-tab-panel" data-admin-panel="rounds" hidden>
+          <section class="frame">
+            <div class="panel-title-row">
+              <div>
+                <h2>Airdrop Rounds</h2>
+                <p class="hint">Drafts come from the database. Deployed rows are merged with onchain epochs so you can see what is live, what is only saved, and what still needs funding or deployment.</p>
+              </div>
+            </div>
+
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Round</th>
+                    <th>Merkle Root</th>
+                    <th>Deadline</th>
+                    <th>Status</th>
+                    <th>Total</th>
+                    <th>Source</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="epochListBody">
+                  <tr><td colspan="7" class="empty-row">No rounds found yet.</td></tr>
                 </tbody>
               </table>
             </div>
+          </section>
 
-            <div class="button-row builder-table-actions">
-              <button id="addBuilderRowButton" type="button" class="ghost">Add Row</button>
-              <p id="builderValidationMessage" class="form-warning builder-inline-warning" hidden></p>
-            </div>
-
-            <div class="builder-divider" aria-hidden="true"></div>
-
-            <div class="subsection-header">
+          <section id="roundClaimsSection" class="frame">
+            <div class="panel-title-row">
               <div>
-                <h3>Upload Existing Claims JSON</h3>
-                <p class="hint">Use this when the raw claims list was prepared outside the admin page.</p>
+                <h2>Round Claims</h2>
+                <p id="selectedRoundMeta" class="hint">Choose a stored round to inspect its claim entries.</p>
               </div>
+              <button id="refreshRoundClaimsStatusButton" type="button" class="ghost" disabled>Load Claimed Status</button>
             </div>
-          </div>
 
-          <form id="startAirdropForm" class="form-grid">
-            <label class="full-width">
-              <span>Claims JSON</span>
-              <input id="uploadClaimsFileInput" type="file" accept=".json,application/json">
-            </label>
-            <label class="full-width">
-              <span>Merkle Root</span>
-              <input id="startRootInput" type="text" placeholder="Upload or build a claims JSON file" readonly>
-            </label>
-            <p id="startRootWarning" class="form-warning full-width" hidden></p>
-            <label>
-              <span>Deadline (local time)</span>
-              <input id="startDeadlineInput" type="datetime-local">
-            </label>
-            <label>
-              <span>Deadline (UTC)</span>
-              <input id="startDeadlineUtcInput" type="datetime-local">
-            </label>
-            <label>
-              <span>Unix Deadline</span>
-              <input id="startDeadlineUnix" type="text" readonly>
-            </label>
-            <div class="full-width button-row">
-              <button id="startAirdropButton" type="submit">Start New Airdrop</button>
-              <button id="clearUploadedButton" type="button" class="ghost" disabled>Clear Claims</button>
+            <div class="detail-list builder-summary-list">
+              <article class="detail-item">
+                <h3>Selected Round</h3>
+                <p id="selectedRoundLabel">None selected</p>
+              </article>
+              <article class="detail-item">
+                <h3>Claim Rows</h3>
+                <p id="selectedRoundClaimCount">-</p>
+              </article>
+              <article class="detail-item">
+                <h3>Total</h3>
+                <p id="selectedRoundTotal">-</p>
+              </article>
             </div>
-          </form>
 
-          <div class="table-wrap upload-preview-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th>Index</th>
-                  <th>Wallet</th>
-                  <th>Amount</th>
-                </tr>
-              </thead>
-              <tbody id="uploadPreviewBody">
-                <tr><td colspan="3" class="empty-row">Upload or build a claims JSON file to preview it.</td></tr>
-              </tbody>
-              <tfoot>
-                <tr>
-                  <td colspan="2" id="uploadedClaimCount" class="table-footer-label">-</td>
-                  <td class="table-footer-value">
-                    <div class="table-footer-actions">
-                      <span id="uploadedClaimTotal">-</span>
-                      <button id="fundUploadedButton" type="button" class="secondary" disabled>Fund Contract</button>
-                    </div>
-                  </td>
-                </tr>
-              </tfoot>
-            </table>
-          </div>
-        </section>
-
-        <section class="frame">
-          <div class="panel-title-row">
-            <div>
-              <h2>Epoch Management</h2>
+            <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Claim Index</th>
+                      <th>Username</th>
+                      <th>Wallet</th>
+                      <th>Amount</th>
+                    <th>Claimed</th>
+                  </tr>
+                </thead>
+                <tbody id="roundClaimsBody">
+                  <tr><td colspan="5" class="empty-row">Select a stored round to view its claims.</td></tr>
+                </tbody>
+              </table>
             </div>
-          </div>
+          </section>
+        </div>
 
-          <form id="updateDeadlineForm" class="form-grid">
-            <label>
-              <span>Epoch</span>
-              <input id="updateEpochInput" type="number" min="1" placeholder="1">
-            </label>
-            <label>
-              <span>Deadline (local time)</span>
-              <input id="updateDeadlineInput" type="datetime-local">
-            </label>
-            <label>
-              <span>Deadline (UTC)</span>
-              <input id="updateDeadlineUtcInput" type="datetime-local">
-            </label>
-            <label>
-              <span>Unix Deadline</span>
-              <input id="updateDeadlineUnix" type="text" readonly>
-            </label>
-            <div class="full-width button-row">
-              <button type="submit">Update Deadline</button>
-              <button id="disableEpochButton" type="button" class="danger">Disable Epoch</button>
-            </div>
-          </form>
-
-          <div class="panel-title-row">
-            <div>
-              <h2>Treasury</h2>
-            </div>
-          </div>
-
-          <div class="card-grid">
-            <form id="fundAirdropForm" class="card-form">
-              <h3>Fund Airdrop Contract</h3>
-              <label><span>Amount</span><input id="fundAirdropAmount" type="text" placeholder="100"></label>
-              <button type="submit">Transfer LIB to Airdrop</button>
-            </form>
-
-            <form id="withdrawForm" class="card-form">
-              <h3>Withdraw LIB</h3>
-              <label><span>Recipient</span><input id="withdrawRecipient" type="text" placeholder="0x..."></label>
-              <label><span>Amount</span><input id="withdrawAmount" type="text" placeholder="10"></label>
-              <button type="submit">Withdraw</button>
-            </form>
-
-            <form id="recoverForm" class="card-form">
-              <h3>Recover ERC20</h3>
-              <label><span>ERC20 Address</span><input id="recoverTokenAddress" type="text" placeholder="0x..."></label>
-              <label><span>Recipient</span><input id="recoverRecipient" type="text" placeholder="0x..."></label>
-              <label><span>Amount</span><input id="recoverAmount" type="text" placeholder="5"></label>
-              <button type="submit">Recover Token</button>
-            </form>
-          </div>
-        </section>
-
-        <section class="frame">
-          <div class="panel-title-row">
-            <div>
-              <h2>All Epochs</h2>
-            </div>
-          </div>
-
-          <div class="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th>Epoch</th>
-                  <th>Merkle Root</th>
-                  <th>Deadline</th>
-                  <th>Status</th>
-                  <th>Claimed / Total</th>
-                </tr>
-              </thead>
-              <tbody id="epochListBody">
-                <tr><td colspan="5" class="empty-row">No epochs started yet.</td></tr>
-              </tbody>
-            </table>
-          </div>
-        </section>
-
-        <section class="split-shell">
+        <div class="admin-tab-panel" data-admin-panel="contract" hidden>
           <section class="frame">
             <div class="panel-title-row">
               <div>
-                <h2>Lookup Epoch</h2>
+                <h2>Epoch Management</h2>
               </div>
             </div>
 
-            <form id="epochQueryForm" class="card-form">
-              <label><span>Epoch</span><input id="queryEpochInput" type="number" min="1" placeholder="1"></label>
-              <button type="submit">Fetch Epoch Data</button>
-              <pre id="epochQueryResult" class="result-block">-</pre>
+            <form id="updateDeadlineForm" class="form-grid">
+              <label>
+                <span>Epoch</span>
+                <input id="updateEpochInput" type="number" min="1" placeholder="1">
+              </label>
+              <label>
+                <span>Deadline (local time)</span>
+                <input id="updateDeadlineInput" type="datetime-local">
+              </label>
+              <label>
+                <span>Deadline (UTC)</span>
+                <input id="updateDeadlineUtcInput" type="datetime-local">
+              </label>
+              <label>
+                <span>Unix Deadline</span>
+                <input id="updateDeadlineUnix" type="text" readonly>
+              </label>
+              <div class="full-width button-row">
+                <button type="submit">Update Deadline</button>
+                <button id="disableEpochButton" type="button" class="danger">Disable Epoch</button>
+              </div>
             </form>
           </section>
 
           <section class="frame">
             <div class="panel-title-row">
               <div>
-                <h2>Check Claim Status</h2>
+                <h2>Treasury</h2>
               </div>
             </div>
 
-            <form id="claimStatusForm" class="card-form">
-              <label><span>Epoch</span><input id="claimedEpochInput" type="number" min="1" placeholder="1"></label>
-              <label><span>Index</span><input id="claimedIndexInput" type="number" min="0" placeholder="0"></label>
-              <button type="submit">Check Claim Status</button>
-              <pre id="claimStatusResult" class="result-block">-</pre>
-            </form>
-          </section>
-        </section>
+            <div class="card-grid">
+              <form id="fundAirdropForm" class="card-form">
+                <h3>Fund Airdrop Contract</h3>
+                <label><span>Amount</span><input id="fundAirdropAmount" type="text" placeholder="100"></label>
+                <button type="submit">Transfer LIB to Airdrop</button>
+              </form>
 
+              <form id="withdrawForm" class="card-form">
+                <h3>Withdraw LIB</h3>
+                <label><span>Recipient</span><input id="withdrawRecipient" type="text" placeholder="0x..."></label>
+                <label><span>Amount</span><input id="withdrawAmount" type="text" placeholder="10"></label>
+                <button type="submit">Withdraw</button>
+              </form>
+
+              <form id="recoverForm" class="card-form">
+                <h3>Recover ERC20</h3>
+                <label><span>ERC20 Address</span><input id="recoverTokenAddress" type="text" placeholder="0x..."></label>
+                <label><span>Recipient</span><input id="recoverRecipient" type="text" placeholder="0x..."></label>
+                <label><span>Amount</span><input id="recoverAmount" type="text" placeholder="5"></label>
+                <button type="submit">Recover Token</button>
+              </form>
+            </div>
+          </section>
+
+          <section id="ownershipShell" class="frame" hidden>
+            <div class="panel-title-row">
+              <div>
+                <h2>Ownership Transfer</h2>
+                <p class="hint">Ownable2Step uses two transactions: the current owner nominates a pending owner, then that pending owner accepts from their wallet.</p>
+              </div>
+            </div>
+
+            <div class="detail-list">
+              <article class="detail-item">
+                <h3>Current Owner</h3>
+                <p id="ownershipCurrentOwner">-</p>
+              </article>
+              <article class="detail-item">
+                <h3>Pending Owner</h3>
+                <p id="ownershipPendingOwner">-</p>
+              </article>
+              <article class="detail-item">
+                <h3>Connected Wallet</h3>
+                <p id="ownershipConnectedWallet">-</p>
+              </article>
+            </div>
+
+            <p id="ownershipStatusMessage" class="hint">Connect the owner or pending owner wallet on the configured network to manage ownership.</p>
+
+            <div class="card-grid ownership-grid">
+              <form id="transferOwnershipForm" class="card-form">
+                <h3>Set Pending Owner</h3>
+                <label><span>New Owner Address</span><input id="transferOwnershipAddress" type="text" placeholder="0x..."></label>
+                <button id="transferOwnershipButton" type="submit">Transfer Ownership</button>
+              </form>
+
+              <form id="acceptOwnershipForm" class="card-form">
+                <h3>Accept Ownership</h3>
+                <p class="hint">Only the pending owner can complete the second step.</p>
+                <button id="acceptOwnershipButton" type="submit">Accept Ownership</button>
+              </form>
+            </div>
+          </section>
+        </div>
+
+        <div class="admin-tab-panel" data-admin-panel="lookups" hidden>
+          <section class="split-shell">
+            <section class="frame">
+              <div class="panel-title-row">
+                <div>
+                  <h2>Lookup Epoch</h2>
+                </div>
+              </div>
+
+              <form id="epochQueryForm" class="card-form">
+                <label><span>Epoch</span><input id="queryEpochInput" type="number" min="1" placeholder="1"></label>
+                <button type="submit">Fetch Epoch Data</button>
+                <pre id="epochQueryResult" class="result-block">-</pre>
+              </form>
+            </section>
+
+            <section class="frame">
+              <div class="panel-title-row">
+                <div>
+                  <h2>Lookup Claim(s)</h2>
+                  <p class="hint">Enter a wallet address to list every stored claim tied to that address.</p>
+                </div>
+              </div>
+
+              <form id="claimStatusForm" class="card-form">
+                <label><span>Wallet Address</span><input id="claimLookupInput" type="text" placeholder="0x..."></label>
+                <button type="submit">Lookup Claim(s)</button>
+              </form>
+
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Round</th>
+                      <th>Claim Index</th>
+                      <th>Username</th>
+                      <th>Wallet</th>
+                      <th>Amount</th>
+                      <th>Claimed</th>
+                    </tr>
+                  </thead>
+                  <tbody id="claimLookupBody">
+                    <tr><td colspan="6" class="empty-row">Run a wallet lookup to view stored claims.</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </section>
+        </div>
       </div>
-
-      <section id="ownershipShell" class="frame" hidden>
-        <div class="panel-title-row">
-          <div>
-            <h2>Ownership Transfer</h2>
-            <p class="hint">Ownable2Step uses two transactions: the current owner nominates a pending owner, then that pending owner accepts from their wallet.</p>
-          </div>
-        </div>
-
-        <div class="detail-list">
-          <article class="detail-item">
-            <h3>Current Owner</h3>
-            <p id="ownershipCurrentOwner">-</p>
-          </article>
-          <article class="detail-item">
-            <h3>Pending Owner</h3>
-            <p id="ownershipPendingOwner">-</p>
-          </article>
-          <article class="detail-item">
-            <h3>Connected Wallet</h3>
-            <p id="ownershipConnectedWallet">-</p>
-          </article>
-        </div>
-
-        <p id="ownershipStatusMessage" class="hint">Connect the owner or pending owner wallet on the configured network to manage ownership.</p>
-
-        <div class="card-grid ownership-grid">
-          <form id="transferOwnershipForm" class="card-form">
-            <h3>Set Pending Owner</h3>
-            <label><span>New Owner Address</span><input id="transferOwnershipAddress" type="text" placeholder="0x..."></label>
-            <button id="transferOwnershipButton" type="submit">Transfer Ownership</button>
-          </form>
-
-          <form id="acceptOwnershipForm" class="card-form">
-            <h3>Accept Ownership</h3>
-            <p class="hint">Only the pending owner can complete the second step.</p>
-            <button id="acceptOwnershipButton" type="submit">Accept Ownership</button>
-          </form>
-        </div>
-      </section>
     </main>
 
     <script type="module" src="./js/pages/admin.js"></script>

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -30,10 +30,12 @@ import {
 import { promptForWalletSelection } from "../shared/wallet-picker.js";
 import {
   fetchStoredAirdropRounds,
-  fetchStoredClaimByEpochAndIndex,
+  fetchStoredRoundClaims,
+  fetchStoredClaimsByWallet,
   isClaimsApiConfigured,
-  persistAirdropRound,
-  requestAirdropFinalizeChallenge,
+  saveAirdropRound,
+  deploySavedAirdropRound,
+  requestAirdropSaveChallenge,
 } from "../shared/claims.js";
 import { buildClaimRound } from "../shared/merkle.js";
 
@@ -51,8 +53,13 @@ const runtime = {
   pendingOwner: null,
   currentEpoch: 0,
   epochRows: [],
-  claimSourcesByEpoch: new Map(),
-  claimSourcesByRoot: new Map(),
+  storedRounds: [],
+  storedRoundsByEpoch: new Map(),
+  storedRoundsByRoot: new Map(),
+  roundRows: [],
+  selectedRoundId: null,
+  selectedRoundClaims: [],
+  claimLookupRows: [],
   uploadedRound: null,
   builderRows: [],
   nextBuilderRowId: 1,
@@ -70,7 +77,7 @@ const runtime = {
   tokenDecimals: 18,
   tokenSymbol: "LIB",
   chainTimestamp: 0,
-  startRequiresNewUpload: false,
+  activeAdminTab: "prepare",
   isConnectingWallet: false,
   noticeTimerId: null,
 };
@@ -86,6 +93,8 @@ const els = {
   claimPageButton: document.getElementById("claimPageButton"),
   copyWalletAddressButton: document.getElementById("copyWalletAddressButton"),
   disconnectButton: document.getElementById("disconnectButton"),
+  adminTabButtons: [...document.querySelectorAll("[data-admin-tab]")],
+  adminTabPanels: [...document.querySelectorAll("[data-admin-panel]")],
   connectedAccount: document.getElementById("connectedAccount"),
   ownerAddress: document.getElementById("ownerAddress"),
   ownershipShell: document.getElementById("ownershipShell"),
@@ -128,7 +137,6 @@ const els = {
   uploadedClaimCount: document.getElementById("uploadedClaimCount"),
   uploadedClaimTotal: document.getElementById("uploadedClaimTotal"),
   uploadPreviewBody: document.getElementById("uploadPreviewBody"),
-  fundUploadedButton: document.getElementById("fundUploadedButton"),
   clearUploadedButton: document.getElementById("clearUploadedButton"),
   updateDeadlineForm: document.getElementById("updateDeadlineForm"),
   updateEpochInput: document.getElementById("updateEpochInput"),
@@ -146,13 +154,19 @@ const els = {
   recoverRecipient: document.getElementById("recoverRecipient"),
   recoverAmount: document.getElementById("recoverAmount"),
   epochListBody: document.getElementById("epochListBody"),
+  roundClaimsSection: document.getElementById("roundClaimsSection"),
+  refreshRoundClaimsStatusButton: document.getElementById("refreshRoundClaimsStatusButton"),
+  selectedRoundLabel: document.getElementById("selectedRoundLabel"),
+  selectedRoundMeta: document.getElementById("selectedRoundMeta"),
+  selectedRoundClaimCount: document.getElementById("selectedRoundClaimCount"),
+  selectedRoundTotal: document.getElementById("selectedRoundTotal"),
+  roundClaimsBody: document.getElementById("roundClaimsBody"),
   epochQueryForm: document.getElementById("epochQueryForm"),
   queryEpochInput: document.getElementById("queryEpochInput"),
   epochQueryResult: document.getElementById("epochQueryResult"),
   claimStatusForm: document.getElementById("claimStatusForm"),
-  claimedEpochInput: document.getElementById("claimedEpochInput"),
-  claimedIndexInput: document.getElementById("claimedIndexInput"),
-  claimStatusResult: document.getElementById("claimStatusResult"),
+  claimLookupInput: document.getElementById("claimLookupInput"),
+  claimLookupBody: document.getElementById("claimLookupBody"),
   adminToast: document.getElementById("adminToast"),
   adminToastMessage: document.getElementById("adminToastMessage"),
   adminToastClose: document.getElementById("adminToastClose"),
@@ -440,8 +454,10 @@ function resetClaimsBuilder({ preserveFileName = false } = {}) {
 }
 
 function applyUploadedRound(round, { clearUploadInput = false } = {}) {
-  runtime.uploadedRound = round;
-  runtime.startRequiresNewUpload = false;
+  runtime.uploadedRound = {
+    storedRoundId: round?.storedRoundId || null,
+    ...round,
+  };
   if (clearUploadInput) {
     els.uploadClaimsFileInput.value = "";
   }
@@ -492,11 +508,45 @@ function getMatchingEpochsForRoot(root) {
     .sort((left, right) => right - left);
 }
 
+function getStoredRoundsForRoot(root) {
+  if (!ethers.isHexString(root, 32)) return [];
+  return runtime.storedRoundsByRoot.get(root.toLowerCase()) || [];
+}
+
+function formatStoredRoundLabel(round) {
+  if (!round) return "-";
+  if (round.status === "draft") return "Draft";
+  if (round.epoch != null) return `Epoch ${round.epoch}`;
+  return "Saved";
+}
+
+function formatSelectedRoundLabel(round) {
+  const baseLabel = formatStoredRoundLabel(round);
+  if (!round?.merkleRoot) return baseLabel;
+  return `${baseLabel} - ${formatHexShort(round.merkleRoot)}`;
+}
+
+function scrollRoundClaimsSectionIntoView() {
+  if (!els.roundClaimsSection) return;
+
+  window.requestAnimationFrame(() => {
+    els.roundClaimsSection.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  });
+}
+
 function updateStartRootWarning() {
   if (!els.startRootWarning) return;
 
   const root = els.startRootInput.value.trim();
   const matchingEpochs = getMatchingEpochsForRoot(root);
+  const matchingStoredRounds = getStoredRoundsForRoot(root);
+  const matchingDrafts = matchingStoredRounds.filter((round) => round.status === "draft");
+  const matchingSavedRound = runtime.uploadedRound?.storedRoundId
+    ? runtime.storedRounds.find((round) => round.id === runtime.uploadedRound.storedRoundId) || null
+    : null;
   const epochLabel = matchingEpochs.length === 1
     ? `epoch ${matchingEpochs[0]}`
     : `epochs ${matchingEpochs.join(", ")}`;
@@ -504,14 +554,19 @@ function updateStartRootWarning() {
   let message = "";
   let tone = "warn";
 
-  if (runtime.startRequiresNewUpload && runtime.uploadedRound) {
-    message = "This claims file was already started successfully. Prepare a new claims file before starting another airdrop.";
-    if (matchingEpochs.length) {
-      message += ` Matching Merkle root found in ${epochLabel}.`;
-    }
+  if (matchingSavedRound) {
+    const savedLabel = matchingSavedRound.status === "draft"
+      ? "a saved draft"
+      : formatStoredRoundLabel(matchingSavedRound).toLowerCase();
+    message = `This claims file is already saved as ${savedLabel}. Deploy it from the rounds tab when you are ready.`;
     tone = "info";
+  } else if (matchingDrafts.length) {
+    const draftLabel = matchingDrafts.length === 1
+      ? "another saved draft"
+      : `${matchingDrafts.length} saved drafts`;
+    message = `Warning: this Merkle root already exists in ${draftLabel}. Saving another draft is allowed, but drafts do not reserve an epoch.`;
   } else if (matchingEpochs.length) {
-    message = `Warning: this Merkle root already exists in ${epochLabel}. Starting it again is allowed, but verify you are not re-submitting the same airdrop.`;
+    message = `Warning: this Merkle root already exists on chain in ${epochLabel}. Saving it again is allowed, but verify you are not re-submitting the same airdrop.`;
   }
 
   if (!message) {
@@ -530,13 +585,14 @@ function updateStartAirdropButtonState() {
   const hasRound = Boolean(runtime.uploadedRound);
   const hasRoot = ethers.isHexString(els.startRootInput.value.trim(), 32);
   const hasDeadline = Number.isFinite(Number(els.startDeadlineUnix.value)) && Number(els.startDeadlineUnix.value) > 0;
+  const alreadySaved = Boolean(runtime.uploadedRound?.storedRoundId);
   const canSubmit = isOwner()
     && isReadyChain()
     && isClaimsApiConfigured(runtime.config)
     && hasRound
     && hasRoot
     && hasDeadline
-    && !runtime.startRequiresNewUpload;
+    && !alreadySaved;
   els.startAirdropButton.disabled = !canSubmit;
   updateStartRootWarning();
 }
@@ -707,7 +763,6 @@ async function validateFutureDeadlineAgainstChain(deadlineUnix, { allowZero = fa
 
 function clearUploadedRoundState() {
   runtime.uploadedRound = null;
-  runtime.startRequiresNewUpload = false;
   els.startRootInput.value = "";
   els.uploadClaimsFileInput.value = "";
   renderUploadedRound();
@@ -721,7 +776,6 @@ function renderUploadedRound() {
     els.uploadedClaimCount.textContent = "-";
     els.uploadedClaimTotal.textContent = "-";
     els.uploadPreviewBody.innerHTML = '<tr><td colspan="3" class="empty-row">Upload or build a claims JSON file to preview it.</td></tr>';
-    els.fundUploadedButton.disabled = true;
     els.clearUploadedButton.disabled = true;
     return;
   }
@@ -738,7 +792,6 @@ function renderUploadedRound() {
       </tr>
     `)
     .join("");
-  els.fundUploadedButton.disabled = false;
   els.clearUploadedButton.disabled = false;
 }
 
@@ -747,20 +800,27 @@ async function loadUploadedClaimsFile(file) {
   applyUploadedRound(buildClaimRound(rawText, runtime.tokenDecimals));
 }
 
-async function refreshCatalogRounds() {
-  runtime.claimSourcesByEpoch = new Map();
-  runtime.claimSourcesByRoot = new Map();
+async function refreshStoredRounds() {
+  runtime.storedRounds = [];
+  runtime.storedRoundsByEpoch = new Map();
+  runtime.storedRoundsByRoot = new Map();
 
   if (!isClaimsApiConfigured(runtime.config)) return;
 
   const payload = await fetchStoredAirdropRounds(runtime.config);
   const rounds = Array.isArray(payload?.rounds) ? payload.rounds : [];
+  runtime.storedRounds = rounds;
 
   for (const round of rounds) {
-    const entry = { epoch: round.epoch, source: null, round, errorMessage: "" };
-    runtime.claimSourcesByEpoch.set(round.epoch, entry);
+    if (round.status === "deployed" && Number.isInteger(round.epoch)) {
+      runtime.storedRoundsByEpoch.set(Number(round.epoch), round);
+    }
+
     if (round?.merkleRoot) {
-      runtime.claimSourcesByRoot.set(round.merkleRoot.toLowerCase(), entry);
+      const rootKey = round.merkleRoot.toLowerCase();
+      const rootMatches = runtime.storedRoundsByRoot.get(rootKey) || [];
+      rootMatches.push(round);
+      runtime.storedRoundsByRoot.set(rootKey, rootMatches);
     }
   }
 }
@@ -771,28 +831,280 @@ function formatClaimedDisplay(claimedAmount, totalAmountRaw) {
   return `${claimedText} / ${formatTokenAmount(totalAmountRaw, runtime.tokenDecimals, runtime.tokenSymbol)}`;
 }
 
-function renderEpochList() {
-  if (!runtime.epochRows.length) {
-    els.epochListBody.innerHTML = '<tr><td colspan="5" class="empty-row">No epochs started yet.</td></tr>';
+function formatRoundTotalDisplay(row) {
+  if (row.claimedAmount != null) {
+    return formatClaimedDisplay(row.claimedAmount, row.totalAmountRaw);
+  }
+
+  if (row.totalAmountRaw != null) {
+    return formatTokenAmount(row.totalAmountRaw, runtime.tokenDecimals, runtime.tokenSymbol);
+  }
+
+  return "-";
+}
+
+function doesStoredRoundMatchChainRow(storedRound, chainRow) {
+  if (!storedRound || !chainRow) return false;
+
+  return String(storedRound.merkleRoot || "").toLowerCase() === String(chainRow.root || "").toLowerCase();
+}
+
+function getRoundRowStatus(row) {
+  if (row.rowType === "draft") {
+    return { tone: "neutral", text: "Draft" };
+  }
+
+  if (row.rowType === "stored-only") {
+    return { tone: "error", text: "Missing on chain" };
+  }
+
+  return {
+    tone: getEpochStatusTone(row.deadline),
+    text: getEpochStatus(row.deadline),
+  };
+}
+
+function sortDraftRounds(left, right) {
+  return String(right.updatedAt || "").localeCompare(String(left.updatedAt || ""));
+}
+
+function sortDeployedRounds(left, right) {
+  const leftEpoch = Number(left.epoch || 0);
+  const rightEpoch = Number(right.epoch || 0);
+  if (leftEpoch !== rightEpoch) {
+    return rightEpoch - leftEpoch;
+  }
+
+  return String(right.updatedAt || "").localeCompare(String(left.updatedAt || ""));
+}
+
+function buildRoundRows() {
+  const rows = [];
+  const matchedStoredRoundIds = new Set();
+  const draftRounds = runtime.storedRounds
+    .filter((round) => round.status === "draft")
+    .sort(sortDraftRounds);
+
+  for (const round of draftRounds) {
+    rows.push({
+      key: `draft-${round.id}`,
+      rowType: "draft",
+      roundId: round.id,
+      label: "Draft",
+      root: round.merkleRoot,
+      deadline: Number(round.deadline || 0),
+      claimedAmount: null,
+      totalAmountRaw: BigInt(round.totalAmountRaw),
+      sourceText: "DB draft",
+      canFundTotal: true,
+      canDeploy: true,
+      canViewClaims: true,
+    });
+  }
+
+  for (const chainRow of runtime.epochRows) {
+    const storedRound = runtime.storedRoundsByEpoch.get(Number(chainRow.epoch)) || null;
+    const matchesStoredRound = doesStoredRoundMatchChainRow(storedRound, chainRow);
+    if (matchesStoredRound) {
+      matchedStoredRoundIds.add(storedRound.id);
+    }
+
+    rows.push({
+      key: matchesStoredRound ? `round-${storedRound.id}` : `chain-${chainRow.epoch}`,
+      rowType: matchesStoredRound ? "deployed" : "chain-only",
+      roundId: matchesStoredRound ? storedRound.id : null,
+      label: `Epoch ${chainRow.epoch}`,
+      root: chainRow.root,
+      deadline: Number(chainRow.deadline || 0),
+      claimedAmount: chainRow.claimedAmount,
+      totalAmountRaw: matchesStoredRound ? BigInt(storedRound.totalAmountRaw) : chainRow.totalAmountRaw,
+      sourceText: matchesStoredRound ? "DB + Chain" : "Chain only",
+      canFundTotal: matchesStoredRound,
+      canDeploy: false,
+      canViewClaims: Boolean(matchesStoredRound),
+    });
+  }
+
+  const storedOnlyRounds = runtime.storedRounds
+    .filter((round) => round.status === "deployed" && !matchedStoredRoundIds.has(round.id))
+    .sort(sortDeployedRounds);
+
+  for (const round of storedOnlyRounds) {
+    rows.push({
+      key: `stored-${round.id}`,
+      rowType: "stored-only",
+      roundId: round.id,
+      label: formatStoredRoundLabel(round),
+      root: round.merkleRoot,
+      deadline: Number(round.deadline || 0),
+      claimedAmount: null,
+      totalAmountRaw: BigInt(round.totalAmountRaw),
+      sourceText: "DB only",
+      canFundTotal: true,
+      canDeploy: false,
+      canViewClaims: true,
+    });
+  }
+
+  return rows;
+}
+
+function formatClaimState(record) {
+  if (record.claimed === true || record.entry?.claimedAt || record.entry?.claimedTxHash) {
+    return "Claimed";
+  }
+
+  if (record.claimed === false) {
+    return "Unclaimed";
+  }
+
+  if (record.round?.status === "draft") {
+    return "Draft";
+  }
+
+  return "Unknown";
+}
+
+function renderSelectedRoundClaims() {
+  if (!runtime.selectedRoundId) {
+    els.selectedRoundLabel.textContent = "None selected";
+    els.selectedRoundLabel.title = "";
+    els.selectedRoundMeta.textContent = "Choose a stored round to inspect its claim entries.";
+    els.selectedRoundClaimCount.textContent = "-";
+    els.selectedRoundTotal.textContent = "-";
+    els.roundClaimsBody.innerHTML = '<tr><td colspan="5" class="empty-row">Select a stored round to view its claims.</td></tr>';
+    els.refreshRoundClaimsStatusButton.disabled = true;
     return;
   }
 
-  els.epochListBody.innerHTML = runtime.epochRows
-    .map((row) => `
+  const selectedRound = runtime.storedRounds.find((round) => round.id === runtime.selectedRoundId) || null;
+  if (!selectedRound) {
+    runtime.selectedRoundId = null;
+    runtime.selectedRoundClaims = [];
+    renderSelectedRoundClaims();
+    return;
+  }
+
+  const claimCount = runtime.selectedRoundClaims.length;
+  els.selectedRoundLabel.textContent = formatSelectedRoundLabel(selectedRound);
+  els.selectedRoundLabel.title = selectedRound.merkleRoot || formatStoredRoundLabel(selectedRound);
+  els.selectedRoundMeta.textContent = selectedRound.status === "draft"
+    ? "Claim indexes match the contract leaf indexes. Claimed status is only available after deployment."
+    : "Claim indexes match the contract leaf indexes. Use Load Claimed Status to query the contract for this round.";
+  els.selectedRoundClaimCount.textContent = claimCount === 1 ? "1 claim" : `${claimCount} claims`;
+  els.selectedRoundTotal.textContent = formatTokenAmount(
+    BigInt(selectedRound.totalAmountRaw),
+    runtime.tokenDecimals,
+    runtime.tokenSymbol,
+  );
+  els.refreshRoundClaimsStatusButton.disabled = !(selectedRound.status === "deployed" && claimCount > 0);
+
+  if (!claimCount) {
+    els.roundClaimsBody.innerHTML = '<tr><td colspan="5" class="empty-row">No claims were found for this round.</td></tr>';
+    return;
+  }
+
+  els.roundClaimsBody.innerHTML = runtime.selectedRoundClaims
+    .map((record) => `
       <tr>
-        <td>${row.epoch}</td>
-        <td><code title="${row.root}">${formatHexShort(row.root)}</code></td>
-        <td>
-          <div class="deadline-stack">
-            <div><span>Local:</span> ${formatAdminDeadlineLocal(row.deadline)}</div>
-            <div><span>UTC:</span> ${formatAdminDeadlineUtc(row.deadline)}</div>
-          </div>
-        </td>
-        <td><span class="status-chip" data-tone="${getEpochStatusTone(row.deadline)}">${getEpochStatus(row.deadline)}</span></td>
-        <td>${formatClaimedDisplay(row.claimedAmount, row.totalAmountRaw)}</td>
+        <td>${record.entry?.index ?? "-"}</td>
+        <td>${escapeHtml(record.entry?.usernameDisplay || "-")}</td>
+        <td><code title="${record.entry?.account || ""}">${record.entry?.account ? formatAddressShort(record.entry.account) : "-"}</code></td>
+        <td>${record.entry?.amountRaw ? formatTokenAmount(BigInt(record.entry.amountRaw), runtime.tokenDecimals, runtime.tokenSymbol) : "-"}</td>
+        <td>${formatClaimState(record)}</td>
       </tr>
     `)
     .join("");
+}
+
+function renderClaimLookupResults() {
+  if (!runtime.claimLookupRows.length) {
+    els.claimLookupBody.innerHTML = '<tr><td colspan="6" class="empty-row">Run a wallet lookup to view stored claims.</td></tr>';
+    return;
+  }
+
+  els.claimLookupBody.innerHTML = runtime.claimLookupRows
+    .map((record) => {
+      const roundLabel = formatStoredRoundLabel(record.round);
+
+      return `
+        <tr>
+          <td>${escapeHtml(roundLabel)}</td>
+          <td>${record.entry?.index ?? "-"}</td>
+          <td>${escapeHtml(record.entry?.usernameDisplay || "-")}</td>
+          <td><code title="${record.entry?.account || ""}">${record.entry?.account ? formatAddressShort(record.entry.account) : "-"}</code></td>
+          <td>${record.entry?.amountRaw ? formatTokenAmount(BigInt(record.entry.amountRaw), runtime.tokenDecimals, runtime.tokenSymbol) : "-"}</td>
+          <td>${formatClaimState(record)}</td>
+        </tr>
+      `;
+    })
+    .join("");
+}
+
+function renderEpochList() {
+  runtime.roundRows = buildRoundRows();
+
+  if (!runtime.roundRows.length) {
+    els.epochListBody.innerHTML = '<tr><td colspan="7" class="empty-row">No rounds found yet.</td></tr>';
+    return;
+  }
+
+  els.epochListBody.innerHTML = runtime.roundRows
+    .map((row) => {
+      const status = getRoundRowStatus(row);
+      return `
+        <tr>
+          <td>${escapeHtml(row.label)}</td>
+          <td><code title="${row.root}">${formatHexShort(row.root)}</code></td>
+          <td>
+            <div class="deadline-stack">
+              <div><span>Local:</span> ${formatAdminDeadlineLocal(row.deadline)}</div>
+              <div><span>UTC:</span> ${formatAdminDeadlineUtc(row.deadline)}</div>
+            </div>
+          </td>
+          <td><span class="status-chip" data-tone="${status.tone}">${status.text}</span></td>
+          <td>${formatRoundTotalDisplay(row)}</td>
+          <td>${escapeHtml(row.sourceText)}</td>
+          <td class="round-action-cell">
+            ${row.canDeploy ? `<button type="button" class="secondary table-action-button" data-round-deploy="${row.roundId}">Deploy</button>` : ""}
+            ${row.canFundTotal ? `<button type="button" class="ghost table-action-button" data-round-fund="${row.roundId}">Fund Total</button>` : ""}
+            ${row.canViewClaims ? `<button type="button" class="ghost table-action-button" data-round-claims="${row.roundId}">View Claims</button>` : ""}
+            ${!row.canDeploy && !row.canFundTotal && !row.canViewClaims ? '<span class="hint">No DB record</span>' : ""}
+          </td>
+        </tr>
+      `;
+    })
+    .join("");
+
+  els.epochListBody.querySelectorAll("[data-round-deploy]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      try {
+        await deployStoredRound(Number(button.getAttribute("data-round-deploy")));
+      } catch (error) {
+        reportError(error, "Deploy saved round");
+      }
+    });
+  });
+
+  els.epochListBody.querySelectorAll("[data-round-fund]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      try {
+        await fundStoredRoundTotal(Number(button.getAttribute("data-round-fund")));
+      } catch (error) {
+        reportError(error, "Fund round total");
+      }
+    });
+  });
+
+  els.epochListBody.querySelectorAll("[data-round-claims]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      try {
+        await loadRoundClaims(Number(button.getAttribute("data-round-claims")), { scrollIntoView: true });
+      } catch (error) {
+        reportError(error, "Load round claims");
+      }
+    });
+  });
 }
 
 function applyOwnershipSection() {
@@ -836,13 +1148,11 @@ async function refreshEpochRows() {
   runtime.epochRows = [];
 
   if (!runtime.provider || runtime.currentEpoch <= 0) {
-    renderEpochList();
     return;
   }
 
   const { airdrop } = getContracts({ config: runtime.config, provider: runtime.provider });
   if (!airdrop) {
-    renderEpochList();
     return;
   }
 
@@ -850,10 +1160,7 @@ async function refreshEpochRows() {
   runtime.epochRows = await Promise.all(
     epochIds.map(async (epoch) => {
       const [root, deadline, claimedAmount] = await airdrop.epochInfo(BigInt(epoch));
-      const localSource = runtime.claimSourcesByEpoch.get(epoch)
-        || runtime.claimSourcesByRoot.get(root.toLowerCase())
-        || null;
-      const localRound = localSource?.round;
+      const localRound = runtime.storedRoundsByEpoch.get(epoch) || null;
       const totalAmountRaw = localRound && localRound.merkleRoot.toLowerCase() === root.toLowerCase()
         ? BigInt(localRound.totalAmountRaw)
         : null;
@@ -867,8 +1174,25 @@ async function refreshEpochRows() {
       };
     }),
   );
+}
 
-  renderEpochList();
+function syncAdminTabs() {
+  const activeTab = runtime.activeAdminTab || "prepare";
+
+  els.adminTabButtons.forEach((button) => {
+    const isActive = button.getAttribute("data-admin-tab") === activeTab;
+    button.setAttribute("aria-selected", isActive ? "true" : "false");
+    button.classList.toggle("is-active", isActive);
+  });
+
+  els.adminTabPanels.forEach((panel) => {
+    panel.hidden = panel.getAttribute("data-admin-panel") !== activeTab;
+  });
+}
+
+function setAdminTab(tabId) {
+  runtime.activeAdminTab = tabId;
+  syncAdminTabs();
 }
 
 function applyOwnerGate() {
@@ -970,14 +1294,19 @@ async function refreshPage() {
     runtime.currentEpoch = 0;
   }
 
-  await refreshCatalogRounds().catch(() => {
-    runtime.claimSourcesByEpoch = new Map();
+  await refreshStoredRounds().catch(() => {
+    runtime.storedRounds = [];
+    runtime.storedRoundsByEpoch = new Map();
+    runtime.storedRoundsByRoot = new Map();
   });
 
   await refreshEpochRows().catch(() => {
     runtime.epochRows = [];
-    renderEpochList();
   });
+
+  renderEpochList();
+  renderSelectedRoundClaims();
+  syncAdminTabs();
 
   if (!runtime.builderRows.length) {
     resetClaimsBuilder();
@@ -992,11 +1321,7 @@ async function refreshPage() {
   updateStartAirdropButtonState();
 }
 
-async function fundUploadedRound() {
-  if (!runtime.uploadedRound) {
-    throw new Error("Prepare a claims JSON file first.");
-  }
-
+async function fundAirdropAmountRaw(amountRaw, label = "Fund airdrop") {
   const { token, airdropAddress } = getContracts({
     config: runtime.config,
     provider: runtime.provider,
@@ -1008,8 +1333,7 @@ async function fundUploadedRound() {
     throw new Error("Token and airdrop addresses must be configured.");
   }
 
-  const amountRaw = BigInt(runtime.uploadedRound.totalAmountRaw);
-  await sendTransaction("Fund airdrop", () => token.transfer(airdropAddress, amountRaw), {
+  await sendTransaction(label, () => token.transfer(airdropAddress, amountRaw), {
     log: logger.log,
     afterSuccess: async () => {
       await refreshPage();
@@ -1018,7 +1342,68 @@ async function fundUploadedRound() {
   });
 }
 
-async function startAirdropAndPersistRound() {
+async function fundStoredRoundTotal(roundId) {
+  const storedRound = runtime.storedRounds.find((round) => round.id === roundId) || null;
+  if (!storedRound) {
+    throw new Error("The selected stored round could not be found.");
+  }
+
+  await fundAirdropAmountRaw(BigInt(storedRound.totalAmountRaw));
+}
+
+async function loadClaimStatuses(records) {
+  if (!Array.isArray(records) || !records.length || !runtime.provider) {
+    return records || [];
+  }
+
+  const { airdrop } = getContracts({ config: runtime.config, provider: runtime.provider });
+  if (!airdrop) {
+    return records;
+  }
+
+  return Promise.all(
+    records.map(async (record) => {
+      if (record?.round?.status !== "deployed" || record?.round?.epoch == null || !record?.entry?.index) {
+        return { ...record, claimed: null };
+      }
+
+      try {
+        const claimed = await airdrop.isClaimed(BigInt(record.round.epoch), BigInt(record.entry.index));
+        return { ...record, claimed };
+      } catch {
+        return { ...record, claimed: null };
+      }
+    }),
+  );
+}
+
+async function loadRoundClaims(roundId, { scrollIntoView = false } = {}) {
+  if (!isClaimsApiConfigured(runtime.config)) {
+    throw new Error("Backend API URL is not configured.");
+  }
+
+  const payload = await fetchStoredRoundClaims(runtime.config, roundId);
+  runtime.selectedRoundId = Number(roundId);
+  runtime.selectedRoundClaims = Array.isArray(payload?.claims)
+    ? payload.claims.map((record) => ({
+      ...record,
+      claimed: record?.entry?.claimedAt || record?.entry?.claimedTxHash ? true : null,
+    }))
+    : [];
+  setAdminTab("rounds");
+  renderSelectedRoundClaims();
+  if (scrollIntoView) {
+    scrollRoundClaimsSectionIntoView();
+  }
+}
+
+async function refreshSelectedRoundClaimStatuses() {
+  if (!runtime.selectedRoundClaims.length) return;
+  runtime.selectedRoundClaims = await loadClaimStatuses(runtime.selectedRoundClaims);
+  renderSelectedRoundClaims();
+}
+
+async function saveDraftRoundToBackend() {
   if (!runtime.uploadedRound) {
     throw new Error("Prepare a claims JSON file first.");
   }
@@ -1026,6 +1411,60 @@ async function startAirdropAndPersistRound() {
   if (!isClaimsApiConfigured(runtime.config)) {
     throw new Error("Backend API URL is not configured.");
   }
+
+  const root = els.startRootInput.value.trim();
+  if (!ethers.isHexString(root, 32)) {
+    throw new Error("Merkle root must be a bytes32 hex string.");
+  }
+
+  const deadlineUnix = Number(els.startDeadlineUnix.value);
+  await validateFutureDeadlineAgainstChain(deadlineUnix);
+
+  const saveChallenge = await requestAirdropSaveChallenge(runtime.config, {
+    walletAddress: runtime.account,
+    merkleRoot: runtime.uploadedRound.root,
+    deadline: deadlineUnix,
+  });
+  const saveSignature = await runtime.signer.signMessage(saveChallenge.message);
+  const persisted = await saveAirdropRound(runtime.config, {
+    deadline: deadlineUnix,
+    walletAddress: runtime.account,
+    challengeId: saveChallenge.challengeId,
+    signature: saveSignature,
+    decimals: runtime.tokenDecimals,
+    claims: runtime.uploadedRound.claims.map((claim) => ({
+      index: claim.index,
+      account: claim.account,
+      amountRaw: claim.amountRaw,
+    })),
+  });
+
+  if (persisted?.round?.id) {
+    applyUploadedRound({
+      ...runtime.uploadedRound,
+      storedRoundId: persisted.round.id,
+    });
+    await refreshPage();
+    await loadRoundClaims(persisted.round.id);
+    logger.log("Draft saved to the backend.", "success");
+  }
+}
+
+async function deployStoredRound(roundId) {
+  const selectedRound = runtime.storedRounds.find((round) => round.id === roundId) || null;
+  if (!selectedRound) {
+    throw new Error("The selected saved round could not be found.");
+  }
+
+  if (selectedRound.status !== "draft") {
+    throw new Error("Only saved draft rounds can be deployed.");
+  }
+
+  if (!isClaimsApiConfigured(runtime.config)) {
+    throw new Error("Backend API URL is not configured.");
+  }
+
+  await validateFutureDeadlineAgainstChain(Number(selectedRound.deadline));
 
   const { airdrop } = getContracts({
     config: runtime.config,
@@ -1038,54 +1477,23 @@ async function startAirdropAndPersistRound() {
     throw new Error("Airdrop address is not configured.");
   }
 
-  const root = els.startRootInput.value.trim();
-  if (!ethers.isHexString(root, 32)) {
-    throw new Error("Merkle root must be a bytes32 hex string.");
+  const tx = await airdrop.startNewAirdrop(selectedRound.merkleRoot, Number(selectedRound.deadline));
+  logger.log(`Deploy saved round: submitted ${tx.hash}`);
+  const receipt = await tx.wait();
+  logger.log(`Deploy saved round: confirmed in block ${receipt.blockNumber}`, "success");
+
+  const persisted = await deploySavedAirdropRound(runtime.config, roundId, {
+    txHash: tx.hash,
+  });
+
+  await refreshPage();
+  if (persisted?.round?.id) {
+    runtime.selectedRoundId = persisted.round.id;
+    await loadRoundClaims(persisted.round.id);
   }
 
-  const deadlineUnix = Number(els.startDeadlineUnix.value);
-  await validateFutureDeadlineAgainstChain(deadlineUnix);
-
-  const tx = await airdrop.startNewAirdrop(root, deadlineUnix);
-  logger.log(`Start airdrop: submitted ${tx.hash}`);
-  const receipt = await tx.wait();
-  logger.log(`Start airdrop: confirmed in block ${receipt.blockNumber}`, "success");
-
-  try {
-    const finalizeChallenge = await requestAirdropFinalizeChallenge(runtime.config, {
-      walletAddress: runtime.account,
-      txHash: tx.hash,
-      merkleRoot: runtime.uploadedRound.root,
-    });
-    const finalizeSignature = await runtime.signer.signMessage(finalizeChallenge.message);
-
-    const persisted = await persistAirdropRound(runtime.config, {
-      txHash: tx.hash,
-      walletAddress: runtime.account,
-      challengeId: finalizeChallenge.challengeId,
-      signature: finalizeSignature,
-      decimals: runtime.tokenDecimals,
-      claims: runtime.uploadedRound.claims.map((claim) => ({
-        index: claim.index,
-        account: claim.account,
-        amountRaw: claim.amountRaw,
-      })),
-    });
-
-    runtime.startRequiresNewUpload = true;
-    await refreshPage();
-    updateStartAirdropButtonState();
-
-    if (persisted?.round?.epoch) {
-      logger.log(`Round ${persisted.round.epoch} saved to the backend.`, "success");
-    }
-  } catch (error) {
-    runtime.startRequiresNewUpload = true;
-    await refreshPage().catch(() => {});
-    updateStartAirdropButtonState();
-    throw new Error(
-      `Airdrop was started on chain, but saving the round to the backend failed. ${error?.message || String(error)}`,
-    );
+  if (persisted?.round?.epoch != null) {
+    logger.log(`Draft deployed as epoch ${persisted.round.epoch}.`, "success");
   }
 }
 
@@ -1113,6 +1521,14 @@ async function updateEpochDeadline(newDeadline) {
 }
 
 function bindEvents() {
+  els.adminTabButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const nextTab = button.getAttribute("data-admin-tab");
+      if (!nextTab) return;
+      setAdminTab(nextTab);
+    });
+  });
+
   els.connectButton.addEventListener("click", async () => {
     if (runtime.account) {
       toggleWalletMenu();
@@ -1185,6 +1601,15 @@ function bindEvents() {
       logger.log("Admin state refreshed.");
     } catch (error) {
       reportError(error, "Refresh page");
+    }
+  });
+
+  els.refreshRoundClaimsStatusButton?.addEventListener("click", async () => {
+    try {
+      await refreshSelectedRoundClaimStatuses();
+      logger.log("Claimed status refreshed.", "success");
+    } catch (error) {
+      reportError(error, "Refresh claimed status");
     }
   });
 
@@ -1285,14 +1710,6 @@ function bindEvents() {
     logger.log("Prepared claims cleared.");
   });
 
-  els.fundUploadedButton.addEventListener("click", async () => {
-    try {
-      await fundUploadedRound();
-    } catch (error) {
-      reportError(error, "Fund airdrop");
-    }
-  });
-
   els.startDeadlineInput.addEventListener("input", () => {
     syncDeadlineFromLocal(els.startDeadlineInput, els.startDeadlineUtcInput, els.startDeadlineUnix);
     updateStartAirdropButtonState();
@@ -1317,22 +1734,8 @@ function bindEvents() {
   els.fundAirdropForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     try {
-      const { token, airdropAddress } = getContracts({
-        config: runtime.config,
-        provider: runtime.provider,
-        signer: runtime.signer,
-        withSigner: true,
-      });
-      if (!token || !airdropAddress) throw new Error("Token and airdrop addresses must be configured.");
-
       const amountRaw = parseHumanAmount(els.fundAirdropAmount.value, runtime.tokenDecimals);
-      await sendTransaction("Fund airdrop", () => token.transfer(airdropAddress, amountRaw), {
-        log: logger.log,
-        afterSuccess: async () => {
-          await refreshPage();
-        },
-        formatError: (error, label) => formatUiError(error, label, runtime),
-      });
+      await fundAirdropAmountRaw(amountRaw);
     } catch (error) {
       reportError(error, "Fund airdrop");
     }
@@ -1341,9 +1744,9 @@ function bindEvents() {
   els.startAirdropForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     try {
-      await startAirdropAndPersistRound();
+      await saveDraftRoundToBackend();
     } catch (error) {
-      reportError(error, "Start airdrop");
+      reportError(error, "Save airdrop draft");
     }
   });
 
@@ -1475,7 +1878,7 @@ function bindEvents() {
 
       const epoch = readRequiredEpoch(els.queryEpochInput, "Epoch query");
       const [root, deadline, claimedAmount] = await airdrop.epochInfo(epoch);
-      const localRound = runtime.claimSourcesByEpoch.get(Number(epoch))?.round;
+      const localRound = runtime.storedRoundsByEpoch.get(Number(epoch)) || null;
       const totalAmountRaw = localRound && localRound.merkleRoot.toLowerCase() === root.toLowerCase()
         ? localRound.totalAmountRaw
         : null;
@@ -1503,30 +1906,29 @@ function bindEvents() {
   els.claimStatusForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     try {
-      const { airdrop } = getContracts({ config: runtime.config, provider: runtime.provider });
-      if (!airdrop) throw new Error("Airdrop address is not configured.");
+      if (!isClaimsApiConfigured(runtime.config)) {
+        throw new Error("Backend API URL is not configured.");
+      }
 
-      const epoch = readRequiredEpoch(els.claimedEpochInput, "Claim status epoch");
-      const index = parseRequiredBigInt(els.claimedIndexInput.value, "Claim status index");
-      if (index < 0n) throw new Error("Claim status index must be zero or greater.");
+      const rawQuery = String(els.claimLookupInput.value || "").trim();
+      if (!rawQuery) {
+        throw new Error("Enter a wallet address.");
+      }
 
-      const claimed = await airdrop.isClaimed(epoch, index);
-      const localClaim = isClaimsApiConfigured(runtime.config)
-        ? await fetchStoredClaimByEpochAndIndex(runtime.config, epoch.toString(), index.toString()).catch(() => null)
-        : null;
-      els.claimStatusResult.textContent = JSON.stringify(
-        {
-          epoch: epoch.toString(),
-          index: index.toString(),
-          account: localClaim?.entry?.account || null,
-          amountRaw: localClaim?.entry?.amountRaw || null,
-          claimed,
-        },
-        null,
-        2,
+      const payload = await fetchStoredClaimsByWallet(runtime.config, rawQuery);
+      const rows = Array.isArray(payload?.claims) ? payload.claims : [];
+
+      runtime.claimLookupRows = await loadClaimStatuses(
+        rows.map((record) => ({
+          ...record,
+          claimed: record?.entry?.claimedAt || record?.entry?.claimedTxHash ? true : null,
+        })),
       );
+      renderClaimLookupResults();
     } catch (error) {
-      reportError(error, "Read claim status");
+      runtime.claimLookupRows = [];
+      renderClaimLookupResults();
+      reportError(error, "Lookup claims");
     }
   });
 
@@ -1558,6 +1960,9 @@ function bindEvents() {
 async function init() {
   bindEvents();
   updateToastOffset();
+  renderSelectedRoundClaims();
+  renderClaimLookupResults();
+  syncAdminTabs();
 
   pageInitPromise = (async () => {
     updateToastOffset();

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -97,6 +97,10 @@ const els = {
   adminTabPanels: [...document.querySelectorAll("[data-admin-panel]")],
   connectedAccount: document.getElementById("connectedAccount"),
   ownerAddress: document.getElementById("ownerAddress"),
+  pendingOwnerShell: document.getElementById("pendingOwnerShell"),
+  pendingOwnershipCurrentOwner: document.getElementById("pendingOwnershipCurrentOwner"),
+  pendingOwnershipPendingOwner: document.getElementById("pendingOwnershipPendingOwner"),
+  pendingAcceptOwnershipButton: document.getElementById("pendingAcceptOwnershipButton"),
   ownershipShell: document.getElementById("ownershipShell"),
   ownershipCurrentOwner: document.getElementById("ownershipCurrentOwner"),
   ownershipPendingOwner: document.getElementById("ownershipPendingOwner"),
@@ -1144,6 +1148,19 @@ function applyOwnershipSection() {
   }
 }
 
+function applyPendingOwnerSection() {
+  if (!els.pendingOwnerShell) return;
+
+  const normalizedPendingOwner = normalizeAddress(runtime.pendingOwner);
+  const hasPendingOwner = Boolean(normalizedPendingOwner && normalizedPendingOwner !== ethers.ZeroAddress);
+  const canAccept = Boolean(runtime.provider && runtime.account && isReadyChain() && isPendingOwner());
+
+  els.pendingOwnerShell.hidden = !canAccept;
+  els.pendingOwnershipCurrentOwner.textContent = runtime.owner || "-";
+  els.pendingOwnershipPendingOwner.textContent = hasPendingOwner ? normalizedPendingOwner : "No pending owner";
+  els.pendingAcceptOwnershipButton.disabled = !canAccept;
+}
+
 async function refreshEpochRows() {
   runtime.epochRows = [];
 
@@ -1200,49 +1217,57 @@ function applyOwnerGate() {
   els.connectedAccount.textContent = runtime.account || "No wallet connected";
 
   if (!runtime.provider) {
-    els.accountRole.textContent = "Wallet missing";
-    els.adminGateMessage.textContent = "Install a compatible browser wallet to manage the airdrop.";
-    els.switchNetworkGateButton.hidden = true;
-    els.adminShell.hidden = true;
-    return;
+      els.accountRole.textContent = "Wallet missing";
+      els.adminGateMessage.textContent = "Install a compatible browser wallet to manage the airdrop.";
+      els.switchNetworkGateButton.hidden = true;
+      els.adminShell.hidden = true;
+      els.pendingOwnerShell.hidden = true;
+      return;
   }
 
   if (!runtime.account) {
-    els.accountRole.textContent = "Disconnected";
-    els.adminGateMessage.textContent = "Connect the owner wallet to view admin controls.";
-    els.switchNetworkGateButton.hidden = true;
-    els.adminShell.hidden = true;
-    return;
+      els.accountRole.textContent = "Disconnected";
+      els.adminGateMessage.textContent = "Connect the owner or pending owner wallet to view admin controls.";
+      els.switchNetworkGateButton.hidden = true;
+      els.adminShell.hidden = true;
+      els.pendingOwnerShell.hidden = true;
+      return;
   }
 
   if (!isReadyChain()) {
-    els.accountRole.textContent = "Wrong network";
-    els.adminGateMessage.textContent = "Switch the connected wallet to the configured network to manage the airdrop.";
-    els.switchNetworkGateButton.hidden = false;
-    els.adminShell.hidden = true;
-    return;
+      els.accountRole.textContent = "Wrong network";
+      els.adminGateMessage.textContent = "Switch the connected wallet to the configured network to manage the airdrop.";
+      els.switchNetworkGateButton.hidden = false;
+      els.adminShell.hidden = true;
+      els.pendingOwnerShell.hidden = true;
+      return;
   }
 
   if (!runtime.owner) {
-    els.accountRole.textContent = "Connected wallet";
-    els.adminGateMessage.textContent = "Owner address is not available yet. Check the contract config.";
-    els.switchNetworkGateButton.hidden = true;
-    els.adminShell.hidden = true;
-    return;
+      els.accountRole.textContent = "Connected wallet";
+      els.adminGateMessage.textContent = "Owner address is not available yet. Check the contract config.";
+      els.switchNetworkGateButton.hidden = true;
+      els.adminShell.hidden = true;
+      els.pendingOwnerShell.hidden = true;
+      return;
   }
 
-  if (!isOwner()) {
-    els.accountRole.textContent = "Connected wallet";
-    els.adminGateMessage.textContent = "This page only unlocks for the current owner address.";
-    els.switchNetworkGateButton.hidden = true;
-    els.adminShell.hidden = true;
-    return;
+  if (!hasOwnershipAccess()) {
+      els.accountRole.textContent = "Connected wallet";
+      els.adminGateMessage.textContent = "This page only unlocks for the current owner or pending owner address.";
+      els.switchNetworkGateButton.hidden = true;
+      els.adminShell.hidden = true;
+      els.pendingOwnerShell.hidden = true;
+      return;
   }
 
-  els.accountRole.textContent = "Owner connected";
-  els.adminGateMessage.textContent = "Owner wallet detected. Admin controls are unlocked.";
+  els.accountRole.textContent = isOwner() ? "Owner connected" : "Pending owner connected";
+  els.adminGateMessage.textContent = isOwner()
+    ? "Owner wallet detected. Admin controls are unlocked."
+    : "Pending owner wallet detected. Accept ownership below to unlock the full admin workspace.";
   els.switchNetworkGateButton.hidden = true;
-  els.adminShell.hidden = false;
+  els.adminShell.hidden = !isOwner();
+  els.pendingOwnerShell.hidden = !isPendingOwner();
   updateStartAirdropButtonState();
 }
 
@@ -1318,7 +1343,27 @@ async function refreshPage() {
   renderUploadedRound();
   applyOwnerGate();
   applyOwnershipSection();
+  applyPendingOwnerSection();
   updateStartAirdropButtonState();
+}
+
+async function acceptOwnershipTransaction() {
+  const { airdrop } = getContracts({
+    config: runtime.config,
+    provider: runtime.provider,
+    signer: runtime.signer,
+    withSigner: true,
+  });
+  if (!airdrop) throw new Error("Airdrop address is not configured.");
+  if (!isPendingOwner()) throw new Error("Only the pending owner can accept ownership.");
+
+  await sendTransaction("Accept ownership", () => airdrop.acceptOwnership(), {
+    log: logger.log,
+    afterSuccess: async () => {
+      await refreshPage();
+    },
+    formatError: (error, label) => formatUiError(error, label, runtime),
+  });
 }
 
 async function fundAirdropAmountRaw(amountRaw, label = "Fund airdrop") {
@@ -1798,22 +1843,15 @@ function bindEvents() {
   els.acceptOwnershipForm?.addEventListener("submit", async (event) => {
     event.preventDefault();
     try {
-      const { airdrop } = getContracts({
-        config: runtime.config,
-        provider: runtime.provider,
-        signer: runtime.signer,
-        withSigner: true,
-      });
-      if (!airdrop) throw new Error("Airdrop address is not configured.");
-      if (!isPendingOwner()) throw new Error("Only the pending owner can accept ownership.");
+      await acceptOwnershipTransaction();
+    } catch (error) {
+      reportError(error, "Accept ownership");
+    }
+  });
 
-      await sendTransaction("Accept ownership", () => airdrop.acceptOwnership(), {
-        log: logger.log,
-        afterSuccess: async () => {
-          await refreshPage();
-        },
-        formatError: (error, label) => formatUiError(error, label, runtime),
-      });
+  els.pendingAcceptOwnershipButton?.addEventListener("click", async () => {
+    try {
+      await acceptOwnershipTransaction();
     } catch (error) {
       reportError(error, "Accept ownership");
     }

--- a/frontend/js/shared/claims.js
+++ b/frontend/js/shared/claims.js
@@ -65,6 +65,17 @@ export async function fetchStoredAirdropRounds(config) {
   return fetchBackendJson(`${backendBaseUrl}/api/airdrop/rounds`);
 }
 
+export async function fetchStoredRoundClaims(config, roundId) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  return fetchBackendJson(
+    `${backendBaseUrl}/api/airdrop/rounds/${encodeURIComponent(roundId)}/claims`,
+  );
+}
+
 export async function fetchStoredClaimByEpochAndIndex(config, epoch, claimIndex) {
   const backendBaseUrl = getBackendBaseUrl(config);
   if (!backendBaseUrl) {
@@ -76,13 +87,40 @@ export async function fetchStoredClaimByEpochAndIndex(config, epoch, claimIndex)
   );
 }
 
-export async function persistAirdropRound(config, payload) {
+export async function fetchStoredClaimById(config, claimId) {
   const backendBaseUrl = getBackendBaseUrl(config);
   if (!backendBaseUrl) {
     throw new Error("Claim backend URL is not configured.");
   }
 
-  return fetchBackendJson(`${backendBaseUrl}/api/admin/airdrop-rounds/finalize`, {
+  return fetchBackendJson(
+    `${backendBaseUrl}/api/airdrop/claims/${encodeURIComponent(claimId)}`,
+  );
+}
+
+export async function fetchStoredClaimsByWallet(config, walletAddress) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  const normalizedWalletAddress = normalizeAddress(walletAddress);
+  if (!normalizedWalletAddress) {
+    throw new Error("Wallet address is invalid.");
+  }
+
+  return fetchBackendJson(
+    `${backendBaseUrl}/api/airdrop/claims?walletAddress=${encodeURIComponent(normalizedWalletAddress)}`,
+  );
+}
+
+export async function saveAirdropRound(config, payload) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  return fetchBackendJson(`${backendBaseUrl}/api/admin/airdrop-rounds/save`, {
     method: "POST",
     credentials: "include",
     headers: {
@@ -92,13 +130,29 @@ export async function persistAirdropRound(config, payload) {
   });
 }
 
-export async function requestAirdropFinalizeChallenge(config, payload) {
+export async function deploySavedAirdropRound(config, roundId, payload) {
   const backendBaseUrl = getBackendBaseUrl(config);
   if (!backendBaseUrl) {
     throw new Error("Claim backend URL is not configured.");
   }
 
-  return fetchBackendJson(`${backendBaseUrl}/api/admin/airdrop-rounds/challenge`, {
+  return fetchBackendJson(`${backendBaseUrl}/api/admin/airdrop-rounds/${encodeURIComponent(roundId)}/deploy`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function requestAirdropSaveChallenge(config, payload) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  return fetchBackendJson(`${backendBaseUrl}/api/admin/airdrop-rounds/save-challenge`, {
     method: "POST",
     credentials: "include",
     headers: {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1566,6 +1566,73 @@ code,
   grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
 }
 
+.admin-tabs-shell {
+  padding-bottom: 18px;
+}
+
+.admin-summary-list {
+  margin: 18px 0 14px;
+}
+
+.admin-summary-list .detail-item p {
+  font-family: var(--mono);
+}
+
+.admin-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  padding: 1px;
+  border: 1px solid rgba(251, 175, 64, 0.18);
+  border-radius: 18px;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 38%),
+    linear-gradient(180deg, rgba(13, 30, 82, 0.92), rgba(6, 17, 52, 0.96));
+}
+
+.admin-tab-button {
+  min-width: 0;
+  height: 54px;
+  min-height: 54px;
+  max-height: 54px;
+  padding: 13px 18px;
+  border: 0;
+  border-radius: 0;
+  background: rgba(251, 175, 64, 0.06);
+  color: var(--accent-strong);
+  box-shadow: none;
+  font-size: 0.92rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    color 140ms ease,
+    transform 140ms ease,
+    box-shadow 140ms ease,
+    filter 140ms ease;
+}
+
+.admin-tab-button:hover,
+.admin-tab-button:focus-visible {
+  color: #ffe9c7;
+  background: rgba(251, 175, 64, 0.1);
+  box-shadow: none;
+}
+
+.admin-tab-button.is-active {
+  background: linear-gradient(135deg, #ffc86d 0%, var(--accent) 42%, #e48e17 100%);
+  color: #111930;
+  box-shadow: inset 0 0 0 1px rgba(251, 175, 64, 0.18);
+}
+
+.admin-tab-button.is-active:hover,
+.admin-tab-button.is-active:focus-visible {
+  background: linear-gradient(135deg, #ffd487 0%, #fbb040 42%, #ee9b26 100%);
+  box-shadow: inset 0 0 0 1px rgba(251, 175, 64, 0.18);
+}
+
 .full-width {
   grid-column: 1 / -1;
 }
@@ -1705,6 +1772,12 @@ select {
 
 .builder-row-action {
   width: 132px;
+}
+
+.round-action-cell {
+  min-width: 190px;
+  display: grid;
+  gap: 10px;
 }
 
 .table-action-button {


### PR DESCRIPTION
## Summary
- move admin airdrop creation to a database-first draft flow, then deploy saved rounds from the rounds workspace
- merge stored rounds with on-chain epochs in the admin UI, add round claim inspection and wallet-based claim lookup, and split the admin page into tabs
- tighten the admin workspace UX with shared contract status, row-level funding/deploy actions, improved round labeling, and updated tab styling

## Why
The previous admin flow deployed to the contract before saving the round to the backend. If the page refreshed before the backend save completed, the proofs could be lost even though the round had already started on chain. Saving drafts first preserves the claims data and allows deployment to happen later from the admin UI.

## Impact
- admins can save airdrop drafts before deployment and come back later to fund/deploy them
- the rounds table shows draft, merged DB+chain, chain-only, and missing-on-chain states in one place
- round claim inspection uses contract claim indexes, and wallet-based claim lookup now uses the stored claims data directly
- the admin page is easier to navigate with segmented tabs and a shared contract summary
