### PR TITLE
Refine X recovery empty claims state

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -41,6 +41,7 @@ const ADMIN_ACCESS_CHALLENGE_TTL_MS = 10 * 60 * 1000;
 const MAX_JSON_BODY_BYTES = 32 * 1024;
 const MAX_IMPORT_BODY_BYTES = 5 * 1024 * 1024;
 const MAX_AIRDROP_ROUND_SAVE_BODY_BYTES = 5 * 1024 * 1024;
+const X_RECOVERY_RECEIVED_MESSAGE = "Your response has been received. You may be eligible for future airdrop rounds.";
 const RATE_LIMITS = {
   start: { limit: 12, windowMs: 10 * 60 * 1000 },
   callback: { limit: 24, windowMs: 10 * 60 * 1000 },
@@ -1002,11 +1003,11 @@ function getExistingWalletMessage(account) {
     return `We already have a wallet on file for this X account: ${account.walletAddress}.`;
   }
 
-  return "We already received a response for this X account.";
+  return X_RECOVERY_RECEIVED_MESSAGE;
 }
 
 function getExistingRecoverySubmissionMessage() {
-  return "We already received a response for this X account.";
+  return X_RECOVERY_RECEIVED_MESSAGE;
 }
 
 function getRequiredDeploymentKey() {

--- a/e2e/tests/claim/claim-flow.spec.js
+++ b/e2e/tests/claim/claim-flow.spec.js
@@ -1,5 +1,5 @@
 const { expect, test, toHexChainId } = require("../../fixtures/testWithMockWallet");
-const { connectViaWalletPicker, startAirdropFromUpload } = require("../helpers");
+const { connectViaWalletPicker, enableXRecovery, startAirdropFromUpload } = require("../helpers");
 
 test("@smoke claimant can claim from the wrong network after wallet switch", async ({ page, e2eClaimsFile, mockWallet }) => {
   await page.goto("admin.html");
@@ -27,7 +27,24 @@ test("@smoke claimant can claim from the wrong network after wallet switch", asy
   await expect(page.getByRole("button", { name: "Already Claimed" })).toBeVisible();
 });
 
-test("claimant outsider sees the generic empty state", async ({ page, e2eClaimsFile, mockWallet }) => {
+test("claim page does not show X recovery before wallet state is known", async ({ page, hardhatChain }) => {
+  await enableXRecovery(page, hardhatChain.backendUrl);
+  await page.route("**/js/pages/claim.js", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/javascript",
+      body: "",
+    });
+  });
+
+  await page.goto("index.html");
+
+  await expect(page.getByRole("heading", { name: "Sign In With X" })).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "Available Claims" })).toBeVisible();
+  await expect(page.getByText(/Loading Rewards/)).toBeVisible();
+});
+
+test("claimant outsider sees the generic empty state when X recovery is disabled", async ({ page, e2eClaimsFile, mockWallet }) => {
   await page.goto("admin.html");
   await connectViaWalletPicker(page);
   await startAirdropFromUpload(page, e2eClaimsFile);
@@ -38,4 +55,64 @@ test("claimant outsider sees the generic empty state", async ({ page, e2eClaimsF
   await expect(page.getByRole("button", { name: /0x9965\.\.\.a4dc/i })).toBeVisible();
   await expect(page.getByText("Nothing available right now.")).toBeVisible();
   await expect(page.getByText("If anything is available for this wallet, it will appear here.")).toBeVisible();
+});
+
+test("claimant sees refresh guidance when rewards lookup fails", async ({ page, hardhatChain, mockWallet }) => {
+  await enableXRecovery(page, hardhatChain.backendUrl);
+  await page.route("**/api/claims/wallet/**", async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Claims API unavailable." }),
+    });
+  });
+
+  await page.goto("index.html");
+  await mockWallet.setAccount(page, mockWallet.accounts.outsider);
+  await connectViaWalletPicker(page);
+
+  await expect(page.getByRole("button", { name: /0x9965\.\.\.a4dc/i })).toBeVisible();
+  await expect(page.getByText("Rewards could not be loaded.")).toBeVisible();
+  await expect(page.getByText("Check your connection, then refresh this page.")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sign In With X" })).toHaveCount(0);
+  await expect(page.getByText("Nothing available right now.")).toHaveCount(0);
+});
+
+test("claimant outsider sees X recovery without the generic empty state when enabled", async ({
+  page,
+  e2eClaimsFile,
+  hardhatChain,
+  mockWallet,
+}) => {
+  await enableXRecovery(page, hardhatChain.backendUrl);
+
+  await page.goto("admin.html");
+  await connectViaWalletPicker(page);
+  await startAirdropFromUpload(page, e2eClaimsFile);
+
+  let releaseClaimsLookup;
+  const claimsLookupCanContinue = new Promise((resolve) => {
+    releaseClaimsLookup = resolve;
+  });
+  await page.route("**/api/claims/wallet/**", async (route) => {
+    await claimsLookupCanContinue;
+    await route.continue();
+  });
+
+  await mockWallet.setAccount(page, mockWallet.accounts.outsider);
+  await page.goto("index.html");
+
+  await expect(page.getByRole("button", { name: /0x9965\.\.\.a4dc/i })).toBeVisible();
+  await expect(page.getByText(/Loading Rewards/)).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sign In With X" })).toHaveCount(0);
+
+  releaseClaimsLookup();
+
+  await expect(page.getByRole("heading", { name: "Sign In With X" })).toBeVisible();
+  await expect(page.getByText("No claim was found for this wallet. Sign in with X to start follower recovery.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sign in with X" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Available Claims" })).toHaveCount(0);
+  await expect(page.getByText(/Loading Rewards/)).toHaveCount(0);
+  await expect(page.getByText("Nothing available right now.")).toHaveCount(0);
+  await expect(page.getByText("If anything is available for this wallet, it will appear here.")).toHaveCount(0);
 });

--- a/e2e/tests/claim/wallet-menu.spec.js
+++ b/e2e/tests/claim/wallet-menu.spec.js
@@ -1,5 +1,7 @@
 const { expect, test } = require("../../fixtures/testWithMockWallet");
-const { connectViaWalletPicker, openWalletMenu } = require("../helpers");
+const { connectViaWalletPicker, enableXRecovery, mockXAuthSession, openWalletMenu } = require("../helpers");
+
+const X_RECOVERY_RECEIVED_MESSAGE = "Your response has been received. You may be eligible for future airdrop rounds.";
 
 test("claimant wallet menu shows the connected address, chain id, and disconnect flow", async ({ page }) => {
   await page.goto("index.html");
@@ -811,6 +813,50 @@ test("connected claimant sees the generic empty state when no rounds have starte
   await expect(page.getByText("Nothing available right now.")).toBeVisible();
   await expect(page.getByText("If anything is available for this wallet, it will appear here.")).toBeVisible();
   await expect(page.getByRole("button", { name: "Claim" })).toHaveCount(0);
+});
+
+test("connected claimant with an existing X recovery response sees the future rounds copy", async ({
+  page,
+  hardhatChain,
+  mockWallet,
+}) => {
+  const sessionPayload = {
+    expiresAt: Date.now() + 60 * 60 * 1000,
+    csrfToken: "test-csrf-token",
+    authenticatedAt: new Date().toISOString(),
+    profile: {
+      id: "12345",
+      name: "Liberdus Fan",
+      username: "liberdus_fan",
+      profileImageUrl: "",
+    },
+    account: null,
+    existingSubmission: {
+      id: "submission-1",
+      xUserId: "12345",
+      usernameAtSubmission: "liberdus_fan",
+      walletAddress: mockWallet.accounts.claimant,
+      wasKnownFollower: true,
+      wasRecoveryCandidate: true,
+      status: "received",
+      submittedAt: new Date().toISOString(),
+    },
+  };
+
+  await enableXRecovery(page, hardhatChain.backendUrl);
+  await mockXAuthSession(page, sessionPayload);
+
+  await page.goto("index.html");
+  await mockWallet.setAccount(page, mockWallet.accounts.claimant);
+  await connectViaWalletPicker(page);
+
+  await expect(page.getByRole("heading", { name: "Sign In With X" })).toBeVisible();
+  await expect(page.getByText("@liberdus_fan")).toBeVisible();
+  await expect(page.getByText(X_RECOVERY_RECEIVED_MESSAGE)).toBeVisible();
+  await expect(page.getByText("We already received a response for this X account.")).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "Available Claims" })).toHaveCount(0);
+  await expect(page.getByText("Nothing available right now.")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Verify Wallet And Save" })).toHaveCount(0);
 });
 
 test("claimant footer can add the token to MetaMask and hides explorer link when explorerBaseUrl is unset", async ({ page, mockWallet }) => {

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -1,8 +1,40 @@
 const { expect } = require("@playwright/test");
 
+const UI_CONFIG_STORAGE_KEY = "liberdus-airdrop-ui-config";
+const X_AUTH_SESSION_KEY = "liberdus-airdrop-x-auth-session";
+
 async function connectViaWalletPicker(page) {
   await page.getByRole("button", { name: "Connect Wallet" }).click();
   await page.getByRole("button", { name: /MetaMask/i }).click();
+}
+
+async function enableXRecovery(page, backendUrl) {
+  await page.addInitScript(({ storageKey, nextBackendUrl }) => {
+    const current = JSON.parse(window.localStorage.getItem(storageKey) || "{}");
+    const currentXAuth = current.xAuth && typeof current.xAuth === "object" ? current.xAuth : {};
+    window.localStorage.setItem(storageKey, JSON.stringify({
+      ...current,
+      xAuth: {
+        ...currentXAuth,
+        enabled: true,
+        backendUrl: nextBackendUrl,
+      },
+    }));
+  }, { storageKey: UI_CONFIG_STORAGE_KEY, nextBackendUrl: backendUrl });
+}
+
+async function mockXAuthSession(page, sessionPayload) {
+  await page.route("**/api/x/session", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(sessionPayload),
+    });
+  });
+
+  await page.addInitScript(({ storageKey, session }) => {
+    window.sessionStorage.setItem(storageKey, JSON.stringify(session));
+  }, { storageKey: X_AUTH_SESSION_KEY, session: sessionPayload });
 }
 
 async function openWalletMenu(page, addressPattern) {
@@ -56,8 +88,10 @@ async function startAirdropFromUpload(page, claimsFile, { deadlineSelector = "#s
 
 module.exports = {
   connectViaWalletPicker,
+  enableXRecovery,
   getLocalDateTimeInputValue,
   getUtcDateTimeInputValue,
+  mockXAuthSession,
   openWalletMenu,
   setFutureDeadline,
   startAirdropFromUpload,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -141,8 +141,8 @@
     <main class="shell shell-narrow">
       <div class="center-stage">
         <section class="frame claim-card">
-          <section class="claim-card-block">
-            <div id="xAuthCard" class="x-auth-card">
+          <section id="xAuthBlock" class="claim-card-block" hidden>
+            <div id="xAuthCard" class="x-auth-card" hidden>
               <div class="x-auth-copy">
                 <div>
                   <h2>Sign In With X</h2>
@@ -176,13 +176,19 @@
             </div>
           </section>
 
-          <section class="claim-card-block">
+          <section id="availableClaimsBlock" class="claim-card-block">
             <div class="panel-title-row">
               <div>
                 <h2>Available Claims</h2>
               </div>
             </div>
-            <div id="roundList" class="round-list"></div>
+            <div id="roundList" class="round-list">
+              <article class="round-card muted rewards-loading-card" aria-busy="true" aria-live="polite">
+                <h3 class="rewards-loading-title">
+                  Loading Rewards<span class="loading-ellipsis" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>
+                </h3>
+              </article>
+            </div>
           </section>
         </section>
       </div>

--- a/frontend/js/pages/claim.js
+++ b/frontend/js/pages/claim.js
@@ -72,6 +72,8 @@ const runtime = {
   claimCelebrationStage: "idle",
   isConnectingWallet: false,
   isConnectingX: false,
+  isLoadingRewards: true,
+  rewardsErrorMessage: "",
   isSubmittingXWalletLink: false,
   xSession: null,
   noticeTimerId: null,
@@ -86,6 +88,7 @@ const CLAIM_CELEBRATION_HIDE_DELAY = 220;
 const CLAIM_AMOUNT_ANIMATION_MS = 1350;
 const TOKEN_RAIN_IMAGE_URL = new URL("../../assets/liberdus-logo.png", import.meta.url).href;
 const DEFAULT_CELEBRATION_MESSAGE = "Keep following Liberdus on our social channels to stay eligible for future rewards.";
+const X_RECOVERY_RECEIVED_MESSAGE = "Your response has been received. You may be eligible for future airdrop rounds.";
 const DEFAULT_SOCIAL_LINKS = Object.freeze([
   { label: "Follow on X", href: "https://x.com/liberdus" },
   { label: "Join Telegram", href: "https://t.me/LiberdusOfficial" },
@@ -101,6 +104,7 @@ const els = {
   adminPageButton: document.getElementById("adminPageButton"),
   copyWalletAddressButton: document.getElementById("copyWalletAddressButton"),
   disconnectButton: document.getElementById("disconnectButton"),
+  availableClaimsBlock: document.getElementById("availableClaimsBlock"),
   roundList: document.getElementById("roundList"),
   addTokenLink: document.getElementById("addTokenLink"),
   tokenExplorerLink: document.getElementById("tokenExplorerLink"),
@@ -122,6 +126,7 @@ const els = {
   claimCelebrationClose: document.getElementById("claimCelebrationClose"),
   claimCelebrationContinue: document.getElementById("claimCelebrationContinue"),
   switchNetworkButton: document.getElementById("switchNetworkButton"),
+  xAuthBlock: document.getElementById("xAuthBlock"),
   xAuthCard: document.getElementById("xAuthCard"),
   xAuthHint: document.getElementById("xAuthHint"),
   xAuthIdentity: document.getElementById("xAuthIdentity"),
@@ -599,12 +604,18 @@ function shouldOfferXRecovery() {
   return !hasAnyOnchainClaimEntry();
 }
 
+function isXRecoveryOffered() {
+  if (runtime.isLoadingRewards) return false;
+  if (runtime.rewardsErrorMessage) return false;
+  return runtime.config?.xAuth?.enabled !== false && shouldOfferXRecovery();
+}
+
 function formatXLinkStatus(linkResult) {
   if (!linkResult) {
     return "";
   }
 
-  return "Thanks. We received your wallet and X account and will review it.";
+  return X_RECOVERY_RECEIVED_MESSAGE;
 }
 
 function getSignedInXAccount() {
@@ -638,7 +649,7 @@ function formatExistingFormWalletStatus(account = getSignedInXAccount()) {
 }
 
 function formatExistingRecoveryStatus() {
-  return "We already received a response for this X account.";
+  return X_RECOVERY_RECEIVED_MESSAGE;
 }
 
 function syncXSessionFromStorage() {
@@ -656,7 +667,10 @@ function syncXSessionFromStorage() {
 function syncXAuthCard() {
   if (!els.xAuthCard) return;
 
-  const xAuthEnabled = runtime.config?.xAuth?.enabled !== false && shouldOfferXRecovery();
+  const xAuthEnabled = isXRecoveryOffered();
+  if (els.xAuthBlock) {
+    els.xAuthBlock.hidden = !xAuthEnabled;
+  }
   els.xAuthCard.hidden = !xAuthEnabled;
   if (!xAuthEnabled) return;
 
@@ -1050,10 +1064,48 @@ function getRoundActionMeta(round) {
   }
 }
 
+function getRewardsLoadingMarkup() {
+  return `
+    <article class="round-card muted rewards-loading-card" aria-busy="true" aria-live="polite">
+      <h3 class="rewards-loading-title">
+        Loading Rewards<span class="loading-ellipsis" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>
+      </h3>
+    </article>
+  `;
+}
+
+function getRewardsErrorMarkup() {
+  return `
+    <article class="round-card muted" aria-live="polite">
+      <p class="round-title">Rewards could not be loaded.</p>
+      <p class="round-meta">Check your connection, then refresh this page.</p>
+    </article>
+  `;
+}
+
 function renderRoundList() {
   const visibleRounds = getVisibleRounds();
+  const showOnlyXRecovery = !visibleRounds.length && isXRecoveryOffered();
+  if (els.availableClaimsBlock) {
+    els.availableClaimsBlock.hidden = showOnlyXRecovery;
+  }
+
+  if (runtime.isLoadingRewards) {
+    els.roundList.innerHTML = getRewardsLoadingMarkup();
+    return;
+  }
+
+  if (runtime.rewardsErrorMessage) {
+    els.roundList.innerHTML = getRewardsErrorMarkup();
+    return;
+  }
 
   if (!visibleRounds.length) {
+    if (showOnlyXRecovery) {
+      els.roundList.replaceChildren();
+      return;
+    }
+
     const title = runtime.account
       ? "Nothing available right now."
       : "Connect your wallet to check for claims.";
@@ -1099,6 +1151,15 @@ function renderRoundList() {
       });
     });
   });
+}
+
+function setRewardsLoading(isLoading) {
+  runtime.isLoadingRewards = isLoading;
+  if (isLoading) {
+    runtime.rewardsErrorMessage = "";
+  }
+  renderRoundList();
+  syncXAuthCard();
 }
 
 async function buildRoundView(storedRound) {
@@ -1162,22 +1223,29 @@ async function buildRoundView(storedRound) {
 }
 
 async function refreshRounds() {
-  if (!runtime.account || !isClaimsApiConfigured(runtime.config)) {
+  try {
+    if (!runtime.account || !isClaimsApiConfigured(runtime.config)) {
+      runtime.rounds = [];
+      runtime.rewardsErrorMessage = "";
+      return;
+    }
+
+    const payload = await fetchWalletClaimRounds(runtime.config, runtime.account);
+    const storedRounds = Array.isArray(payload?.rounds) ? payload.rounds : [];
+    runtime.rounds = await Promise.all(storedRounds.map((round) => buildRoundView(round)));
+    runtime.rewardsErrorMessage = "";
+  } catch {
     runtime.rounds = [];
+    runtime.rewardsErrorMessage = "Rewards could not be loaded.";
+  } finally {
+    runtime.isLoadingRewards = false;
     renderRoundList();
     syncXAuthCard();
-    return;
   }
-
-  const payload = await fetchWalletClaimRounds(runtime.config, runtime.account);
-  const storedRounds = Array.isArray(payload?.rounds) ? payload.rounds : [];
-  runtime.rounds = await Promise.all(storedRounds.map((round) => buildRoundView(round)));
-
-  renderRoundList();
-  syncXAuthCard();
 }
 
 async function refreshPage() {
+  setRewardsLoading(true);
   await syncWalletState(runtime);
 
   try {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1264,6 +1264,31 @@ h3 {
   font-size: 1rem;
 }
 
+.rewards-loading-title {
+  color: #fff6df;
+  font-size: clamp(1.2rem, 4vw, 1.55rem);
+  line-height: 1.1;
+}
+
+.loading-ellipsis {
+  display: inline-grid;
+  grid-template-columns: repeat(3, 0.42em);
+  margin-left: 2px;
+}
+
+.loading-ellipsis span {
+  opacity: 0.28;
+  animation: loadingDot 1.15s ease-in-out infinite;
+}
+
+.loading-ellipsis span:nth-child(2) {
+  animation-delay: 150ms;
+}
+
+.loading-ellipsis span:nth-child(3) {
+  animation-delay: 300ms;
+}
+
 .lede,
 .hint {
   margin: 0;
@@ -2058,6 +2083,12 @@ tbody tr:last-child td {
   box-shadow: none;
 }
 
+.rewards-loading-card {
+  min-height: 88px;
+  display: flex;
+  align-items: center;
+}
+
 .round-card-top {
   display: flex;
   align-items: flex-start;
@@ -2215,6 +2246,19 @@ code {
   }
   50% {
     transform: translateY(8px) scale(1.04);
+  }
+}
+
+@keyframes loadingDot {
+  0%,
+  80%,
+  100% {
+    opacity: 0.28;
+    transform: translateY(0);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-2px);
   }
 }
 


### PR DESCRIPTION
## Summary

- Hide the generic available-claims empty state when X recovery is the actionable path.
- Keep X recovery hidden until wallet rewards loading finishes successfully, with a loading card while rewards are resolving.
- Show refresh guidance when the rewards lookup fails instead of implying the wallet has no claims.
- Update submitted/repeated X recovery copy to point users toward future airdrop rounds.

## New / edited claim page states

- **Initial page load / wallet state resolving:** show `Available Claims` with `Loading Rewards...`; keep X recovery hidden.
- **Wallet connected and rewards lookup in progress:** show `Available Claims` with `Loading Rewards...`; keep X recovery hidden.
- **Wallet connected and rewards lookup fails:** show `Rewards could not be loaded.` plus `Check your connection, then refresh this page.`; keep X recovery hidden.
- **Wallet connected with no visible/on-chain claims and X recovery is enabled:** show only the X sign-in/recovery section; hide the `Available Claims` block and generic empty state.
- **Signed in with X and a recovery response already exists:** show `Your response has been received. You may be eligible for future airdrop rounds.` and hide the verify action.

## Root Cause

The X recovery card and the available-claims empty state were controlled by separate rendering paths. That allowed the generic empty state, wrapper title, and initial static X markup to appear even when the app was still resolving wallet reward state or offering X recovery.

## Validation

- `npx playwright test e2e/tests/claim/claim-flow.spec.js e2e/tests/claim/wallet-menu.spec.js`
- Result: `24 passed`