### PR TITLE
Fix footer contract explorer link

### DIFF
--- a/e2e/tests/claim/connect-and-routing.spec.js
+++ b/e2e/tests/claim/connect-and-routing.spec.js
@@ -7,9 +7,18 @@ test("@smoke claimant page connects owner and links to admin", async ({ page }) 
   await expect(page.getByText("Connect your wallet to check for claims.")).toBeVisible();
   await connectViaWalletPicker(page);
 
+  const configuredAirdropAddress = await page.evaluate(async () => {
+    const response = await fetch("config.local.json", { cache: "no-store" });
+    const config = await response.json();
+    return config.airdropAddress;
+  });
+
   await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
   await expect(page.locator("#addTokenLink")).toBeVisible();
-  await expect(page.locator("#tokenExplorerLink")).toHaveAttribute("href", /https:\/\/explorer\.local\.test\/address\/0x/i);
+  await expect(page.locator("#tokenExplorerLink")).toHaveAttribute(
+    "href",
+    `https://explorer.local.test/address/${configuredAirdropAddress}`,
+  );
 
   await openWalletMenu(page, /0xf39f\.\.\.2266/i);
   await expect(page.getByRole("button", { name: "Open Admin" })).toBeVisible();

--- a/e2e/tests/claim/wallet-menu.spec.js
+++ b/e2e/tests/claim/wallet-menu.spec.js
@@ -828,3 +828,21 @@ test("claimant footer can add the token to MetaMask and hides explorer link when
   await expect(page.locator("#addTokenLink")).toBeVisible();
   await expect(page.locator("#tokenExplorerLink")).toBeHidden();
 });
+
+test("claimant footer hides explorer link when airdrop address is unset", async ({ page }) => {
+  await page.route("**/config.local.json", async (route) => {
+    const response = await route.fetch();
+    const config = await response.json();
+    delete config.airdropAddress;
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(config),
+    });
+  });
+
+  await page.goto("index.html");
+
+  await expect(page.locator("#tokenExplorerLink")).toBeHidden();
+});

--- a/frontend/js/pages/claim.js
+++ b/frontend/js/pages/claim.js
@@ -989,6 +989,7 @@ function syncWalletButton() {
 
 function updateFooterLinks() {
   const hasTokenAddress = Boolean(runtime.config.tokenAddress);
+  const hasAirdropAddress = Boolean(runtime.config.airdropAddress);
   const showAddToWallet = hasTokenAddress && runtime.account && isMetaMaskWalletSelected();
   els.addTokenLink.hidden = !showAddToWallet;
   if (showAddToWallet) {
@@ -998,8 +999,8 @@ function updateFooterLinks() {
   }
 
   const explorerBaseUrl = String(runtime.config.explorerBaseUrl || "").trim().replace(/\/+$/, "");
-  if (explorerBaseUrl && hasTokenAddress) {
-    els.tokenExplorerLink.href = `${explorerBaseUrl}/address/${runtime.config.tokenAddress}`;
+  if (explorerBaseUrl && hasAirdropAddress) {
+    els.tokenExplorerLink.href = `${explorerBaseUrl}/address/${runtime.config.airdropAddress}`;
     els.tokenExplorerLink.hidden = false;
   } else {
     els.tokenExplorerLink.hidden = true;


### PR DESCRIPTION
## Summary
- Update the claimant footer `contract` link to use the configured airdrop contract address instead of the token address.
- Keep the footer explorer link hidden when the explorer base URL or airdrop address is unavailable.
- Extend claim-page e2e coverage for the airdrop contract href and missing-airdrop-address hidden state.


