### PR TITLE
Fix duplicate wallet discovery entries

### DIFF
--- a/e2e/fixtures/testWithMockWallet.js
+++ b/e2e/fixtures/testWithMockWallet.js
@@ -41,7 +41,9 @@ function installHardhatBackedWalletMock(config) {
   const CONNECTED_STORAGE_KEY = "__liberdus_mock_wallet_connected__";
   const ACCOUNT_STORAGE_KEY = "__liberdus_mock_wallet_account__";
   const CHAIN_STORAGE_KEY = "__liberdus_mock_wallet_chain__";
-  const discoveryMode = config.discoveryMode === "eip6963-only" ? "eip6963-only" : "legacy";
+  const discoveryMode = ["eip6963-only", "manual-eip6963"].includes(config.discoveryMode)
+    ? config.discoveryMode
+    : "legacy";
   const listenerMap = new Map();
   const queuedFailures = new Map();
   const knownChains = new Set([String(config.chainId).toLowerCase()]);
@@ -289,14 +291,14 @@ function installHardhatBackedWalletMock(config) {
     }));
   };
 
-  if (discoveryMode !== "eip6963-only") {
+  if (discoveryMode === "legacy") {
     Object.defineProperty(globalWindow, "ethereum", {
       configurable: false,
       enumerable: true,
       writable: false,
       value: provider,
     });
-  } else {
+  } else if (discoveryMode === "eip6963-only") {
     globalWindow.addEventListener("eip6963:requestProvider", announceEip6963Provider);
   }
 
@@ -374,7 +376,7 @@ function installHardhatBackedWalletMock(config) {
 
   localStorage.setItem(config.storageKey, JSON.stringify(mergedUiConfig));
 
-  if (discoveryMode !== "eip6963-only") {
+  if (discoveryMode === "legacy") {
     window.dispatchEvent(new Event("ethereum#initialized"));
   }
 }

--- a/e2e/fixtures/testWithMockWallet.js
+++ b/e2e/fixtures/testWithMockWallet.js
@@ -41,6 +41,7 @@ function installHardhatBackedWalletMock(config) {
   const CONNECTED_STORAGE_KEY = "__liberdus_mock_wallet_connected__";
   const ACCOUNT_STORAGE_KEY = "__liberdus_mock_wallet_account__";
   const CHAIN_STORAGE_KEY = "__liberdus_mock_wallet_chain__";
+  const discoveryMode = config.discoveryMode === "eip6963-only" ? "eip6963-only" : "legacy";
   const listenerMap = new Map();
   const queuedFailures = new Map();
   const knownChains = new Set([String(config.chainId).toLowerCase()]);
@@ -274,9 +275,34 @@ function installHardhatBackedWalletMock(config) {
 
   const provider = new HardhatBackedEthereumProvider();
 
-  Object.defineProperty(globalWindow, "ethereum", {
+  const announceEip6963Provider = () => {
+    globalWindow.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+      detail: {
+        info: {
+          uuid: "liberdus-e2e-metamask",
+          name: "MetaMask",
+          icon: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E",
+          rdns: "io.metamask",
+        },
+        provider,
+      },
+    }));
+  };
+
+  if (discoveryMode !== "eip6963-only") {
+    Object.defineProperty(globalWindow, "ethereum", {
+      configurable: false,
+      enumerable: true,
+      writable: false,
+      value: provider,
+    });
+  } else {
+    globalWindow.addEventListener("eip6963:requestProvider", announceEip6963Provider);
+  }
+
+  Object.defineProperty(globalWindow, "__liberdusMockWalletProvider", {
     configurable: false,
-    enumerable: true,
+    enumerable: false,
     writable: false,
     value: provider,
   });
@@ -348,10 +374,13 @@ function installHardhatBackedWalletMock(config) {
 
   localStorage.setItem(config.storageKey, JSON.stringify(mergedUiConfig));
 
-  window.dispatchEvent(new Event("ethereum#initialized"));
+  if (discoveryMode !== "eip6963-only") {
+    window.dispatchEvent(new Event("ethereum#initialized"));
+  }
 }
 
 const test = base.extend({
+  walletDiscoveryMode: ["legacy", { option: true }],
   hardhatChain: [async ({}, use) => {
     await resetLocalChain();
     resetE2eDatabaseFile();
@@ -385,11 +414,12 @@ const test = base.extend({
     },
     { auto: true },
   ],
-  context: async ({ context }, use) => {
+  context: async ({ context, walletDiscoveryMode }, use) => {
     await context.addInitScript(installHardhatBackedWalletMock, {
       account: MOCK_WALLETS.owner,
       chainId: toHexChainId(1337),
       rpcUrl: RPC_URL,
+      discoveryMode: walletDiscoveryMode,
       storageKey: STORAGE_KEY,
       apiBaseUrl: E2E_BACKEND_ORIGIN,
       explorerBaseUrl: "https://explorer.local.test",
@@ -423,7 +453,10 @@ const test = base.extend({
         );
       },
       async connect(page) {
-        return page.evaluate(() => window.ethereum.request({ method: "eth_requestAccounts" }));
+        return page.evaluate(() => {
+          const provider = window.ethereum || window.__liberdusMockWalletProvider;
+          return provider.request({ method: "eth_requestAccounts" });
+        });
       },
       async failNextRequest(page, method, failure) {
         return page.evaluate(

--- a/e2e/tests/admin/wallet-discovery.spec.js
+++ b/e2e/tests/admin/wallet-discovery.spec.js
@@ -3,6 +3,70 @@ const { expect, test, toHexChainId } = require("../../fixtures/testWithMockWalle
 test.describe("admin wallet discovery", () => {
   test.use({ walletDiscoveryMode: "manual-eip6963" });
 
+  test("admin wallet picker shows Phantom as unavailable on BNB Smart Chain", async ({ page }) => {
+    await page.addInitScript(() => {
+      const storageKey = "liberdus-airdrop-ui-config";
+      const current = JSON.parse(window.localStorage.getItem(storageKey) || "{}");
+      window.localStorage.setItem(storageKey, JSON.stringify({
+        ...current,
+        chainId: 56,
+        networkName: "BNB Smart Chain",
+        rpcUrl: "https://bsc-dataseed.binance.org",
+        explorerBaseUrl: "https://bscscan.com",
+        nativeCurrency: {
+          name: "BNB",
+          symbol: "BNB",
+          decimals: 18,
+        },
+      }));
+
+      const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%2353f3c3'/%3E%3C/svg%3E";
+
+      window.addEventListener("eip6963:requestProvider", () => {
+        const provider = {
+          get isPhantom() {
+            return true;
+          },
+          request(args) {
+            return window.__liberdusMockWalletProvider.request(args);
+          },
+          on(...args) {
+            return window.__liberdusMockWalletProvider.on(...args);
+          },
+          removeListener(...args) {
+            return window.__liberdusMockWalletProvider.removeListener(...args);
+          },
+          off(...args) {
+            return window.__liberdusMockWalletProvider.off?.(...args);
+          },
+          once(...args) {
+            return window.__liberdusMockWalletProvider.once?.(...args);
+          },
+        };
+
+        window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+          detail: {
+            info: {
+              uuid: "phantom-admin-wallet",
+              name: "Phantom Wallet",
+              icon,
+              rdns: "com.phantom.browser",
+            },
+            provider,
+          },
+        }));
+      });
+    });
+
+    await page.goto("admin.html");
+    await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+    const phantomOption = page.locator(".wallet-picker-option", { hasText: "Phantom Wallet" });
+    await expect(phantomOption).toHaveCount(1);
+    await expect(phantomOption).toBeDisabled();
+    await expect(phantomOption).toContainText("Doesn't support BNB Smart Chain.");
+  });
+
   test("admin auto-switches the configured network through the selected wallet", async ({ page, mockWallet }) => {
     await page.addInitScript(() => {
       const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E";

--- a/e2e/tests/admin/wallet-discovery.spec.js
+++ b/e2e/tests/admin/wallet-discovery.spec.js
@@ -1,0 +1,135 @@
+const { expect, test, toHexChainId } = require("../../fixtures/testWithMockWallet");
+
+test.describe("admin wallet discovery", () => {
+  test.use({ walletDiscoveryMode: "manual-eip6963" });
+
+  test("admin auto-switches the configured network through the selected wallet", async ({ page, mockWallet }) => {
+    await page.addInitScript(() => {
+      const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E";
+      window.localStorage.setItem("__wallet_switch_log__", "[]");
+
+      function appendSwitch(walletName, method) {
+        const current = JSON.parse(window.localStorage.getItem("__wallet_switch_log__") || "[]");
+        current.push({ walletName, method });
+        window.localStorage.setItem("__wallet_switch_log__", JSON.stringify(current));
+      }
+
+      function createProvider(walletName) {
+        return {
+          get isMetaMask() {
+            return true;
+          },
+          request(args) {
+            const method = String(args?.method || "");
+            if (method.startsWith("wallet_")) {
+              appendSwitch(walletName, method);
+            }
+            return window.__liberdusMockWalletProvider.request(args);
+          },
+          on(...args) {
+            return window.__liberdusMockWalletProvider.on(...args);
+          },
+          removeListener(...args) {
+            return window.__liberdusMockWalletProvider.removeListener(...args);
+          },
+          off(...args) {
+            return window.__liberdusMockWalletProvider.off?.(...args);
+          },
+          once(...args) {
+            return window.__liberdusMockWalletProvider.once?.(...args);
+          },
+        };
+      }
+
+      window.addEventListener("eip6963:requestProvider", () => {
+        const wallets = [
+          { uuid: "metamask-primary-wallet", name: "MetaMask Primary", rdns: "io.metamask" },
+          { uuid: "metamask-secondary-wallet", name: "MetaMask Secondary", rdns: "io.metamask" },
+        ];
+
+        for (const wallet of wallets) {
+          window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+            detail: {
+              info: {
+                ...wallet,
+                icon,
+              },
+              provider: createProvider(wallet.name),
+            },
+          }));
+        }
+      });
+    });
+
+    await page.goto("admin.html");
+    await page.getByRole("button", { name: "Connect Wallet" }).click();
+    await page.getByRole("button", { name: /^MetaMask Secondary$/ }).click();
+    await expect(page.getByText("Owner wallet detected. Admin controls are unlocked.")).toBeVisible();
+    await mockWallet.setChainId(page, toHexChainId(31337));
+    await expect(page.locator("#accountRole")).toHaveText("Wrong network");
+    await page.getByRole("button", { name: "Switch to Configured Network" }).click();
+    await expect(page.getByText("Switched to Hardhat Local.")).toBeVisible();
+    await expect(page.getByText("Owner wallet detected. Admin controls are unlocked.")).toBeVisible();
+
+    const switchLog = await page.evaluate(() => JSON.parse(window.localStorage.getItem("__wallet_switch_log__") || "[]"));
+    expect(switchLog).toContainEqual({ walletName: "MetaMask Secondary", method: "wallet_switchEthereumChain" });
+    expect([...new Set(switchLog.map((entry) => entry.walletName))]).toEqual(["MetaMask Secondary"]);
+  });
+
+  test("admin connects through the latest announced provider wrapper", async ({ page }) => {
+    await page.addInitScript(() => {
+      const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E";
+      let latestGeneration = 0;
+
+      function createProvider(wrapperGeneration) {
+        return {
+          get isMetaMask() {
+            return true;
+          },
+          request(args) {
+            if (wrapperGeneration !== latestGeneration) {
+              const error = new Error("Stale EIP-6963 wrapper");
+              error.code = 4999;
+              throw error;
+            }
+            return window.__liberdusMockWalletProvider.request(args);
+          },
+          on(...args) {
+            return window.__liberdusMockWalletProvider.on(...args);
+          },
+          removeListener(...args) {
+            return window.__liberdusMockWalletProvider.removeListener(...args);
+          },
+          off(...args) {
+            return window.__liberdusMockWalletProvider.off?.(...args);
+          },
+          once(...args) {
+            return window.__liberdusMockWalletProvider.once?.(...args);
+          },
+        };
+      }
+
+      window.addEventListener("eip6963:requestProvider", () => {
+        latestGeneration += 1;
+        window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+          detail: {
+            info: {
+              uuid: "metamask-live-wrapper",
+              name: "MetaMask",
+              icon,
+              rdns: "io.metamask",
+            },
+            provider: createProvider(latestGeneration),
+          },
+        }));
+      });
+    });
+
+    await page.goto("admin.html");
+    await page.getByRole("button", { name: "Connect Wallet" }).click();
+    await page.getByRole("button", { name: /^MetaMask$/ }).click();
+
+    await expect(page.getByText("Owner wallet detected. Admin controls are unlocked.")).toBeVisible();
+    await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
+  });
+});

--- a/e2e/tests/claim/wallet-menu.spec.js
+++ b/e2e/tests/claim/wallet-menu.spec.js
@@ -4,6 +4,7 @@ const { connectViaWalletPicker, openWalletMenu } = require("../helpers");
 test("claimant wallet menu shows the connected address, chain id, and disconnect flow", async ({ page }) => {
   await page.goto("index.html");
   await connectViaWalletPicker(page);
+  await expect(page.getByText("Nothing available right now.")).toBeVisible();
 
   await openWalletMenu(page, /0xf39f\.\.\.2266/i);
   await expect(page.locator("#walletMenu")).toBeVisible();
@@ -21,6 +22,73 @@ test("claimant wallet menu shows the connected address, chain id, and disconnect
   await expect(page.getByRole("button", { name: "Connect Wallet" })).toBeVisible();
   await expect(page.getByText("Connect your wallet to check for claims.")).toBeVisible();
   await expect(page.getByText("Available claims will appear here after you connect.")).toBeVisible();
+});
+
+test("wallet picker merges a legacy wallet with the same EIP-6963 wallet announcement", async ({ page }) => {
+  await page.addInitScript(() => {
+    const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E";
+
+    window.addEventListener("eip6963:requestProvider", () => {
+      const provider = {
+        get isMetaMask() {
+          return Boolean(window.ethereum?.isMetaMask);
+        },
+        request(args) {
+          return window.ethereum.request(args);
+        },
+        on(...args) {
+          return window.ethereum.on(...args);
+        },
+        removeListener(...args) {
+          return window.ethereum.removeListener(...args);
+        },
+        off(...args) {
+          return window.ethereum.off?.(...args);
+        },
+        once(...args) {
+          return window.ethereum.once?.(...args);
+        },
+      };
+
+      window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+        detail: {
+          info: {
+            uuid: "test-metamask-wallet",
+            name: "MetaMask",
+            icon,
+            rdns: "io.metamask",
+          },
+          provider,
+        },
+      }));
+    });
+  });
+
+  await page.goto("index.html");
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+  const metaMaskOption = page.getByRole("button", { name: /^MetaMask$/ });
+  await expect(metaMaskOption).toHaveCount(1);
+  await metaMaskOption.click();
+  await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
+});
+
+test.describe("EIP-6963-only wallet discovery", () => {
+  test.use({ walletDiscoveryMode: "eip6963-only" });
+
+  test("claimant page connects through an announced provider without window.ethereum", async ({ page }) => {
+    await page.goto("index.html");
+    await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+    const metaMaskOption = page.getByRole("button", { name: /^MetaMask$/ });
+    await expect(metaMaskOption).toHaveCount(1);
+    await metaMaskOption.click();
+    await expect(page.getByText("Nothing available right now.")).toBeVisible();
+
+    await openWalletMenu(page, /0xf39f\.\.\.2266/i);
+    await expect(page.locator("#walletMenu")).toBeVisible();
+    await expect(page.locator("#walletMenuChainId")).toHaveText("1337");
+  });
 });
 
 test("connected claimant sees the generic empty state when no rounds have started", async ({ page, mockWallet }) => {

--- a/e2e/tests/claim/wallet-menu.spec.js
+++ b/e2e/tests/claim/wallet-menu.spec.js
@@ -446,6 +446,248 @@ test("wallet picker merges Firefox-style Phantom variants into one option", asyn
   await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
 });
 
+test("wallet picker shows Phantom as unavailable on BNB Smart Chain", async ({ page }) => {
+  await page.addInitScript(() => {
+    const storageKey = "liberdus-airdrop-ui-config";
+    const current = JSON.parse(window.localStorage.getItem(storageKey) || "{}");
+    window.localStorage.setItem(storageKey, JSON.stringify({
+      ...current,
+      chainId: 56,
+      networkName: "BNB Smart Chain",
+      rpcUrl: "https://bsc-dataseed.binance.org",
+      explorerBaseUrl: "https://bscscan.com",
+      nativeCurrency: {
+        name: "BNB",
+        symbol: "BNB",
+        decimals: 18,
+      },
+    }));
+
+    const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%2353f3c3'/%3E%3C/svg%3E";
+
+    window.addEventListener("ethereum#initialized", () => {
+      window.ethereum.isPhantom = true;
+    });
+
+    window.addEventListener("eip6963:requestProvider", () => {
+      const provider = {
+        get isPhantom() {
+          return true;
+        },
+        request(args) {
+          return window.ethereum.request(args);
+        },
+        on(...args) {
+          return window.ethereum.on(...args);
+        },
+        removeListener(...args) {
+          return window.ethereum.removeListener(...args);
+        },
+        off(...args) {
+          return window.ethereum.off?.(...args);
+        },
+        once(...args) {
+          return window.ethereum.once?.(...args);
+        },
+      };
+
+      window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+        detail: {
+          info: {
+            uuid: "phantom-bnb-wallet",
+            name: "Phantom Wallet",
+            icon,
+            rdns: "com.phantom.browser",
+          },
+          provider,
+        },
+      }));
+    });
+  });
+
+  await page.goto("index.html");
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+  const phantomOption = page.locator(".wallet-picker-option", { hasText: "Phantom Wallet" });
+  await expect(phantomOption).toHaveCount(1);
+  await expect(phantomOption).toBeDisabled();
+  await expect(phantomOption).toContainText("Doesn't support BNB Smart Chain.");
+
+  await page.evaluate(() => {
+    const button = [...document.querySelectorAll(".wallet-picker-option")]
+      .find((candidate) => candidate.textContent?.includes("Phantom Wallet"));
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error("Phantom option not found.");
+    }
+
+    button.disabled = false;
+    button.click();
+  });
+
+  await expect(page.locator("#claimToastMessage")).toHaveText(
+    "Connect wallet: Phantom Wallet does not support BNB Smart Chain.",
+  );
+  await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toHaveCount(0);
+});
+
+test("wallet picker waits for config before disabling Phantom on BNB Smart Chain", async ({ page }) => {
+  await page.route("**/config.local.json", async (route) => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 750);
+    });
+    await route.continue();
+  });
+
+  await page.addInitScript(() => {
+    const storageKey = "liberdus-airdrop-ui-config";
+    const current = JSON.parse(window.localStorage.getItem(storageKey) || "{}");
+    window.localStorage.setItem(storageKey, JSON.stringify({
+      ...current,
+      chainId: 56,
+      networkName: "BNB Smart Chain",
+      rpcUrl: "https://bsc-dataseed.binance.org",
+      explorerBaseUrl: "https://bscscan.com",
+      nativeCurrency: {
+        name: "BNB",
+        symbol: "BNB",
+        decimals: 18,
+      },
+    }));
+
+    const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%2353f3c3'/%3E%3C/svg%3E";
+
+    window.addEventListener("ethereum#initialized", () => {
+      window.ethereum.isPhantom = true;
+    });
+
+    window.addEventListener("eip6963:requestProvider", () => {
+      const provider = {
+        get isPhantom() {
+          return true;
+        },
+        request(args) {
+          return window.ethereum.request(args);
+        },
+        on(...args) {
+          return window.ethereum.on(...args);
+        },
+        removeListener(...args) {
+          return window.ethereum.removeListener(...args);
+        },
+        off(...args) {
+          return window.ethereum.off?.(...args);
+        },
+        once(...args) {
+          return window.ethereum.once?.(...args);
+        },
+      };
+
+      window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+        detail: {
+          info: {
+            uuid: "phantom-delayed-config-wallet",
+            name: "Phantom Wallet",
+            icon,
+            rdns: "com.phantom.browser",
+          },
+          provider,
+        },
+      }));
+    });
+  });
+
+  await page.goto("index.html");
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+  const phantomOption = page.locator(".wallet-picker-option", { hasText: "Phantom Wallet" });
+  await expect(phantomOption).toHaveCount(1);
+  await expect(phantomOption).toBeDisabled();
+  await expect(phantomOption).toContainText("Doesn't support BNB Smart Chain.");
+});
+
+test("connect button shows a busy state while waiting for wallet config", async ({ page }) => {
+  await page.route("**/config.local.json", async (route) => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 750);
+    });
+    await route.continue();
+  });
+
+  await page.goto("index.html");
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+  await expect(page.getByRole("button", { name: "Connecting..." })).toBeDisabled();
+  await expect(page.locator(".wallet-picker")).toBeVisible();
+});
+
+test("wallet picker does not show a stray MetaMask entry for Firefox-style Phantom provider arrays", async ({ page }) => {
+  await page.addInitScript(() => {
+    const storageKey = "liberdus-airdrop-ui-config";
+    const current = JSON.parse(window.localStorage.getItem(storageKey) || "{}");
+    window.localStorage.setItem(storageKey, JSON.stringify({
+      ...current,
+      chainId: 56,
+      networkName: "BNB Smart Chain",
+      rpcUrl: "https://bsc-dataseed.binance.org",
+      explorerBaseUrl: "https://bscscan.com",
+      nativeCurrency: {
+        name: "BNB",
+        symbol: "BNB",
+        decimals: 18,
+      },
+    }));
+
+    const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%2353f3c3'/%3E%3C/svg%3E";
+
+    window.ethereum.providers = [window.ethereum];
+    window.ethereum.isMetaMask = true;
+    window.ethereum.isPhantom = false;
+    window.phantom = { ethereum: window.ethereum };
+
+    window.addEventListener("eip6963:requestProvider", () => {
+      const provider = {
+        get isPhantom() {
+          return true;
+        },
+        request(args) {
+          return window.ethereum.request(args);
+        },
+        on(...args) {
+          return window.ethereum.on(...args);
+        },
+        removeListener(...args) {
+          return window.ethereum.removeListener(...args);
+        },
+        off(...args) {
+          return window.ethereum.off?.(...args);
+        },
+        once(...args) {
+          return window.ethereum.once?.(...args);
+        },
+      };
+
+      window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+        detail: {
+          info: {
+            uuid: "firefox-phantom-wallet",
+            name: "Phantom Wallet",
+            icon,
+            rdns: "com.phantom.browser",
+          },
+          provider,
+        },
+      }));
+    });
+  });
+
+  await page.goto("index.html");
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+  await expect(page.locator(".wallet-picker-option", { hasText: "Phantom Wallet" })).toHaveCount(1);
+  await expect(page.getByRole("button", { name: /MetaMask/i })).toHaveCount(0);
+  await expect(page.locator(".wallet-picker-option", { hasText: "Phantom Wallet" })).toBeDisabled();
+});
+
 test("wallet picker removes a stale legacy entry once a later Phantom match is found", async ({ page }) => {
   await page.addInitScript(() => {
     let legacyLooksLikePhantom = false;

--- a/e2e/tests/claim/wallet-menu.spec.js
+++ b/e2e/tests/claim/wallet-menu.spec.js
@@ -91,6 +91,59 @@ test.describe("EIP-6963-only wallet discovery", () => {
   });
 });
 
+test("wallet picker merges Firefox-style Phantom variants into one option", async ({ page }) => {
+  await page.addInitScript(() => {
+    const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%2353f3c3'/%3E%3C/svg%3E";
+
+    window.addEventListener("ethereum#initialized", () => {
+      window.ethereum.isPhantom = true;
+    });
+
+    window.addEventListener("eip6963:requestProvider", () => {
+      const provider = {
+        get isPhantom() {
+          return true;
+        },
+        request(args) {
+          return window.ethereum.request(args);
+        },
+        on(...args) {
+          return window.ethereum.on(...args);
+        },
+        removeListener(...args) {
+          return window.ethereum.removeListener(...args);
+        },
+        off(...args) {
+          return window.ethereum.off?.(...args);
+        },
+        once(...args) {
+          return window.ethereum.once?.(...args);
+        },
+      };
+
+      window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+        detail: {
+          info: {
+            uuid: "test-phantom-wallet",
+            name: "Phantom Wallet",
+            icon,
+            rdns: "com.phantom.browser",
+          },
+          provider,
+        },
+      }));
+    });
+  });
+
+  await page.goto("index.html");
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+  const phantomOptions = page.getByRole("button", { name: /Phantom/i });
+  await expect(phantomOptions).toHaveCount(1);
+  await phantomOptions.first().click();
+  await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
+});
+
 test("connected claimant sees the generic empty state when no rounds have started", async ({ page, mockWallet }) => {
   await page.goto("index.html");
   await mockWallet.setAccount(page, mockWallet.accounts.claimant);

--- a/e2e/tests/claim/wallet-menu.spec.js
+++ b/e2e/tests/claim/wallet-menu.spec.js
@@ -24,9 +24,10 @@ test("claimant wallet menu shows the connected address, chain id, and disconnect
   await expect(page.getByText("Available claims will appear here after you connect.")).toBeVisible();
 });
 
-test("wallet picker merges a legacy wallet with the same EIP-6963 wallet announcement", async ({ page }) => {
+test("wallet picker merges a provider-array wallet with the same EIP-6963 wallet announcement", async ({ page }) => {
   await page.addInitScript(() => {
     const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E";
+    window.ethereum.providers = [window.ethereum];
 
     window.addEventListener("eip6963:requestProvider", () => {
       const provider = {
@@ -73,6 +74,114 @@ test("wallet picker merges a legacy wallet with the same EIP-6963 wallet announc
   await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
 });
 
+test("wallet picker keeps distinct EIP-6963 wallets separate when they share a brand", async ({ page }) => {
+  await page.addInitScript(() => {
+    const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%2353f3c3'/%3E%3C/svg%3E";
+
+    function createProvider() {
+      return {
+        get isPhantom() {
+          return true;
+        },
+        request(args) {
+          return window.ethereum.request(args);
+        },
+        on(...args) {
+          return window.ethereum.on(...args);
+        },
+        removeListener(...args) {
+          return window.ethereum.removeListener(...args);
+        },
+        off(...args) {
+          return window.ethereum.off?.(...args);
+        },
+        once(...args) {
+          return window.ethereum.once?.(...args);
+        },
+      };
+    }
+
+    window.addEventListener("eip6963:requestProvider", () => {
+      const wallets = [
+        { uuid: "phantom-alpha-wallet", name: "Phantom Alpha", rdns: "com.phantom.alpha" },
+        { uuid: "phantom-beta-wallet", name: "Phantom Beta", rdns: "com.phantom.beta" },
+      ];
+
+      for (const wallet of wallets) {
+        window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+          detail: {
+            info: {
+              ...wallet,
+              icon,
+            },
+            provider: createProvider(),
+          },
+        }));
+      }
+    });
+  });
+
+  await page.goto("index.html");
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+  await expect(page.getByRole("button", { name: /^Phantom/ })).toHaveCount(2);
+  await expect(page.getByRole("button", { name: /^Phantom Alpha$/ })).toHaveCount(1);
+  await expect(page.getByRole("button", { name: /^Phantom Beta$/ })).toHaveCount(1);
+});
+
+test("wallet picker keeps Frame separate from unrelated announced sh-prefixed wallets", async ({ page }) => {
+  await page.addInitScript(() => {
+    const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%233b82f6'/%3E%3C/svg%3E";
+
+    const markAsFrame = () => {
+      if (!window.ethereum) return;
+      window.ethereum.isMetaMask = false;
+      window.ethereum.isFrame = true;
+    };
+
+    markAsFrame();
+    window.addEventListener("ethereum#initialized", markAsFrame);
+
+    window.addEventListener("eip6963:requestProvider", () => {
+      const provider = {
+        request(args) {
+          return window.ethereum.request(args);
+        },
+        on(...args) {
+          return window.ethereum.on(...args);
+        },
+        removeListener(...args) {
+          return window.ethereum.removeListener(...args);
+        },
+        off(...args) {
+          return window.ethereum.off?.(...args);
+        },
+        once(...args) {
+          return window.ethereum.once?.(...args);
+        },
+      };
+
+      window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+        detail: {
+          info: {
+            uuid: "random-sh-wallet",
+            name: "Random Wallet",
+            icon,
+            rdns: "sh.random.wallet",
+          },
+          provider,
+        },
+      }));
+    });
+  });
+
+  await page.goto("index.html");
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+  await expect(page.getByRole("button", { name: /Frame/ })).toHaveCount(1);
+  await expect(page.getByRole("button", { name: /^Random Wallet$/ })).toHaveCount(1);
+});
+
 test.describe("EIP-6963-only wallet discovery", () => {
   test.use({ walletDiscoveryMode: "eip6963-only" });
 
@@ -88,6 +197,199 @@ test.describe("EIP-6963-only wallet discovery", () => {
     await openWalletMenu(page, /0xf39f\.\.\.2266/i);
     await expect(page.locator("#walletMenu")).toBeVisible();
     await expect(page.locator("#walletMenuChainId")).toHaveText("1337");
+  });
+});
+
+test.describe("Manual EIP-6963 announcements", () => {
+  test.use({ walletDiscoveryMode: "manual-eip6963" });
+
+  test("wallet picker keeps distinct announced wallets separate when they share rdns", async ({ page }) => {
+    await page.addInitScript(() => {
+      const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E";
+
+      function createProvider() {
+        return {
+          get isMetaMask() {
+            return true;
+          },
+          request(args) {
+            return window.__liberdusMockWalletProvider.request(args);
+          },
+          on(...args) {
+            return window.__liberdusMockWalletProvider.on(...args);
+          },
+          removeListener(...args) {
+            return window.__liberdusMockWalletProvider.removeListener(...args);
+          },
+          off(...args) {
+            return window.__liberdusMockWalletProvider.off?.(...args);
+          },
+          once(...args) {
+            return window.__liberdusMockWalletProvider.once?.(...args);
+          },
+        };
+      }
+
+      window.addEventListener("eip6963:requestProvider", () => {
+        const wallets = [
+          { uuid: "metamask-primary-wallet", name: "MetaMask Primary", rdns: "io.metamask" },
+          { uuid: "metamask-secondary-wallet", name: "MetaMask Secondary", rdns: "io.metamask" },
+        ];
+
+        for (const wallet of wallets) {
+          window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+            detail: {
+              info: {
+                ...wallet,
+                icon,
+              },
+              provider: createProvider(),
+            },
+          }));
+        }
+      });
+    });
+
+    await page.goto("index.html");
+    await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+    await expect(page.getByRole("button", { name: /^MetaMask/ })).toHaveCount(2);
+    await expect(page.getByRole("button", { name: /^MetaMask Primary$/ })).toHaveCount(1);
+    await expect(page.getByRole("button", { name: /^MetaMask Secondary$/ })).toHaveCount(1);
+  });
+
+  test("selected announced wallet session restores after reload", async ({ page }) => {
+    await page.addInitScript(() => {
+      const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E";
+
+      function appendRequest(walletName, method) {
+        const current = JSON.parse(window.localStorage.getItem("__wallet_request_log__") || "[]");
+        current.push({ walletName, method });
+        window.localStorage.setItem("__wallet_request_log__", JSON.stringify(current));
+      }
+
+      function createProvider(walletName) {
+        return {
+          get isMetaMask() {
+            return true;
+          },
+          request(args) {
+            appendRequest(walletName, String(args?.method || ""));
+            return window.__liberdusMockWalletProvider.request(args);
+          },
+          on(...args) {
+            return window.__liberdusMockWalletProvider.on(...args);
+          },
+          removeListener(...args) {
+            return window.__liberdusMockWalletProvider.removeListener(...args);
+          },
+          off(...args) {
+            return window.__liberdusMockWalletProvider.off?.(...args);
+          },
+          once(...args) {
+            return window.__liberdusMockWalletProvider.once?.(...args);
+          },
+        };
+      }
+
+      window.addEventListener("eip6963:requestProvider", () => {
+        const wallets = [
+          { uuid: "metamask-primary-wallet", name: "MetaMask Primary", rdns: "io.metamask" },
+          { uuid: "metamask-secondary-wallet", name: "MetaMask Secondary", rdns: "io.metamask" },
+        ];
+
+        for (const wallet of wallets) {
+          window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+            detail: {
+              info: {
+                ...wallet,
+                icon,
+              },
+              provider: createProvider(wallet.name),
+            },
+          }));
+        }
+      });
+    });
+
+    await page.goto("index.html");
+    await page.getByRole("button", { name: "Connect Wallet" }).click();
+    await page.getByRole("button", { name: /^MetaMask Secondary$/ }).click();
+    await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
+
+    await page.evaluate(() => {
+      window.localStorage.setItem("__wallet_request_log__", "[]");
+    });
+
+    await page.reload();
+    await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
+    await page.waitForFunction(() => {
+      const entries = JSON.parse(window.localStorage.getItem("__wallet_request_log__") || "[]");
+      return entries.length > 0;
+    });
+
+    const requestLog = await page.evaluate(() => JSON.parse(window.localStorage.getItem("__wallet_request_log__") || "[]"));
+    const restoredWalletNames = [...new Set(requestLog.map((entry) => entry.walletName))];
+    expect(restoredWalletNames).toEqual(["MetaMask Secondary"]);
+    await expect.poll(async () => page.evaluate(() => {
+      return JSON.parse(window.localStorage.getItem("liberdus-airdrop-wallet-session") || "null")?.walletId || null;
+    })).toBe("metamask-secondary-wallet");
+  });
+
+  test("wallet picker uses the latest announced provider wrapper", async ({ page }) => {
+    await page.addInitScript(() => {
+      const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E";
+      let latestGeneration = 0;
+
+      function createProvider(wrapperGeneration) {
+        return {
+          get isMetaMask() {
+            return true;
+          },
+          request(args) {
+            if (wrapperGeneration !== latestGeneration) {
+              const error = new Error("Stale EIP-6963 wrapper");
+              error.code = 4999;
+              throw error;
+            }
+            return window.__liberdusMockWalletProvider.request(args);
+          },
+          on(...args) {
+            return window.__liberdusMockWalletProvider.on(...args);
+          },
+          removeListener(...args) {
+            return window.__liberdusMockWalletProvider.removeListener(...args);
+          },
+          off(...args) {
+            return window.__liberdusMockWalletProvider.off?.(...args);
+          },
+          once(...args) {
+            return window.__liberdusMockWalletProvider.once?.(...args);
+          },
+        };
+      }
+
+      window.addEventListener("eip6963:requestProvider", () => {
+        latestGeneration += 1;
+        window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+          detail: {
+            info: {
+              uuid: "metamask-live-wrapper",
+              name: "MetaMask",
+              icon,
+              rdns: "io.metamask",
+            },
+            provider: createProvider(latestGeneration),
+          },
+        }));
+      });
+    });
+
+    await page.goto("index.html");
+    await page.getByRole("button", { name: "Connect Wallet" }).click();
+    await page.getByRole("button", { name: /^MetaMask$/ }).click();
+
+    await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
   });
 });
 
