### PR TITLE
Simplify round creation in the admin Prepare tab

### DIFF
--- a/backend/lib/x-account-store.js
+++ b/backend/lib/x-account-store.js
@@ -542,6 +542,7 @@ function createAccountStore(db) {
     const requestedPage = Number.parseInt(String(options.page || "1").trim(), 10);
     const requestedPageSize = Number.parseInt(String(options.pageSize || "50").trim(), 10);
     const search = String(options.search || options.query || "").trim().toLowerCase();
+    const walletOnly = parseBoolean(options.walletOnly || options.hasWallet);
 
     return {
       page: Number.isInteger(requestedPage) && requestedPage > 0 ? requestedPage : 1,
@@ -549,28 +550,35 @@ function createAccountStore(db) {
         ? Math.min(Math.max(requestedPageSize, 1), 200)
         : 50,
       search,
+      walletOnly,
     };
   }
 
   function buildAccountSearchState(options = {}) {
     const normalized = normalizeAccountQueryOptions(options);
     const hasSearch = Boolean(normalized.search);
-    const sqlParams = hasSearch
-      ? {
-        search: `%${normalized.search}%`,
-      }
-      : {};
+    const filters = [];
+    const sqlParams = {};
+
+    if (hasSearch) {
+      sqlParams.search = `%${normalized.search}%`;
+      filters.push(`
+        (
+          LOWER(username_display) LIKE @search
+          OR LOWER(COALESCE(x_user_id, '')) LIKE @search
+          OR LOWER(COALESCE(wallet_address, '')) LIKE @search
+        )
+      `);
+    }
+
+    if (normalized.walletOnly) {
+      filters.push(`TRIM(COALESCE(wallet_address, '')) <> ''`);
+    }
 
     return {
       ...normalized,
       sqlParams,
-      whereClause: hasSearch
-        ? `
-          WHERE LOWER(username_display) LIKE @search
-             OR LOWER(COALESCE(x_user_id, '')) LIKE @search
-             OR LOWER(COALESCE(wallet_address, '')) LIKE @search
-        `
-        : "",
+      whereClause: filters.length ? `WHERE ${filters.join("\n          AND ")}` : "",
     };
   }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -40,6 +40,7 @@ const ADMIN_ROUND_SAVE_CHALLENGE_TTL_MS = 10 * 60 * 1000;
 const ADMIN_ACCESS_CHALLENGE_TTL_MS = 10 * 60 * 1000;
 const MAX_JSON_BODY_BYTES = 32 * 1024;
 const MAX_IMPORT_BODY_BYTES = 5 * 1024 * 1024;
+const MAX_AIRDROP_ROUND_SAVE_BODY_BYTES = 5 * 1024 * 1024;
 const RATE_LIMITS = {
   start: { limit: 12, windowMs: 10 * 60 * 1000 },
   callback: { limit: 24, windowMs: 10 * 60 * 1000 },
@@ -383,29 +384,58 @@ function redirect(response, location) {
 function readJsonRequest(request, maxBytes = MAX_JSON_BODY_BYTES) {
   return new Promise((resolve, reject) => {
     let rawBody = "";
+    let settled = false;
 
-    request.on("data", (chunk) => {
+    const cleanup = () => {
+      request.off("data", handleData);
+      request.off("end", handleEnd);
+      request.off("error", handleError);
+    };
+
+    const rejectOnce = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const resolveOnce = (value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+
+    const handleData = (chunk) => {
+      if (settled) return;
       rawBody += chunk;
       if (Buffer.byteLength(rawBody, "utf8") > maxBytes) {
-        reject(new HttpError(413, "Request body is too large."));
-        request.destroy();
+        rawBody = "";
+        rejectOnce(new HttpError(413, "Request body is too large."));
       }
-    });
+    };
 
-    request.on("end", () => {
+    const handleEnd = () => {
+      if (settled) return;
       if (!rawBody) {
-        resolve({});
+        resolveOnce({});
         return;
       }
 
       try {
-        resolve(JSON.parse(rawBody));
+        resolveOnce(JSON.parse(rawBody));
       } catch {
-        reject(new HttpError(400, "Request body must be valid JSON."));
+        rejectOnce(new HttpError(400, "Request body must be valid JSON."));
       }
-    });
+    };
 
-    request.on("error", reject);
+    const handleError = (error) => {
+      rejectOnce(error);
+    };
+
+    request.on("data", handleData);
+    request.on("end", handleEnd);
+    request.on("error", handleError);
   });
 }
 
@@ -1371,6 +1401,7 @@ function getAdminListOptions(requestUrl) {
     page: parsePositiveInteger(requestUrl.searchParams.get("page"), 1, { min: 1, max: 10000 }),
     pageSize: parsePositiveInteger(requestUrl.searchParams.get("pageSize"), 50, { min: 1, max: 200 }),
     search: String(requestUrl.searchParams.get("query") || "").trim(),
+    walletOnly: parseBooleanInput(requestUrl.searchParams.get("walletOnly")),
   };
 }
 
@@ -1695,7 +1726,7 @@ async function handleAdminDraftChallenge(request, response) {
 }
 
 async function handleSaveAirdropRound(request, response) {
-  const body = await readJsonRequest(request);
+  const body = await readJsonRequest(request, MAX_AIRDROP_ROUND_SAVE_BODY_BYTES);
   const rawClaims = Array.isArray(body.claims)
     ? body.claims
     : Array.isArray(body.round?.claims)

--- a/e2e/tests/admin/start-airdrop.spec.js
+++ b/e2e/tests/admin/start-airdrop.spec.js
@@ -1,5 +1,15 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
 const { expect, test } = require("../../fixtures/testWithMockWallet");
 const { connectViaWalletPicker, setFutureDeadline } = require("../helpers");
+
+function writeFixtureFile(testInfo, name, content) {
+  const filePath = testInfo.outputPath(name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
 
 test("@smoke admin claims builder can save and deploy a matching airdrop draft", async ({ page, mockWallet }) => {
   await page.goto("admin.html");
@@ -34,4 +44,46 @@ test("@smoke admin claims builder can save and deploy a matching airdrop draft",
   await expect(page.locator("#epochListBody")).toContainText("DB + Chain");
   await page.getByRole("button", { name: "Prepare" }).click();
   await expect(page.locator("#epochListBody")).toContainText("Active");
+});
+
+test("admin can build a round from every linked wallet with one shared amount", async ({ page, mockWallet }, testInfo) => {
+  const accountsCsvPath = writeFixtureFile(testInfo, "linked-wallet-accounts.csv", [
+    "x_username,wallet_address,x_user_id,is_follower,needs_recovery",
+    `alpha,${mockWallet.accounts.claimant},111,true,false`,
+    `beta,${mockWallet.accounts.secondary},222,true,false`,
+    `beta-duplicate,${mockWallet.accounts.secondary},333,false,false`,
+    "invalid,not-a-wallet,444,false,false",
+    "no-wallet,,555,false,false",
+  ].join("\n"));
+
+  await page.goto("admin.html");
+  await connectViaWalletPicker(page);
+
+  await expect(page.getByText("Owner wallet detected. Admin controls are unlocked.")).toBeVisible();
+
+  await page.getByRole("button", { name: "Accounts", exact: true }).click();
+  await page.locator("#accountsImportFileInput").setInputFiles(accountsCsvPath);
+  await page.getByRole("button", { name: "Upload Accounts" }).click();
+  await expect(page.locator("#managementAccountCount")).toHaveText("5");
+
+  await page.getByRole("button", { name: "Prepare" }).click();
+  await page.locator("#builderUniformAmountInput").fill("25");
+  await page.getByRole("button", { name: "Use All Linked Wallets" }).click();
+
+  await expect(page.locator("#builderClaimCount")).toHaveText("2 wallets");
+  await expect(page.locator("#builderClaimTotal")).toHaveText("50 LIB");
+  await expect(page.locator("#uploadedClaimCount")).toHaveText("2 wallets");
+  await expect(page.locator("#uploadedClaimTotal")).toContainText("50 LIB");
+  await expect(page.locator("#claimsBuilderBody tr")).toHaveCount(2);
+  await expect(page.locator('[data-builder-field="account"]').nth(0)).toHaveValue(new RegExp(`^${mockWallet.accounts.claimant}$`, "i"));
+  await expect(page.locator('[data-builder-field="account"]').nth(1)).toHaveValue(new RegExp(`^${mockWallet.accounts.secondary}$`, "i"));
+  await expect(page.locator("#adminToastMessage")).toHaveText("2 linked wallets loaded; 1 invalid skipped; 1 duplicate skipped.");
+
+  await setFutureDeadline(page, "#startDeadlineInput");
+  await page.getByRole("button", { name: "Save Round to DB" }).click();
+  await expect(page.locator("#selectedRoundLabel")).toContainText("Draft");
+  await page.getByRole("button", { name: "Fund Total" }).first().click();
+  await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
+  await page.getByRole("button", { name: "Deploy" }).first().click();
+  await expect(page.locator("#currentEpoch")).toHaveText("1");
 });

--- a/e2e/tests/admin/upload-existing-file.spec.js
+++ b/e2e/tests/admin/upload-existing-file.spec.js
@@ -1,5 +1,15 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
 const { expect, test } = require("../../fixtures/testWithMockWallet");
 const { connectViaWalletPicker, setFutureDeadline } = require("../helpers");
+
+function writeFixtureFile(testInfo, name, content) {
+  const filePath = testInfo.outputPath(name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
 
 test("admin can upload an existing claims file and gets a duplicate-root warning on re-upload", async ({ page, e2eClaimsFile }) => {
   await page.goto("admin.html");
@@ -26,4 +36,34 @@ test("admin can upload an existing claims file and gets a duplicate-root warning
   await page.locator("#uploadClaimsFileInput").setInputFiles(e2eClaimsFile);
   await expect(page.getByText("Claims file loaded.")).toBeVisible();
   await expect(page.locator("#startRootWarning")).toContainText("already exists on chain");
+});
+
+test("admin can save a large uploaded round to the backend", async ({ page }, testInfo) => {
+  const claimCount = 600;
+  const claimsFile = writeFixtureFile(
+    testInfo,
+    "large-round.claims.json",
+    `${JSON.stringify(
+      Array.from({ length: claimCount }, (_, index) => ({
+        index,
+        account: `0x${(index + 1).toString(16).padStart(40, "0")}`,
+        amount: "1",
+      })),
+      null,
+      2,
+    )}\n`,
+  );
+
+  await page.goto("admin.html");
+  await connectViaWalletPicker(page);
+
+  await page.locator("#uploadClaimsFileInput").setInputFiles(claimsFile);
+  await expect(page.getByText("Claims file loaded.")).toBeVisible();
+  await expect(page.locator("#uploadedClaimCount")).toHaveText(`${claimCount} wallets`);
+
+  await setFutureDeadline(page, "#startDeadlineInput");
+  await page.getByRole("button", { name: "Save Round to DB" }).click();
+
+  await expect(page.locator("#selectedRoundLabel")).toContainText("Draft");
+  await expect(page.locator("#uploadedClaimCount")).toHaveText(`${claimCount} wallets`);
 });

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -172,12 +172,17 @@
                   <span>Download File Name</span>
                   <input id="builderFileNameInput" type="text" placeholder="round-1.claims.json">
                 </label>
+                <label>
+                  <span>Amount For Every Wallet</span>
+                  <input id="builderUniformAmountInput" type="text" inputmode="decimal" placeholder="100">
+                </label>
                 <div class="full-width button-row">
+                  <button id="loadWalletAccountsButton" type="button" class="secondary">Use All Linked Wallets</button>
                   <button id="loadBuilderButton" type="button">Use Built Claims</button>
                   <button id="downloadBuilderButton" type="button" class="secondary">Download JSON</button>
                   <button id="clearBuilderButton" type="button" class="ghost">Clear Table</button>
                 </div>
-                <p class="hint full-width">Indexes are assigned automatically when the JSON is generated. Enter token amounts in human units.</p>
+                <p class="hint full-width">Indexes are assigned automatically when the JSON is generated. Enter token amounts in human units. The linked-wallet shortcut uses every account with a saved wallet, then skips invalid or duplicate wallet values.</p>
               </form>
 
               <div class="detail-list builder-summary-list">

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -162,8 +162,10 @@ const els = {
   airdropTokenBalance: document.getElementById("airdropTokenBalance"),
   claimsBuilderForm: document.getElementById("claimsBuilderForm"),
   builderFileNameInput: document.getElementById("builderFileNameInput"),
+  builderUniformAmountInput: document.getElementById("builderUniformAmountInput"),
   addBuilderRowButton: document.getElementById("addBuilderRowButton"),
   clearBuilderButton: document.getElementById("clearBuilderButton"),
+  loadWalletAccountsButton: document.getElementById("loadWalletAccountsButton"),
   loadBuilderButton: document.getElementById("loadBuilderButton"),
   downloadBuilderButton: document.getElementById("downloadBuilderButton"),
   builderValidationMessage: document.getElementById("builderValidationMessage"),
@@ -294,6 +296,7 @@ function clearMessage() {
 const logger = { log: setMessage, clear: clearMessage };
 const reportError = createErrorReporter(logger.log, () => runtime);
 let pageInitPromise = Promise.resolve();
+const ADMIN_LINKED_WALLET_PAGE_SIZE = 200;
 const ADMIN_ACCOUNTS_TEMPLATE_CSV = [
   "x_username,wallet_address,x_user_id,is_follower,needs_recovery,snapshot_history_json",
   "example_user,0x0000000000000000000000000000000000000001,123456789,true,false,\"[\"\"2026-04-15T17:38:57.616Z\"\", \"\"2026-04-20T15:59:46.289Z\"\"]\"",
@@ -703,6 +706,130 @@ function downloadClaimsBuilderJson() {
   link.click();
   link.remove();
   URL.revokeObjectURL(downloadUrl);
+}
+
+async function fetchAllLinkedWalletAccounts() {
+  const accounts = [];
+  let page = 1;
+
+  while (true) {
+    const payload = await callAdminApi((accessToken) => fetchAdminAccounts(runtime.config, accessToken, {
+      page,
+      pageSize: ADMIN_LINKED_WALLET_PAGE_SIZE,
+      walletOnly: true,
+    }));
+
+    if (page === 1) {
+      applyManagementResponse(payload);
+      renderManagementSummary();
+    }
+
+    accounts.push(...(Array.isArray(payload?.accounts) ? payload.accounts : []));
+
+    if (!payload?.pagination?.hasNextPage) {
+      return {
+        accounts,
+        total: Number(payload?.pagination?.total || accounts.length),
+      };
+    }
+
+    page += 1;
+  }
+}
+
+function buildBuilderRowsFromLinkedWalletAccounts(accounts, amount) {
+  const rows = [];
+  const seenWallets = new Set();
+  let invalidCount = 0;
+  let duplicateCount = 0;
+
+  for (const account of accounts) {
+    const normalizedWallet = normalizeAddress(account?.walletAddress);
+    if (!normalizedWallet || normalizedWallet === ethers.ZeroAddress) {
+      invalidCount += 1;
+      continue;
+    }
+
+    if (seenWallets.has(normalizedWallet)) {
+      duplicateCount += 1;
+      continue;
+    }
+
+    seenWallets.add(normalizedWallet);
+    rows.push(createBuilderRow({
+      account: normalizedWallet,
+      amount,
+    }));
+  }
+
+  return {
+    rows,
+    invalidCount,
+    duplicateCount,
+  };
+}
+
+function formatLinkedWalletLoadMessage({ loadedCount, invalidCount = 0, duplicateCount = 0 }) {
+  const segments = [
+    `${loadedCount} linked ${loadedCount === 1 ? "wallet" : "wallets"} loaded`,
+  ];
+
+  if (invalidCount) {
+    segments.push(`${invalidCount} invalid skipped`);
+  }
+
+  if (duplicateCount) {
+    segments.push(`${duplicateCount} duplicate skipped`);
+  }
+
+  return `${segments.join("; ")}.`;
+}
+
+async function loadAllLinkedWalletClaimsIntoBuilder() {
+  const amount = String(els.builderUniformAmountInput?.value || "").trim();
+  if (!amount) {
+    throw new Error("Enter an amount to use for every linked wallet.");
+  }
+
+  try {
+    parseHumanAmount(amount, runtime.tokenDecimals);
+  } catch {
+    throw new Error("Enter a valid amount to use for every linked wallet.");
+  }
+
+  els.builderUniformAmountInput.value = amount;
+
+  const { accounts, total } = await fetchAllLinkedWalletAccounts();
+  if (!total) {
+    throw new Error("No accounts with saved wallets were found.");
+  }
+
+  const {
+    rows,
+    invalidCount,
+    duplicateCount,
+  } = buildBuilderRowsFromLinkedWalletAccounts(accounts, amount);
+
+  if (!rows.length) {
+    throw new Error("No valid linked wallets were found.");
+  }
+
+  runtime.builderRows = rows;
+  ensureClaimsBuilderFileName();
+  renderClaimsBuilderRows();
+
+  const artifact = buildClaimsBuilderArtifact();
+  if (!artifact) {
+    throw new Error("Unable to build claims from linked wallets.");
+  }
+
+  applyUploadedRound(artifact.round, { clearUploadInput: true });
+
+  return {
+    loadedCount: rows.length,
+    invalidCount,
+    duplicateCount,
+  };
 }
 
 function getEpochStatus(deadline) {
@@ -2102,6 +2229,22 @@ function bindEvents() {
   els.clearBuilderButton?.addEventListener("click", () => {
     resetClaimsBuilder({ preserveFileName: true });
     logger.log("Claims builder cleared.");
+  });
+
+  els.loadWalletAccountsButton?.addEventListener("click", async () => {
+    const originalLabel = els.loadWalletAccountsButton.textContent;
+    els.loadWalletAccountsButton.disabled = true;
+    els.loadWalletAccountsButton.textContent = "Loading...";
+
+    try {
+      const result = await loadAllLinkedWalletClaimsIntoBuilder();
+      logger.log(formatLinkedWalletLoadMessage(result), "success");
+    } catch (error) {
+      reportError(error, "Use all linked wallets");
+    } finally {
+      els.loadWalletAccountsButton.disabled = false;
+      els.loadWalletAccountsButton.textContent = originalLabel;
+    }
   });
 
   els.loadBuilderButton?.addEventListener("click", async () => {

--- a/frontend/js/shared/admin-data.js
+++ b/frontend/js/shared/admin-data.js
@@ -95,6 +95,9 @@ export async function fetchAdminAccounts(config, accessToken, options = {}) {
   if (String(options.search || "").trim()) {
     url.searchParams.set("query", String(options.search || "").trim());
   }
+  if (options.walletOnly) {
+    url.searchParams.set("walletOnly", "true");
+  }
 
   return fetchJson(url, {
     headers: buildAdminHeaders(accessToken),


### PR DESCRIPTION
## Summary
- add a single-amount "Use All Linked Wallets" flow to the admin Prepare tab
- fetch only wallet-backed accounts for the builder path and dedupe/skip invalid wallet rows before loading the round
- allow larger draft-save payloads and return a clean HTTP error instead of a dropped connection when a JSON body is too large

## Why
Creating a new round from the Prepare tab was still manual even after the account-management work landed. This change lets the admin build a round directly from the saved account database with one shared amount.

This also fixes the save-round failure you hit after loading larger claim sets. The root cause was that `/api/admin/airdrop-rounds/save` still used the default 32 KB JSON body limit, so larger draft-save requests could overflow the parser and surface in the browser as `TypeError: Failed to fetch`.