@@ -207,6 +509,55 @@ test("wallet picker removes a stale legacy entry once a later Phantom match is f
 
   await expect(page.getByRole("button", { name: /Phantom/i })).toHaveCount(1);
   await expect(page.getByRole("button", { name: /Injected Wallet/i })).toHaveCount(0);
+});
+
+test("stale legacy shim sessions are cleared instead of rebinding to an announced wallet", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("liberdus-airdrop-wallet-session", JSON.stringify({ walletId: "legacy:default" }));
+
+    const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%2353f3c3'/%3E%3C/svg%3E";
+    window.addEventListener("eip6963:requestProvider", () => {
+      const provider = {
+        get isPhantom() {
+          return true;
+        },
+        request(args) {
+          return window.ethereum.request(args);
+        },
+        on(...args) {
+          return window.ethereum.on(...args);
+        },
+        removeListener(...args) {
+          return window.ethereum.removeListener(...args);
+        },
+        off(...args) {
+          return window.ethereum.off?.(...args);
+        },
+        once(...args) {
+          return window.ethereum.once?.(...args);
+        },
+      };
+
+      window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+        detail: {
+          info: {
+            uuid: "unrelated-phantom-wallet",
+            name: "Phantom Wallet",
+            icon,
+            rdns: "com.phantom.browser",
+          },
+          provider,
+        },
+      }));
+    });
+  });
+
+  await page.goto("index.html");
+  await expect(page.getByRole("button", { name: "Connect Wallet" })).toBeVisible();
+  await expect.poll(async () => page.evaluate(() => window.localStorage.getItem("liberdus-airdrop-wallet-session"))).toBeNull();
+
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+  await expect(page.getByText("Last used")).toHaveCount(0);
 });
 
 test("connected claimant sees the generic empty state when no rounds have started", async ({ page, mockWallet }) => {

--- a/e2e/tests/claim/wallet-menu.spec.js
+++ b/e2e/tests/claim/wallet-menu.spec.js
@@ -144,6 +144,71 @@ test("wallet picker merges Firefox-style Phantom variants into one option", asyn
   await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
 });
 
+test("wallet picker removes a stale legacy entry once a later Phantom match is found", async ({ page }) => {
+  await page.addInitScript(() => {
+    let legacyLooksLikePhantom = false;
+    const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%2353f3c3'/%3E%3C/svg%3E";
+
+    window.addEventListener("ethereum#initialized", () => {
+      Object.defineProperty(window.ethereum, "isMetaMask", {
+        configurable: true,
+        get() {
+          return false;
+        },
+      });
+      Object.defineProperty(window.ethereum, "isPhantom", {
+        configurable: true,
+        get() {
+          return legacyLooksLikePhantom;
+        },
+      });
+    });
+
+    window.addEventListener("eip6963:requestProvider", () => {
+      legacyLooksLikePhantom = true;
+
+      const provider = {
+        get isPhantom() {
+          return true;
+        },
+        request(args) {
+          return window.ethereum.request(args);
+        },
+        on(...args) {
+          return window.ethereum.on(...args);
+        },
+        removeListener(...args) {
+          return window.ethereum.removeListener(...args);
+        },
+        off(...args) {
+          return window.ethereum.off?.(...args);
+        },
+        once(...args) {
+          return window.ethereum.once?.(...args);
+        },
+      };
+
+      window.dispatchEvent(new CustomEvent("eip6963:announceProvider", {
+        detail: {
+          info: {
+            uuid: "late-phantom-match",
+            name: "Phantom Wallet",
+            icon,
+            rdns: "com.phantom.browser",
+          },
+          provider,
+        },
+      }));
+    });
+  });
+
+  await page.goto("index.html");
+  await page.getByRole("button", { name: "Connect Wallet" }).click();
+
+  await expect(page.getByRole("button", { name: /Phantom/i })).toHaveCount(1);
+  await expect(page.getByRole("button", { name: /Injected Wallet/i })).toHaveCount(0);
+});
+
 test("connected claimant sees the generic empty state when no rounds have started", async ({ page, mockWallet }) => {
   await page.goto("index.html");
   await mockWallet.setAccount(page, mockWallet.accounts.claimant);

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -2714,6 +2714,7 @@ function bindEvents() {
 
   bindWalletEvents({
     onAccountsChanged: async () => {
+      if (runtime.isConnectingWallet) return;
       await refreshPage();
       clearMessage();
     },

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -295,6 +295,7 @@ function clearMessage() {
 
 const logger = { log: setMessage, clear: clearMessage };
 const reportError = createErrorReporter(logger.log, () => runtime);
+let configReadyPromise = Promise.resolve();
 let pageInitPromise = Promise.resolve();
 const ADMIN_LINKED_WALLET_PAGE_SIZE = 200;
 const ADMIN_ACCOUNTS_TEMPLATE_CSV = [
@@ -2099,18 +2100,27 @@ function bindEvents() {
       return;
     }
 
+    if (runtime.isConnectingWallet) {
+      return;
+    }
+
     try {
-      const wallets = await getAvailableWallets();
+      runtime.isConnectingWallet = true;
+      syncWalletButton();
+      await configReadyPromise;
+      const wallets = await getAvailableWallets(runtime.config);
       const selectedWalletId = await promptForWalletSelection({
         wallets,
         selectedWalletId: runtime.selectedWalletId,
         title: "Select Wallet",
       });
 
-      if (!selectedWalletId) return;
+      if (!selectedWalletId) {
+        runtime.isConnectingWallet = false;
+        syncWalletButton();
+        return;
+      }
 
-      runtime.isConnectingWallet = true;
-      syncWalletButton();
       await connectWallet(runtime, selectedWalletId);
       await pageInitPromise;
       await tryAutoSwitchAfterConnect();
@@ -2748,12 +2758,16 @@ async function init() {
   renderClaimLookupResults();
   syncAdminTabs();
 
+  configReadyPromise = (async () => {
+    const loaded = await loadUiConfig();
+    runtime.config = loaded.config;
+    runtime.configSource = loaded.source;
+  })();
+
   pageInitPromise = (async () => {
     updateToastOffset();
     try {
-      const loaded = await loadUiConfig();
-      runtime.config = loaded.config;
-      runtime.configSource = loaded.source;
+      await configReadyPromise;
       await ensureProvider(runtime).catch(() => null);
       await refreshPage();
     } catch (error) {

--- a/frontend/js/pages/claim.js
+++ b/frontend/js/pages/claim.js
@@ -573,6 +573,7 @@ function ensureReadProvider() {
 
 const logger = { log: setMessage, clear: clearMessage };
 const reportError = createErrorReporter(logger.log, () => runtime);
+let configReadyPromise = Promise.resolve();
 let pageInitPromise = Promise.resolve();
 
 function updateToastOffset() {
@@ -1272,18 +1273,27 @@ function bindEvents() {
       return;
     }
 
+    if (runtime.isConnectingWallet) {
+      return;
+    }
+
     try {
-      const wallets = await getAvailableWallets();
+      runtime.isConnectingWallet = true;
+      syncWalletButton();
+      await configReadyPromise;
+      const wallets = await getAvailableWallets(runtime.config);
       const selectedWalletId = await promptForWalletSelection({
         wallets,
         selectedWalletId: runtime.selectedWalletId,
         title: "Select Wallet",
       });
 
-      if (!selectedWalletId) return;
+      if (!selectedWalletId) {
+        runtime.isConnectingWallet = false;
+        syncWalletButton();
+        return;
+      }
 
-      runtime.isConnectingWallet = true;
-      syncWalletButton();
       await connectWallet(runtime, selectedWalletId);
       await pageInitPromise;
       runtime.isConnectingWallet = false;
@@ -1431,16 +1441,20 @@ async function init() {
   bindEvents();
   updateToastOffset();
 
+  configReadyPromise = (async () => {
+    const loaded = await loadUiConfig();
+    runtime.config = loaded.config;
+    runtime.configSource = loaded.source;
+    runtime.readProvider = null;
+    runtime.readProviderKey = null;
+    syncXSessionFromStorage();
+    syncXAuthCard();
+  })();
+
   pageInitPromise = (async () => {
     updateToastOffset();
     try {
-      const loaded = await loadUiConfig();
-      runtime.config = loaded.config;
-      runtime.configSource = loaded.source;
-      runtime.readProvider = null;
-      runtime.readProviderKey = null;
-      syncXSessionFromStorage();
-      syncXAuthCard();
+      await configReadyPromise;
 
       try {
         const xAuthResult = await completeXLoginIfPresent(runtime.config);

--- a/frontend/js/pages/claim.js
+++ b/frontend/js/pages/claim.js
@@ -1390,6 +1390,7 @@ function bindEvents() {
 
   bindWalletEvents({
     onAccountsChanged: async () => {
+      if (runtime.isConnectingWallet) return;
       runtime.claimInFlightEpoch = null;
       hideClaimCelebration({ restoreFocus: false, immediate: true });
       await refreshPage();

--- a/frontend/js/shared/wallet-picker.js
+++ b/frontend/js/shared/wallet-picker.js
@@ -13,6 +13,10 @@ function createWalletInitials(name) {
   return parts.map((part) => part[0]?.toUpperCase() || "").join("");
 }
 
+function createWalletReasonId(walletId) {
+  return `walletPickerReason-${String(walletId || "wallet").replace(/[^a-z0-9_-]+/gi, "-")}`;
+}
+
 function ensureWalletPicker() {
   if (walletPickerElements) return walletPickerElements;
 
@@ -91,6 +95,7 @@ function createWalletOption(wallet, selectedWalletId) {
   button.type = "button";
   button.className = "wallet-picker-option";
   button.dataset.walletId = wallet.id;
+  button.disabled = Boolean(wallet.isDisabled);
 
   const iconShell = document.createElement("span");
   iconShell.className = "wallet-picker-icon-shell";
@@ -121,6 +126,16 @@ function createWalletOption(wallet, selectedWalletId) {
   label.className = "wallet-picker-name";
   label.textContent = wallet.info?.name || "Injected Wallet";
   copy.append(label);
+
+  if (wallet.disabledReason) {
+    const reason = document.createElement("span");
+    reason.className = "wallet-picker-reason";
+    reason.id = createWalletReasonId(wallet.id);
+    reason.textContent = wallet.disabledReason;
+    copy.append(reason);
+    button.setAttribute("aria-describedby", reason.id);
+    button.title = wallet.disabledReason;
+  }
 
   if (wallet.id === selectedWalletId) {
     const badge = document.createElement("span");
@@ -172,7 +187,7 @@ export function promptForWalletSelection({
     const button = event.target instanceof Element
       ? event.target.closest("[data-wallet-id]")
       : null;
-    if (!button) return;
+    if (!button || button.disabled) return;
 
     closeWalletPicker(button.dataset.walletId || null);
   };
@@ -199,7 +214,7 @@ export function promptForWalletSelection({
   document.body.classList.add("wallet-picker-open");
   elements.overlay.hidden = false;
 
-  const firstOption = elements.list.querySelector("[data-wallet-id]");
+  const firstOption = elements.list.querySelector("[data-wallet-id]:not(:disabled)");
   window.setTimeout(() => {
     if (firstOption instanceof HTMLElement) {
       firstOption.focus();

--- a/frontend/js/shared/wallet.js
+++ b/frontend/js/shared/wallet.js
@@ -6,10 +6,22 @@ const EIP6963_REQUEST_EVENT = "eip6963:requestProvider";
 const LEGACY_WALLET_PREFIX = "legacy";
 const LEGACY_DEFAULT_WALLET_ID = `${LEGACY_WALLET_PREFIX}:default`;
 const GENERIC_WALLET_NAME_KEYS = new Set(["wallet", "injected-wallet"]);
+const GENERIC_WALLET_IDENTITY_TOKENS = new Set([
+  "app",
+  "browser",
+  "com",
+  "extension",
+  "injected",
+  "io",
+  "org",
+  "provider",
+  "providers",
+  "wallet",
+  "www",
+]);
 
-const discoveredWallets = new Map();
-const providerIds = new WeakMap();
-const walletIdentityIds = new Map();
+const walletObservations = new Map();
+const providerObservationIds = new WeakMap();
 const walletEventSubscribers = new Set();
 
 let discoveryInitialized = false;
@@ -113,18 +125,25 @@ function normalizeWalletNameKey(value) {
   return normalizeWalletIdentityValue(value).replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
-function resolveWalletBrand(provider, info = {}) {
-  const rdns = normalizeWalletIdentityValue(info.rdns || guessLegacyWalletRdns(provider));
-  const name = normalizeWalletIdentityValue(info.name || guessLegacyWalletName(provider));
+function getWalletIdentityTokens(provider, info = {}) {
+  const values = [
+    normalizeWalletIdentityValue(info.rdns || guessLegacyWalletRdns(provider)),
+    normalizeWalletIdentityValue(info.name || guessLegacyWalletName(provider)),
+  ];
+  const tokens = new Set();
 
-  if (provider?.isPhantom || rdns.includes("phantom") || name.includes("phantom")) return "phantom";
-  if (provider?.isRabby || rdns.includes("rabby") || name.includes("rabby")) return "rabby";
-  if (provider?.isCoinbaseWallet || rdns.includes("coinbase") || name.includes("coinbase")) return "coinbase-wallet";
-  if (provider?.isBraveWallet || rdns.includes("brave") || name.includes("brave")) return "brave-wallet";
-  if (provider?.isFrame || rdns.includes("frame") || name.includes("frame")) return "frame";
-  if (provider?.isTally || rdns.includes("tally") || name.includes("taho") || name.includes("tally")) return "taho";
-  if (provider?.isMetaMask || rdns.includes("metamask") || name.includes("metamask")) return "metamask";
-  return "";
+  for (const value of values) {
+    if (!value) continue;
+    const pieces = value.split(/[^a-z0-9]+/).filter(Boolean);
+    for (const piece of pieces) {
+      if (piece.length < 2) continue;
+      if (/^\d+$/u.test(piece)) continue;
+      if (GENERIC_WALLET_IDENTITY_TOKENS.has(piece)) continue;
+      tokens.add(piece);
+    }
+  }
+
+  return [...tokens];
 }
 
 function getWalletIdentityKeys(provider, info = {}) {
@@ -132,10 +151,11 @@ function getWalletIdentityKeys(provider, info = {}) {
   const uuid = normalizeWalletIdentityValue(info.uuid);
   const rdns = normalizeWalletIdentityValue(info.rdns || guessLegacyWalletRdns(provider));
   const nameKey = normalizeWalletNameKey(info.name || guessLegacyWalletName(provider));
-  const brand = resolveWalletBrand(provider, info);
 
   if (uuid) keys.push(`uuid:${uuid}`);
-  if (brand) keys.push(`brand:${brand}`);
+  for (const token of getWalletIdentityTokens(provider, info)) {
+    keys.push(`brand:${token}`);
+  }
   if (rdns) keys.push(`rdns:${rdns}`);
   if (nameKey && !GENERIC_WALLET_NAME_KEYS.has(nameKey)) {
     keys.push(`name:${nameKey}`);
@@ -144,33 +164,46 @@ function getWalletIdentityKeys(provider, info = {}) {
   return [...new Set(keys)];
 }
 
-function findWalletIdentityId(provider, info = {}) {
-  for (const key of getWalletIdentityKeys(provider, info)) {
-    const walletId = walletIdentityIds.get(key);
-    if (walletId) return walletId;
-  }
-
-  return null;
+function mergeWalletInfo(primary = {}, secondary = {}) {
+  return {
+    uuid: String(primary.uuid || secondary.uuid || ""),
+    name: String(primary.name || secondary.name || "Injected Wallet"),
+    icon: String(primary.icon || secondary.icon || ""),
+    rdns: String(primary.rdns || secondary.rdns || ""),
+  };
 }
 
-function rememberWalletIdentity(walletId, provider, info = {}) {
-  for (const key of getWalletIdentityKeys(provider, info)) {
-    walletIdentityIds.set(key, walletId);
-  }
+function mergeSourceIds(primaryIds = [], secondaryIds = []) {
+  return [...new Set([...primaryIds.filter(Boolean), ...secondaryIds.filter(Boolean)])];
 }
 
-function resolveWalletProvider(previous, candidate) {
-  if (!previous?.provider) return candidate?.provider || null;
-  if (candidate?.source === "eip6963") return candidate.provider;
-  return previous.provider;
+function createWalletObservation(candidate) {
+  return {
+    observationId: `observation:${walletObservations.size + 1}`,
+    provider: candidate.provider,
+    source: candidate.source || LEGACY_WALLET_PREFIX,
+    sourceIds: candidate.id ? [candidate.id] : [],
+    info: mergeWalletInfo(candidate.info || {}),
+  };
 }
 
-function resolveWalletSource(previous, candidate) {
-  if (previous?.source === "eip6963" || candidate?.source === "eip6963") {
-    return "eip6963";
-  }
+function mergeWalletObservation(previous, candidate) {
+  const candidateSource = candidate.source || LEGACY_WALLET_PREFIX;
+  const preferCandidateInfo = candidateSource === "eip6963" || previous.source !== "eip6963";
+  const primaryInfo = preferCandidateInfo ? (candidate.info || {}) : previous.info;
+  const secondaryInfo = preferCandidateInfo ? previous.info : (candidate.info || {});
+  const primaryIds = candidateSource === "eip6963" ? [candidate.id] : previous.sourceIds;
+  const secondaryIds = candidateSource === "eip6963" ? previous.sourceIds : [candidate.id];
 
-  return candidate?.source || previous?.source || LEGACY_WALLET_PREFIX;
+  return {
+    observationId: previous.observationId,
+    provider: candidate.provider,
+    source: previous.source === "eip6963" || candidateSource === "eip6963"
+      ? "eip6963"
+      : candidateSource,
+    sourceIds: mergeSourceIds(primaryIds, secondaryIds),
+    info: mergeWalletInfo(primaryInfo, secondaryInfo),
+  };
 }
 
 function getWalletSortLabel(wallet) {
@@ -178,7 +211,135 @@ function getWalletSortLabel(wallet) {
 }
 
 function listWalletsSnapshot() {
-  return [...discoveredWallets.values()].sort((left, right) => getWalletSortLabel(left).localeCompare(getWalletSortLabel(right)));
+  const buckets = new Map();
+  const bucketIdsByKey = new Map();
+  let nextBucketIndex = 1;
+
+  function ensureBucket(bucketId) {
+    if (!buckets.has(bucketId)) {
+      buckets.set(bucketId, {
+        id: bucketId,
+        identityKeys: new Set(),
+        observations: [],
+      });
+    }
+    return buckets.get(bucketId);
+  }
+
+  function mergeBuckets(targetBucketId, sourceBucketId) {
+    if (!sourceBucketId || sourceBucketId === targetBucketId) return targetBucketId;
+    const targetBucket = ensureBucket(targetBucketId);
+    const sourceBucket = buckets.get(sourceBucketId);
+    if (!sourceBucket) return targetBucketId;
+
+    for (const observation of sourceBucket.observations) {
+      if (!targetBucket.observations.includes(observation)) {
+        targetBucket.observations.push(observation);
+      }
+    }
+
+    for (const key of sourceBucket.identityKeys) {
+      targetBucket.identityKeys.add(key);
+      bucketIdsByKey.set(key, targetBucketId);
+    }
+
+    buckets.delete(sourceBucketId);
+    return targetBucketId;
+  }
+
+  for (const observation of walletObservations.values()) {
+    const identityKeys = getWalletIdentityKeys(observation.provider, observation.info);
+    const keys = identityKeys.length ? identityKeys : [`observation:${observation.observationId}`];
+    const matchedBucketIds = [...new Set(keys.map((key) => bucketIdsByKey.get(key)).filter(Boolean))];
+    const bucketId = matchedBucketIds[0] || `bucket:${nextBucketIndex++}`;
+
+    ensureBucket(bucketId);
+    for (const extraBucketId of matchedBucketIds.slice(1)) {
+      mergeBuckets(bucketId, extraBucketId);
+    }
+
+    const bucket = ensureBucket(bucketId);
+    bucket.observations.push(observation);
+    for (const key of keys) {
+      bucket.identityKeys.add(key);
+      bucketIdsByKey.set(key, bucketId);
+    }
+  }
+
+  return [...buckets.values()]
+    .map((bucket) => createWalletDescriptor(bucket))
+    .filter(Boolean)
+    .sort((left, right) => getWalletSortLabel(left).localeCompare(getWalletSortLabel(right)));
+}
+
+function compareObservationPreference(left, right) {
+  const leftRank = [
+    left.source === "eip6963" ? 1 : 0,
+    left.info?.uuid ? 1 : 0,
+    left.info?.icon ? 1 : 0,
+    left.info?.rdns ? 1 : 0,
+    left.info?.name ? 1 : 0,
+  ];
+  const rightRank = [
+    right.source === "eip6963" ? 1 : 0,
+    right.info?.uuid ? 1 : 0,
+    right.info?.icon ? 1 : 0,
+    right.info?.rdns ? 1 : 0,
+    right.info?.name ? 1 : 0,
+  ];
+
+  for (let index = 0; index < leftRank.length; index += 1) {
+    if (leftRank[index] !== rightRank[index]) {
+      return rightRank[index] - leftRank[index];
+    }
+  }
+
+  return 0;
+}
+
+function pickPreferredObservation(observations) {
+  return [...observations].sort(compareObservationPreference)[0] || null;
+}
+
+function createWalletDescriptor(bucket) {
+  const preferredObservation = pickPreferredObservation(bucket.observations);
+  if (!preferredObservation) return null;
+
+  let info = mergeWalletInfo(preferredObservation.info);
+  for (const observation of bucket.observations) {
+    if (observation === preferredObservation) continue;
+    info = mergeWalletInfo(info, observation.info);
+  }
+
+  const preferredId = preferredObservation.sourceIds[0] || "";
+  const walletId = preferredId || createWalletId(
+    preferredObservation.source || LEGACY_WALLET_PREFIX,
+    info.name,
+    "wallet",
+  );
+  const aliases = new Set();
+
+  for (const observation of bucket.observations) {
+    for (const sourceId of observation.sourceIds) {
+      if (sourceId && sourceId !== walletId) {
+        aliases.add(sourceId);
+      }
+    }
+  }
+
+  return {
+    id: walletId,
+    provider: preferredObservation.provider,
+    source: bucket.observations.some((observation) => observation.source === "eip6963")
+      ? "eip6963"
+      : (preferredObservation.source || LEGACY_WALLET_PREFIX),
+    info,
+    aliases,
+  };
+}
+
+function findWalletById(wallets, walletId) {
+  return wallets.find((wallet) => wallet.id === walletId || wallet.aliases?.has(walletId)) || null;
 }
 
 function unbindWalletEventProvider() {
@@ -248,39 +409,22 @@ function registerWallet(candidate) {
   const provider = candidate?.provider;
   if (!provider || typeof provider.request !== "function") return null;
 
-  const existingId = providerIds.get(provider);
-  const info = candidate?.info || {};
-  const matchingIdentityId = findWalletIdentityId(provider, info);
-  const nextId = existingId
-    || matchingIdentityId
-    || candidate?.id
-    || info.uuid
-    || info.rdns
-    || createWalletId(candidate?.source || LEGACY_WALLET_PREFIX, info.name, "wallet");
-  const previous = discoveredWallets.get(nextId);
+  const existingObservationId = providerObservationIds.get(provider);
+  if (existingObservationId) {
+    const previousObservation = walletObservations.get(existingObservationId);
+    if (!previousObservation) return null;
 
-  const descriptor = {
-    id: nextId,
-    provider: resolveWalletProvider(previous, candidate),
-    source: resolveWalletSource(previous, candidate),
-    info: {
-      uuid: info.uuid || previous?.info?.uuid || "",
-      name: info.name || previous?.info?.name || "Injected Wallet",
-      icon: info.icon || previous?.info?.icon || "",
-      rdns: info.rdns || previous?.info?.rdns || "",
-    },
-  };
-
-  discoveredWallets.set(nextId, descriptor);
-  providerIds.set(provider, nextId);
-  if (previous?.provider) {
-    providerIds.set(previous.provider, nextId);
-    rememberWalletIdentity(nextId, previous.provider, previous.info);
+    const nextObservation = mergeWalletObservation(previousObservation, candidate);
+    walletObservations.set(existingObservationId, nextObservation);
+    syncWalletEventProvider();
+    return nextObservation;
   }
-  rememberWalletIdentity(nextId, provider, info);
-  rememberWalletIdentity(nextId, descriptor.provider, descriptor.info);
+
+  const observation = createWalletObservation(candidate);
+  walletObservations.set(observation.observationId, observation);
+  providerObservationIds.set(provider, observation.observationId);
   syncWalletEventProvider();
-  return descriptor;
+  return observation;
 }
 
 function registerLegacyWallet(provider, index = 0) {
@@ -377,10 +521,10 @@ function applyActiveWallet(runtime, wallet) {
 
 async function resolveWalletById(walletId) {
   if (!walletId) return null;
-  const cachedWallet = discoveredWallets.get(walletId);
+  const cachedWallet = findWalletById(listWalletsSnapshot(), walletId);
   if (cachedWallet) return cachedWallet;
   const wallets = await discoverWallets();
-  return wallets.find((wallet) => wallet.id === walletId) || null;
+  return findWalletById(wallets, walletId);
 }
 
 export async function getAvailableWallets() {

--- a/frontend/js/shared/wallet.js
+++ b/frontend/js/shared/wallet.js
@@ -113,13 +113,29 @@ function normalizeWalletNameKey(value) {
   return normalizeWalletIdentityValue(value).replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
+function resolveWalletBrand(provider, info = {}) {
+  const rdns = normalizeWalletIdentityValue(info.rdns || guessLegacyWalletRdns(provider));
+  const name = normalizeWalletIdentityValue(info.name || guessLegacyWalletName(provider));
+
+  if (provider?.isPhantom || rdns.includes("phantom") || name.includes("phantom")) return "phantom";
+  if (provider?.isRabby || rdns.includes("rabby") || name.includes("rabby")) return "rabby";
+  if (provider?.isCoinbaseWallet || rdns.includes("coinbase") || name.includes("coinbase")) return "coinbase-wallet";
+  if (provider?.isBraveWallet || rdns.includes("brave") || name.includes("brave")) return "brave-wallet";
+  if (provider?.isFrame || rdns.includes("frame") || name.includes("frame")) return "frame";
+  if (provider?.isTally || rdns.includes("tally") || name.includes("taho") || name.includes("tally")) return "taho";
+  if (provider?.isMetaMask || rdns.includes("metamask") || name.includes("metamask")) return "metamask";
+  return "";
+}
+
 function getWalletIdentityKeys(provider, info = {}) {
   const keys = [];
   const uuid = normalizeWalletIdentityValue(info.uuid);
   const rdns = normalizeWalletIdentityValue(info.rdns || guessLegacyWalletRdns(provider));
   const nameKey = normalizeWalletNameKey(info.name || guessLegacyWalletName(provider));
+  const brand = resolveWalletBrand(provider, info);
 
   if (uuid) keys.push(`uuid:${uuid}`);
+  if (brand) keys.push(`brand:${brand}`);
   if (rdns) keys.push(`rdns:${rdns}`);
   if (nameKey && !GENERIC_WALLET_NAME_KEYS.has(nameKey)) {
     keys.push(`name:${nameKey}`);

--- a/frontend/js/shared/wallet.js
+++ b/frontend/js/shared/wallet.js
@@ -86,8 +86,27 @@ function applyNetworkToRuntime(runtime, network) {
   runtime.chainName = resolveChainName(runtime, runtime.chainId, network.name);
 }
 
+function matchesWalletNamespaceProvider(namespaceProvider, provider) {
+  if (!namespaceProvider || !provider) return false;
+  if (namespaceProvider === provider) return true;
+
+  const namespaceProviders = Array.isArray(namespaceProvider.providers)
+    ? namespaceProvider.providers
+    : [];
+  const candidateProviders = Array.isArray(provider.providers)
+    ? provider.providers
+    : [];
+
+  return namespaceProviders.includes(provider) || candidateProviders.includes(namespaceProvider);
+}
+
+function isPhantomNamespaceProvider(provider) {
+  if (typeof window === "undefined") return false;
+  return matchesWalletNamespaceProvider(window.phantom?.ethereum, provider);
+}
+
 function guessLegacyWalletName(provider) {
-  if (provider?.isPhantom) return "Phantom";
+  if (provider?.isPhantom || isPhantomNamespaceProvider(provider)) return "Phantom";
   if (provider?.isRabby) return "Rabby";
   if (provider?.isCoinbaseWallet) return "Coinbase Wallet";
   if (provider?.isBraveWallet) return "Brave Wallet";
@@ -98,7 +117,7 @@ function guessLegacyWalletName(provider) {
 }
 
 function guessLegacyWalletRdns(provider) {
-  if (provider?.isPhantom) return "app.phantom";
+  if (provider?.isPhantom || isPhantomNamespaceProvider(provider)) return "com.phantom.browser";
   if (provider?.isRabby) return "io.rabby";
   if (provider?.isCoinbaseWallet) return "com.coinbase.wallet";
   if (provider?.isBraveWallet) return "com.brave.wallet";
@@ -119,6 +138,64 @@ function normalizeWalletInfo(info = {}) {
     icon: String(info.icon || "").trim(),
     rdns: normalizeWalletIdentityValue(info.rdns),
   };
+}
+
+function isBnbChainConfig(config) {
+  const chainId = Number(config?.chainId);
+  return chainId === 56 || chainId === 97;
+}
+
+function getConfiguredNetworkLabel(config) {
+  return String(config?.networkName || "").trim() || "the configured network";
+}
+
+function isPhantomWallet(wallet) {
+  if (!wallet) return false;
+
+  const name = normalizeWalletIdentityValue(wallet.info?.name);
+  const rdns = normalizeWalletIdentityValue(wallet.info?.rdns);
+  return name.includes("phantom")
+    || rdns.includes("phantom")
+    || Boolean(wallet.provider?.isPhantom)
+    || isPhantomNamespaceProvider(wallet.provider);
+}
+
+function getWalletCompatibility(config, wallet) {
+  if (!wallet) {
+    return {
+      isSupported: true,
+      isDisabled: false,
+      disabledReason: "",
+      errorMessage: "",
+    };
+  }
+
+  if (isBnbChainConfig(config) && isPhantomWallet(wallet)) {
+    const networkLabel = getConfiguredNetworkLabel(config);
+    const walletName = wallet.info?.name || "This wallet";
+    return {
+      isSupported: false,
+      isDisabled: true,
+      disabledReason: `Doesn't support ${networkLabel}.`,
+      errorMessage: `${walletName} does not support ${networkLabel}.`,
+    };
+  }
+
+  return {
+    isSupported: true,
+    isDisabled: false,
+    disabledReason: "",
+    errorMessage: "",
+  };
+}
+
+function assertWalletSupported(config, wallet) {
+  const compatibility = getWalletCompatibility(config, wallet);
+  if (!compatibility.isSupported) {
+    throw new Error(compatibility.errorMessage);
+  }
+
+  return compatibility;
 }
 
 function mergeWalletInfo(primary = {}, secondary = {}) {
@@ -390,18 +467,25 @@ function registerLegacyWallet(provider, index = 0) {
 function collectLegacyWallets() {
   if (!window.ethereum) return [];
 
+  const namespaceProviders = [...new Set([window.phantom?.ethereum].filter(Boolean))];
   const rawProviders = Array.isArray(window.ethereum.providers) && window.ethereum.providers.length
     ? window.ethereum.providers
     : [];
-  const uniqueProviders = [...new Set(rawProviders.filter(Boolean))];
+  const uniqueProviders = [...new Set(rawProviders.filter(Boolean))]
+    .filter((provider) => !(namespaceProviders.length && provider === window.ethereum && !namespaceProviders.includes(provider)));
+  const candidateProviders = [...new Set([...namespaceProviders, ...uniqueProviders])];
 
-  if (uniqueProviders.length) {
-    return uniqueProviders
+  if (candidateProviders.length) {
+    return candidateProviders
       .map((provider, index) => registerLegacyWallet(provider, index))
       .filter(Boolean);
   }
 
   if (hasDiscoveredEip6963Wallets()) {
+    return [];
+  }
+
+  if (namespaceProviders.length) {
     return [];
   }
 
@@ -503,13 +587,18 @@ async function resolveWalletById(walletId) {
   return wallets.find((wallet) => wallet.id === resolveWalletAlias(walletId)) || null;
 }
 
-export async function getAvailableWallets() {
+export async function getAvailableWallets(config = null) {
   const wallets = await discoverWallets();
-  return wallets.map((wallet) => ({
-    id: wallet.id,
-    source: wallet.source,
-    info: { ...wallet.info },
-  }));
+  return wallets.map((wallet) => {
+    const compatibility = getWalletCompatibility(config, wallet);
+    return {
+      id: wallet.id,
+      source: wallet.source,
+      info: { ...wallet.info },
+      isDisabled: compatibility.isDisabled,
+      disabledReason: compatibility.disabledReason,
+    };
+  });
 }
 
 export async function ensureProvider(runtime) {
@@ -543,6 +632,8 @@ export async function connectWallet(runtime, walletId) {
     throw new Error("The selected wallet is no longer available. Refresh the page and try again.");
   }
 
+  assertWalletSupported(runtime?.config, wallet);
+
   applyActiveWallet(runtime, wallet);
 
   const provider = await ensureProvider(runtime);
@@ -573,7 +664,15 @@ export async function disconnectWallet(runtime) {
 
 export async function syncWalletState(runtime) {
   const session = getWalletSession();
-  const selectedWallet = session?.walletId ? await resolveWalletById(session.walletId) : null;
+  let selectedWallet = session?.walletId ? await resolveWalletById(session.walletId) : null;
+
+  if (selectedWallet) {
+    try {
+      assertWalletSupported(runtime?.config, selectedWallet);
+    } catch {
+      selectedWallet = null;
+    }
+  }
 
   if (session?.walletId && !selectedWallet) {
     clearWalletSession();

--- a/frontend/js/shared/wallet.js
+++ b/frontend/js/shared/wallet.js
@@ -5,9 +5,11 @@ const EIP6963_ANNOUNCE_EVENT = "eip6963:announceProvider";
 const EIP6963_REQUEST_EVENT = "eip6963:requestProvider";
 const LEGACY_WALLET_PREFIX = "legacy";
 const LEGACY_DEFAULT_WALLET_ID = `${LEGACY_WALLET_PREFIX}:default`;
+const GENERIC_WALLET_NAME_KEYS = new Set(["wallet", "injected-wallet"]);
 
 const discoveredWallets = new Map();
 const providerIds = new WeakMap();
+const walletIdentityIds = new Map();
 const walletEventSubscribers = new Set();
 
 let discoveryInitialized = false;
@@ -85,10 +87,10 @@ function guessLegacyWalletName(provider) {
   if (provider?.isPhantom) return "Phantom";
   if (provider?.isRabby) return "Rabby";
   if (provider?.isCoinbaseWallet) return "Coinbase Wallet";
-  if (provider?.isMetaMask) return "MetaMask";
   if (provider?.isBraveWallet) return "Brave Wallet";
   if (provider?.isFrame) return "Frame";
   if (provider?.isTally) return "Taho";
+  if (provider?.isMetaMask) return "MetaMask";
   return "Injected Wallet";
 }
 
@@ -96,11 +98,63 @@ function guessLegacyWalletRdns(provider) {
   if (provider?.isPhantom) return "app.phantom";
   if (provider?.isRabby) return "io.rabby";
   if (provider?.isCoinbaseWallet) return "com.coinbase.wallet";
-  if (provider?.isMetaMask) return "io.metamask";
   if (provider?.isBraveWallet) return "com.brave.wallet";
   if (provider?.isFrame) return "sh.frame";
   if (provider?.isTally) return "so.tally";
+  if (provider?.isMetaMask) return "io.metamask";
   return "";
+}
+
+function normalizeWalletIdentityValue(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function normalizeWalletNameKey(value) {
+  return normalizeWalletIdentityValue(value).replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function getWalletIdentityKeys(provider, info = {}) {
+  const keys = [];
+  const uuid = normalizeWalletIdentityValue(info.uuid);
+  const rdns = normalizeWalletIdentityValue(info.rdns || guessLegacyWalletRdns(provider));
+  const nameKey = normalizeWalletNameKey(info.name || guessLegacyWalletName(provider));
+
+  if (uuid) keys.push(`uuid:${uuid}`);
+  if (rdns) keys.push(`rdns:${rdns}`);
+  if (nameKey && !GENERIC_WALLET_NAME_KEYS.has(nameKey)) {
+    keys.push(`name:${nameKey}`);
+  }
+
+  return [...new Set(keys)];
+}
+
+function findWalletIdentityId(provider, info = {}) {
+  for (const key of getWalletIdentityKeys(provider, info)) {
+    const walletId = walletIdentityIds.get(key);
+    if (walletId) return walletId;
+  }
+
+  return null;
+}
+
+function rememberWalletIdentity(walletId, provider, info = {}) {
+  for (const key of getWalletIdentityKeys(provider, info)) {
+    walletIdentityIds.set(key, walletId);
+  }
+}
+
+function resolveWalletProvider(previous, candidate) {
+  if (!previous?.provider) return candidate?.provider || null;
+  if (candidate?.source === "eip6963") return candidate.provider;
+  return previous.provider;
+}
+
+function resolveWalletSource(previous, candidate) {
+  if (previous?.source === "eip6963" || candidate?.source === "eip6963") {
+    return "eip6963";
+  }
+
+  return candidate?.source || previous?.source || LEGACY_WALLET_PREFIX;
 }
 
 function getWalletSortLabel(wallet) {
@@ -180,7 +234,9 @@ function registerWallet(candidate) {
 
   const existingId = providerIds.get(provider);
   const info = candidate?.info || {};
+  const matchingIdentityId = findWalletIdentityId(provider, info);
   const nextId = existingId
+    || matchingIdentityId
     || candidate?.id
     || info.uuid
     || info.rdns
@@ -189,8 +245,8 @@ function registerWallet(candidate) {
 
   const descriptor = {
     id: nextId,
-    provider,
-    source: candidate?.source || previous?.source || LEGACY_WALLET_PREFIX,
+    provider: resolveWalletProvider(previous, candidate),
+    source: resolveWalletSource(previous, candidate),
     info: {
       uuid: info.uuid || previous?.info?.uuid || "",
       name: info.name || previous?.info?.name || "Injected Wallet",
@@ -201,6 +257,12 @@ function registerWallet(candidate) {
 
   discoveredWallets.set(nextId, descriptor);
   providerIds.set(provider, nextId);
+  if (previous?.provider) {
+    providerIds.set(previous.provider, nextId);
+    rememberWalletIdentity(nextId, previous.provider, previous.info);
+  }
+  rememberWalletIdentity(nextId, provider, info);
+  rememberWalletIdentity(nextId, descriptor.provider, descriptor.info);
   syncWalletEventProvider();
   return descriptor;
 }

--- a/frontend/js/shared/wallet.js
+++ b/frontend/js/shared/wallet.js
@@ -5,30 +5,21 @@ const EIP6963_ANNOUNCE_EVENT = "eip6963:announceProvider";
 const EIP6963_REQUEST_EVENT = "eip6963:requestProvider";
 const LEGACY_WALLET_PREFIX = "legacy";
 const LEGACY_DEFAULT_WALLET_ID = `${LEGACY_WALLET_PREFIX}:default`;
-const GENERIC_WALLET_NAME_KEYS = new Set(["wallet", "injected-wallet"]);
-const GENERIC_WALLET_IDENTITY_TOKENS = new Set([
-  "app",
-  "browser",
-  "com",
-  "extension",
-  "injected",
-  "io",
-  "org",
-  "provider",
-  "providers",
-  "wallet",
-  "www",
-]);
+const AMBIGUOUS_WALLET_ID = Symbol("ambiguous-wallet-id");
 
-const walletObservations = new Map();
-const providerObservationIds = new WeakMap();
+const discoveredWallets = new Map();
+const walletAliasIds = new Map();
 const walletEventSubscribers = new Set();
 
+let providerIds = new WeakMap();
+let walletIdsByUuid = new Map();
+let walletIdsByRdns = new Map();
 let discoveryInitialized = false;
 let activeInjectedProvider = null;
 let boundWalletEventProvider = null;
 let boundAccountsChanged = null;
 let boundChainChanged = null;
+let nextEip6963SortIndex = 0;
 
 function createWalletId(source, name, fallback = "wallet") {
   return `${source}:${String(name || fallback).trim().toLowerCase().replace(/[^a-z0-9]+/g, "-") || fallback}`;
@@ -121,47 +112,13 @@ function normalizeWalletIdentityValue(value) {
   return String(value || "").trim().toLowerCase();
 }
 
-function normalizeWalletNameKey(value) {
-  return normalizeWalletIdentityValue(value).replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
-}
-
-function getWalletIdentityTokens(provider, info = {}) {
-  const values = [
-    normalizeWalletIdentityValue(info.rdns || guessLegacyWalletRdns(provider)),
-    normalizeWalletIdentityValue(info.name || guessLegacyWalletName(provider)),
-  ];
-  const tokens = new Set();
-
-  for (const value of values) {
-    if (!value) continue;
-    const pieces = value.split(/[^a-z0-9]+/).filter(Boolean);
-    for (const piece of pieces) {
-      if (piece.length < 2) continue;
-      if (/^\d+$/u.test(piece)) continue;
-      if (GENERIC_WALLET_IDENTITY_TOKENS.has(piece)) continue;
-      tokens.add(piece);
-    }
-  }
-
-  return [...tokens];
-}
-
-function getWalletIdentityKeys(provider, info = {}) {
-  const keys = [];
-  const uuid = normalizeWalletIdentityValue(info.uuid);
-  const rdns = normalizeWalletIdentityValue(info.rdns || guessLegacyWalletRdns(provider));
-  const nameKey = normalizeWalletNameKey(info.name || guessLegacyWalletName(provider));
-
-  if (uuid) keys.push(`uuid:${uuid}`);
-  for (const token of getWalletIdentityTokens(provider, info)) {
-    keys.push(`brand:${token}`);
-  }
-  if (rdns) keys.push(`rdns:${rdns}`);
-  if (nameKey && !GENERIC_WALLET_NAME_KEYS.has(nameKey)) {
-    keys.push(`name:${nameKey}`);
-  }
-
-  return [...new Set(keys)];
+function normalizeWalletInfo(info = {}) {
+  return {
+    uuid: normalizeWalletIdentityValue(info.uuid),
+    name: String(info.name || "").trim(),
+    icon: String(info.icon || "").trim(),
+    rdns: normalizeWalletIdentityValue(info.rdns),
+  };
 }
 
 function mergeWalletInfo(primary = {}, secondary = {}) {
@@ -173,36 +130,36 @@ function mergeWalletInfo(primary = {}, secondary = {}) {
   };
 }
 
-function mergeSourceIds(primaryIds = [], secondaryIds = []) {
-  return [...new Set([...primaryIds.filter(Boolean), ...secondaryIds.filter(Boolean)])];
+function mergeLinkedProviders(...providers) {
+  return [...new Set(providers.filter(Boolean))];
 }
 
-function createWalletObservation(candidate) {
-  return {
-    observationId: `observation:${walletObservations.size + 1}`,
-    provider: candidate.provider,
-    source: candidate.source || LEGACY_WALLET_PREFIX,
-    sourceIds: candidate.id ? [candidate.id] : [],
-    info: mergeWalletInfo(candidate.info || {}),
-  };
+function getWalletSourcePriority(source) {
+  return source === "eip6963" ? 0 : 1;
 }
 
-function mergeWalletObservation(previous, candidate) {
-  const candidateSource = candidate.source || LEGACY_WALLET_PREFIX;
-  const preferCandidateInfo = candidateSource === "eip6963" || previous.source !== "eip6963";
-  const primaryInfo = preferCandidateInfo ? (candidate.info || {}) : previous.info;
-  const secondaryInfo = preferCandidateInfo ? previous.info : (candidate.info || {});
-  const primaryIds = candidateSource === "eip6963" ? [candidate.id] : previous.sourceIds;
-  const secondaryIds = candidateSource === "eip6963" ? previous.sourceIds : [candidate.id];
+function createWalletDescriptor(candidate, previous = null) {
+  const candidateSource = candidate.source || previous?.source || LEGACY_WALLET_PREFIX;
+  const candidatePriority = getWalletSourcePriority(candidateSource);
+  const previousPriority = previous?.sourcePriority ?? Number.POSITIVE_INFINITY;
+  const isFreshEip6963Announcement = previous
+    && candidateSource === "eip6963"
+    && previous.source === "eip6963";
+  const preferCandidate = !previous || candidatePriority < previousPriority || isFreshEip6963Announcement;
 
   return {
-    observationId: previous.observationId,
-    provider: candidate.provider,
-    source: previous.source === "eip6963" || candidateSource === "eip6963"
-      ? "eip6963"
-      : candidateSource,
-    sourceIds: mergeSourceIds(primaryIds, secondaryIds),
-    info: mergeWalletInfo(primaryInfo, secondaryInfo),
+    id: candidate.id,
+    provider: preferCandidate ? candidate.provider : (previous?.provider || candidate.provider),
+    linkedProviders: mergeLinkedProviders(previous?.provider, candidate.provider),
+    source: preferCandidate ? candidateSource : (previous?.source || candidateSource),
+    sourcePriority: preferCandidate ? candidatePriority : (previous?.sourcePriority ?? candidatePriority),
+    sortIndex: previous
+      ? (preferCandidate ? (candidate.sortIndex ?? previous.sortIndex) : previous.sortIndex)
+      : (candidate.sortIndex ?? 0),
+    info: mergeWalletInfo(
+      preferCandidate ? candidate.info : previous?.info,
+      preferCandidate ? previous?.info : candidate.info,
+    ),
   };
 }
 
@@ -211,135 +168,109 @@ function getWalletSortLabel(wallet) {
 }
 
 function listWalletsSnapshot() {
-  const buckets = new Map();
-  const bucketIdsByKey = new Map();
-  let nextBucketIndex = 1;
-
-  function ensureBucket(bucketId) {
-    if (!buckets.has(bucketId)) {
-      buckets.set(bucketId, {
-        id: bucketId,
-        identityKeys: new Set(),
-        observations: [],
-      });
-    }
-    return buckets.get(bucketId);
-  }
-
-  function mergeBuckets(targetBucketId, sourceBucketId) {
-    if (!sourceBucketId || sourceBucketId === targetBucketId) return targetBucketId;
-    const targetBucket = ensureBucket(targetBucketId);
-    const sourceBucket = buckets.get(sourceBucketId);
-    if (!sourceBucket) return targetBucketId;
-
-    for (const observation of sourceBucket.observations) {
-      if (!targetBucket.observations.includes(observation)) {
-        targetBucket.observations.push(observation);
+  return [...discoveredWallets.values()]
+    .sort((left, right) => {
+      if (left.sourcePriority !== right.sourcePriority) {
+        return left.sourcePriority - right.sourcePriority;
       }
-    }
-
-    for (const key of sourceBucket.identityKeys) {
-      targetBucket.identityKeys.add(key);
-      bucketIdsByKey.set(key, targetBucketId);
-    }
-
-    buckets.delete(sourceBucketId);
-    return targetBucketId;
-  }
-
-  for (const observation of walletObservations.values()) {
-    const identityKeys = getWalletIdentityKeys(observation.provider, observation.info);
-    const keys = identityKeys.length ? identityKeys : [`observation:${observation.observationId}`];
-    const matchedBucketIds = [...new Set(keys.map((key) => bucketIdsByKey.get(key)).filter(Boolean))];
-    const bucketId = matchedBucketIds[0] || `bucket:${nextBucketIndex++}`;
-
-    ensureBucket(bucketId);
-    for (const extraBucketId of matchedBucketIds.slice(1)) {
-      mergeBuckets(bucketId, extraBucketId);
-    }
-
-    const bucket = ensureBucket(bucketId);
-    bucket.observations.push(observation);
-    for (const key of keys) {
-      bucket.identityKeys.add(key);
-      bucketIdsByKey.set(key, bucketId);
-    }
-  }
-
-  return [...buckets.values()]
-    .map((bucket) => createWalletDescriptor(bucket))
-    .filter(Boolean)
-    .sort((left, right) => getWalletSortLabel(left).localeCompare(getWalletSortLabel(right)));
+      if (left.sortIndex !== right.sortIndex) {
+        return left.sortIndex - right.sortIndex;
+      }
+      return getWalletSortLabel(left).localeCompare(getWalletSortLabel(right));
+    });
 }
 
-function compareObservationPreference(left, right) {
-  const leftRank = [
-    left.source === "eip6963" ? 1 : 0,
-    left.info?.uuid ? 1 : 0,
-    left.info?.icon ? 1 : 0,
-    left.info?.rdns ? 1 : 0,
-    left.info?.name ? 1 : 0,
-  ];
-  const rightRank = [
-    right.source === "eip6963" ? 1 : 0,
-    right.info?.uuid ? 1 : 0,
-    right.info?.icon ? 1 : 0,
-    right.info?.rdns ? 1 : 0,
-    right.info?.name ? 1 : 0,
-  ];
+function rebuildWalletLookups() {
+  providerIds = new WeakMap();
+  walletIdsByUuid = new Map();
+  walletIdsByRdns = new Map();
 
-  for (let index = 0; index < leftRank.length; index += 1) {
-    if (leftRank[index] !== rightRank[index]) {
-      return rightRank[index] - leftRank[index];
+  for (const wallet of discoveredWallets.values()) {
+    for (const provider of mergeLinkedProviders(wallet.provider, ...(wallet.linkedProviders || []))) {
+      providerIds.set(provider, wallet.id);
     }
-  }
-
-  return 0;
-}
-
-function pickPreferredObservation(observations) {
-  return [...observations].sort(compareObservationPreference)[0] || null;
-}
-
-function createWalletDescriptor(bucket) {
-  const preferredObservation = pickPreferredObservation(bucket.observations);
-  if (!preferredObservation) return null;
-
-  let info = mergeWalletInfo(preferredObservation.info);
-  for (const observation of bucket.observations) {
-    if (observation === preferredObservation) continue;
-    info = mergeWalletInfo(info, observation.info);
-  }
-
-  const preferredId = preferredObservation.sourceIds[0] || "";
-  const walletId = preferredId || createWalletId(
-    preferredObservation.source || LEGACY_WALLET_PREFIX,
-    info.name,
-    "wallet",
-  );
-  const aliases = new Set();
-
-  for (const observation of bucket.observations) {
-    for (const sourceId of observation.sourceIds) {
-      if (sourceId && sourceId !== walletId) {
-        aliases.add(sourceId);
+    if (wallet.info?.uuid) {
+      walletIdsByUuid.set(wallet.info.uuid, wallet.id);
+    }
+    if (wallet.info?.rdns) {
+      const existingWalletId = walletIdsByRdns.get(wallet.info.rdns);
+      if (!existingWalletId) {
+        walletIdsByRdns.set(wallet.info.rdns, wallet.id);
+      } else if (existingWalletId !== wallet.id) {
+        walletIdsByRdns.set(wallet.info.rdns, AMBIGUOUS_WALLET_ID);
       }
     }
   }
-
-  return {
-    id: walletId,
-    provider: preferredObservation.provider,
-    source: bucket.observations.some((observation) => observation.source === "eip6963")
-      ? "eip6963"
-      : (preferredObservation.source || LEGACY_WALLET_PREFIX),
-    info,
-    aliases,
-  };
 }
 
-function findWalletById(wallets, walletId) {
-  return wallets.find((wallet) => wallet.id === walletId || wallet.aliases?.has(walletId)) || null;
+function resolveWalletAlias(walletId) {
+  let resolvedWalletId = String(walletId || "");
+  const visited = new Set();
+
+  while (walletAliasIds.has(resolvedWalletId) && !visited.has(resolvedWalletId)) {
+    visited.add(resolvedWalletId);
+    resolvedWalletId = walletAliasIds.get(resolvedWalletId);
+  }
+
+  return resolvedWalletId;
+}
+
+function findWalletById(walletId) {
+  if (!walletId) return null;
+  return discoveredWallets.get(resolveWalletAlias(walletId)) || null;
+}
+
+function findWalletId(provider, info = {}, source = LEGACY_WALLET_PREFIX) {
+  const existingProviderId = providerIds.get(provider);
+  if (existingProviderId) return existingProviderId;
+
+  if (info.uuid && walletIdsByUuid.has(info.uuid)) {
+    return walletIdsByUuid.get(info.uuid);
+  }
+
+  if (info.rdns) {
+    const rdnsWalletId = walletIdsByRdns.get(info.rdns);
+    if (rdnsWalletId && rdnsWalletId !== AMBIGUOUS_WALLET_ID) {
+      const rdnsWallet = discoveredWallets.get(rdnsWalletId) || null;
+      if (source === "eip6963" && info.uuid && rdnsWallet?.source !== LEGACY_WALLET_PREFIX) {
+        return null;
+      }
+      return rdnsWalletId;
+    }
+  }
+
+  if (source === "eip6963" && info.uuid) {
+    return null;
+  }
+
+  return null;
+}
+
+function hasDiscoveredEip6963Wallets() {
+  return [...discoveredWallets.values()].some((wallet) => wallet.source === "eip6963");
+}
+
+function pruneLegacyShimWallets(latestWallet) {
+  if (!latestWallet || typeof window === "undefined") return false;
+
+  const ethereum = window?.ethereum;
+  if (!ethereum || Array.isArray(ethereum.providers)) return false;
+
+  let changed = false;
+  for (const wallet of [...discoveredWallets.values()]) {
+    if (wallet.id === latestWallet.id) continue;
+    if (wallet.source !== LEGACY_WALLET_PREFIX) continue;
+    if (wallet.provider !== ethereum) continue;
+
+    discoveredWallets.delete(wallet.id);
+    changed = true;
+  }
+
+  if (changed) {
+    rebuildWalletLookups();
+  }
+
+  return changed;
 }
 
 function unbindWalletEventProvider() {
@@ -370,8 +301,10 @@ async function notifyChainChanged(chainId) {
 }
 
 function getReadOnlyInjectedProvider() {
+  const discoveredProvider = listWalletsSnapshot()[0]?.provider || null;
+  if (discoveredProvider) return discoveredProvider;
   if (window.ethereum) return window.ethereum;
-  return listWalletsSnapshot()[0]?.provider || null;
+  return null;
 }
 
 function getCurrentInjectedProvider() {
@@ -409,22 +342,34 @@ function registerWallet(candidate) {
   const provider = candidate?.provider;
   if (!provider || typeof provider.request !== "function") return null;
 
-  const existingObservationId = providerObservationIds.get(provider);
-  if (existingObservationId) {
-    const previousObservation = walletObservations.get(existingObservationId);
-    if (!previousObservation) return null;
+  const normalizedInfo = normalizeWalletInfo(candidate.info);
+  const walletId = findWalletId(provider, normalizedInfo, candidate?.source || LEGACY_WALLET_PREFIX)
+    || candidate?.id
+    || createWalletId(
+      candidate?.source || LEGACY_WALLET_PREFIX,
+      normalizedInfo.name || guessLegacyWalletName(provider),
+      "wallet",
+    );
+  const previousWallet = discoveredWallets.get(walletId) || null;
+  const nextWallet = createWalletDescriptor({
+    id: walletId,
+    provider,
+    source: candidate?.source || LEGACY_WALLET_PREFIX,
+    sortIndex: candidate?.sortIndex ?? previousWallet?.sortIndex ?? 0,
+    info: normalizedInfo,
+  }, previousWallet);
 
-    const nextObservation = mergeWalletObservation(previousObservation, candidate);
-    walletObservations.set(existingObservationId, nextObservation);
-    syncWalletEventProvider();
-    return nextObservation;
+  discoveredWallets.set(walletId, nextWallet);
+  if (candidate?.id && candidate.id !== walletId) {
+    walletAliasIds.set(candidate.id, walletId);
   }
 
-  const observation = createWalletObservation(candidate);
-  walletObservations.set(observation.observationId, observation);
-  providerObservationIds.set(provider, observation.observationId);
+  rebuildWalletLookups();
+  if (activeInjectedProvider === previousWallet?.provider && previousWallet?.provider !== nextWallet.provider) {
+    activeInjectedProvider = nextWallet.provider;
+  }
   syncWalletEventProvider();
-  return observation;
+  return nextWallet;
 }
 
 function registerLegacyWallet(provider, index = 0) {
@@ -432,6 +377,7 @@ function registerLegacyWallet(provider, index = 0) {
     id: index === 0 ? LEGACY_DEFAULT_WALLET_ID : createWalletId(LEGACY_WALLET_PREFIX, `${guessLegacyWalletName(provider)}-${index + 1}`),
     provider,
     source: LEGACY_WALLET_PREFIX,
+    sortIndex: index,
     info: {
       name: guessLegacyWalletName(provider),
       rdns: guessLegacyWalletRdns(provider),
@@ -446,12 +392,25 @@ function collectLegacyWallets() {
 
   const rawProviders = Array.isArray(window.ethereum.providers) && window.ethereum.providers.length
     ? window.ethereum.providers
-    : [window.ethereum];
+    : [];
   const uniqueProviders = [...new Set(rawProviders.filter(Boolean))];
 
-  return uniqueProviders
-    .map((provider, index) => registerLegacyWallet(provider, index))
-    .filter(Boolean);
+  if (uniqueProviders.length) {
+    return uniqueProviders
+      .map((provider, index) => registerLegacyWallet(provider, index))
+      .filter(Boolean);
+  }
+
+  if (hasDiscoveredEip6963Wallets()) {
+    return [];
+  }
+
+  if (providerIds.get(window.ethereum)) {
+    return [];
+  }
+
+  const wallet = registerLegacyWallet(window.ethereum, 0);
+  return wallet ? [wallet] : [];
 }
 
 function requestWalletAnnouncements() {
@@ -470,12 +429,17 @@ function initWalletDiscovery() {
     const detail = event?.detail;
     if (!detail?.provider) return;
 
-    registerWallet({
+    const wallet = registerWallet({
       id: detail.info?.uuid || detail.info?.rdns || createWalletId("eip6963", detail.info?.name, "wallet"),
       provider: detail.provider,
       source: "eip6963",
+      sortIndex: nextEip6963SortIndex++,
       info: detail.info || {},
     });
+
+    if (pruneLegacyShimWallets(wallet)) {
+      syncWalletEventProvider();
+    }
   });
 
   collectLegacyWallets();
@@ -519,12 +483,24 @@ function applyActiveWallet(runtime, wallet) {
   syncWalletEventProvider();
 }
 
+function getInjectedProviderForRuntime(runtime) {
+  const selectedWallet = runtime?.selectedWalletId ? findWalletById(runtime.selectedWalletId) : null;
+  if (selectedWallet) {
+    runtime.selectedWalletName = selectedWallet.info?.name || null;
+    runtime.selectedWalletRdns = selectedWallet.info?.rdns || null;
+    runtime.injectedProvider = selectedWallet.provider || null;
+    return runtime.injectedProvider;
+  }
+
+  return runtime?.injectedProvider || getReadOnlyInjectedProvider();
+}
+
 async function resolveWalletById(walletId) {
   if (!walletId) return null;
-  const cachedWallet = findWalletById(listWalletsSnapshot(), walletId);
+  const cachedWallet = findWalletById(walletId);
   if (cachedWallet) return cachedWallet;
   const wallets = await discoverWallets();
-  return findWalletById(wallets, walletId);
+  return wallets.find((wallet) => wallet.id === resolveWalletAlias(walletId)) || null;
 }
 
 export async function getAvailableWallets() {
@@ -538,7 +514,7 @@ export async function getAvailableWallets() {
 
 export async function ensureProvider(runtime) {
   await discoverWallets();
-  const injected = runtime.injectedProvider || getReadOnlyInjectedProvider();
+  const injected = getInjectedProviderForRuntime(runtime);
   if (!injected) throw new Error("No compatible wallet was detected in this browser.");
 
   if (!runtime.provider || runtime.providerSource !== injected) {
@@ -605,7 +581,7 @@ export async function syncWalletState(runtime) {
 
   applyActiveWallet(runtime, selectedWallet);
 
-  const injected = runtime.injectedProvider || getReadOnlyInjectedProvider();
+  const injected = getInjectedProviderForRuntime(runtime);
   if (!injected) {
     runtime.account = null;
     runtime.signer = null;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -930,6 +930,21 @@ select {
   box-shadow: 0 0 0 4px rgba(251, 175, 64, 0.08);
 }
 
+.wallet-picker-option:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  border-color: rgba(174, 184, 214, 0.16);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 38%),
+    linear-gradient(180deg, rgba(15, 20, 37, 0.94), rgba(10, 14, 28, 0.98));
+}
+
+.wallet-picker-option:disabled:hover,
+.wallet-picker-option:disabled:focus-visible {
+  border-color: rgba(174, 184, 214, 0.16);
+  box-shadow: none;
+}
+
 .wallet-picker-icon-shell {
   position: relative;
   width: 50px;
@@ -964,7 +979,10 @@ select {
 .wallet-picker-copy {
   flex: 1 1 auto;
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 4px;
 }
 
 .wallet-picker-name {
@@ -972,6 +990,12 @@ select {
   font-family: var(--display);
   font-size: 1.06rem;
   font-weight: 700;
+}
+
+.wallet-picker-reason {
+  color: rgba(231, 217, 188, 0.76);
+  font-size: 0.86rem;
+  line-height: 1.45;
 }
 
 .wallet-picker-badge {


### PR DESCRIPTION
## Summary
This fixes duplicate wallet options in the wallet picker when the same browser wallet is discovered through both the legacy `window.ethereum` path and EIP-6963 announcements.

## Root cause
Our wallet discovery logic registered legacy injected providers and EIP-6963 providers independently, but only deduplicated by provider object identity. In browsers where the same wallet is surfaced through different provider objects or proxies, the picker could show the same wallet twice. In the reported Firefox case, Phantom still surfaced as two options because a legacy entry could be created first and only later gain enough identity to match the announced Phantom wallet.

## What changed
- keep legacy discovery as a fallback source instead of removing it
- group raw wallet observations into a derived wallet list instead of mutating canonical wallet ids as providers arrive
- merge wallets by generic identity signals: `uuid`, `rdns`, normalized non-generic name, and normalized identity tokens derived from `rdns` and wallet name
- prefer EIP-6963 metadata and provider handles when a merged wallet includes both sources
- preserve compatibility with old saved wallet ids by resolving any grouped observation id as an alias for the merged wallet
- add coverage for the mixed legacy+EIP-6963 merge path
- add coverage for a pure EIP-6963 discovery path
- add a Firefox-style Phantom regression where legacy `Phantom` and announced `Phantom Wallet` variants must collapse into one option
- add coverage for the late-match case where a stale legacy entry would previously survive after a later Phantom match was found

## User impact
- the picker should no longer show duplicate entries for the same wallet when both discovery mechanisms are active
- Phantom-branded variants should collapse into a single picker option even when the legacy and announced metadata differ slightly or arrive at different times
- EIP-6963-only wallets still connect correctly
- existing legacy-only behavior remains covered

## Diff size breakdown
| Category | Files | Additions | Deletions | Notes |
|---|---:|---:|---:|---|
| E2E tests + fixtures | 3 | 1,018 | 5 | New/expanded wallet discovery, Phantom, BNB, restore, and admin coverage |
| Core wallet logic | 1 | 342 | 45 | `frontend/js/shared/wallet.js` discovery, dedupe, and unsupported-wallet handling |
| Page integration | 2 | 48 | 18 | Claim/admin connect flow and config readiness |
| Picker UI + CSS | 2 | 42 | 3 | Disabled wallet display and reason text |

About 70% of the added lines are tests/fixtures. Excluding tests, the production change is 5 files with 432 additions and 66 deletions.

<img width="583" height="405" alt="image" src="https://github.com/user-attachments/assets/1cab1873-e0c6-4e21-a5f9-8958fbb5f38c" />
