### PR TITLE
Integrate shared wallet module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Check Out Repository
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Set Up Node.js
         uses: actions/setup-node@v6
@@ -53,6 +55,8 @@ jobs:
     steps:
       - name: Check Out Repository
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Set Up Node.js
         uses: actions/setup-node@v6
@@ -89,6 +93,8 @@ jobs:
     steps:
       - name: Check Out Repository
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Set Up Node.js
         uses: actions/setup-node@v6

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "frontend/vendor/liberdus-wallet-module"]
+	path = frontend/vendor/liberdus-wallet-module
+	url = https://github.com/Liberdus/liberdus-wallet-module.git
+	branch = main

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -1009,60 +1009,15 @@ async function copyWalletAddress() {
   logger.log("Wallet address copied.", "success");
 }
 
-function createWalletInitials(name) {
-  const parts = String(name || "Wallet")
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2);
-
-  if (!parts.length) return "W";
-  return parts.map((part) => part[0]?.toUpperCase() || "").join("");
-}
-
-function createWalletTriggerIcon() {
-  const iconShell = document.createElement("span");
-  iconShell.className = "wallet-trigger-icon-shell";
-  iconShell.setAttribute("aria-hidden", "true");
-
-  const fallback = document.createElement("span");
-  fallback.className = "wallet-trigger-icon-fallback";
-  fallback.textContent = createWalletInitials(runtime.selectedWalletName);
-  iconShell.append(fallback);
-
-  if (runtime.selectedWalletIcon) {
-    const image = document.createElement("img");
-    image.className = "wallet-trigger-icon";
-    image.src = runtime.selectedWalletIcon;
-    image.alt = "";
-    image.hidden = true;
-    image.addEventListener("load", () => {
-      fallback.hidden = true;
-      image.hidden = false;
-    });
-    image.addEventListener("error", () => {
-      image.remove();
-    });
-    iconShell.prepend(image);
-  }
-
-  return iconShell;
-}
-
 function renderWalletTrigger(label) {
+  els.connectButton.textContent = label;
+
   if (!runtime.account) {
-    els.connectButton.textContent = label;
     els.connectButton.removeAttribute("aria-label");
     return;
   }
 
-  const labelText = document.createElement("span");
-  labelText.className = "wallet-trigger-label";
-  labelText.textContent = label;
-
-  const walletName = String(runtime.selectedWalletName || "").trim() || "Wallet";
-  els.connectButton.replaceChildren(createWalletTriggerIcon(), labelText);
-  els.connectButton.setAttribute("aria-label", `${walletName} ${label}`);
+  els.connectButton.setAttribute("aria-label", `Connected wallet ${label}`);
 }
 
 function syncWalletButton() {

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -26,6 +26,7 @@ import {
   switchConfiguredNetwork,
   bindWalletEvents,
   getAvailableWallets,
+  parseWalletChainId,
 } from "../shared/wallet.js";
 import { promptForWalletSelection } from "../shared/wallet-picker.js";
 import {
@@ -59,6 +60,8 @@ const runtime = {
   injectedProvider: null,
   selectedWalletId: null,
   selectedWalletName: null,
+  selectedWalletRdns: null,
+  selectedWalletIcon: null,
   owner: null,
   pendingOwner: null,
   currentEpoch: 0,
@@ -1006,13 +1009,69 @@ async function copyWalletAddress() {
   logger.log("Wallet address copied.", "success");
 }
 
+function createWalletInitials(name) {
+  const parts = String(name || "Wallet")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2);
+
+  if (!parts.length) return "W";
+  return parts.map((part) => part[0]?.toUpperCase() || "").join("");
+}
+
+function createWalletTriggerIcon() {
+  const iconShell = document.createElement("span");
+  iconShell.className = "wallet-trigger-icon-shell";
+  iconShell.setAttribute("aria-hidden", "true");
+
+  const fallback = document.createElement("span");
+  fallback.className = "wallet-trigger-icon-fallback";
+  fallback.textContent = createWalletInitials(runtime.selectedWalletName);
+  iconShell.append(fallback);
+
+  if (runtime.selectedWalletIcon) {
+    const image = document.createElement("img");
+    image.className = "wallet-trigger-icon";
+    image.src = runtime.selectedWalletIcon;
+    image.alt = "";
+    image.hidden = true;
+    image.addEventListener("load", () => {
+      fallback.hidden = true;
+      image.hidden = false;
+    });
+    image.addEventListener("error", () => {
+      image.remove();
+    });
+    iconShell.prepend(image);
+  }
+
+  return iconShell;
+}
+
+function renderWalletTrigger(label) {
+  if (!runtime.account) {
+    els.connectButton.textContent = label;
+    els.connectButton.removeAttribute("aria-label");
+    return;
+  }
+
+  const labelText = document.createElement("span");
+  labelText.className = "wallet-trigger-label";
+  labelText.textContent = label;
+
+  const walletName = String(runtime.selectedWalletName || "").trim() || "Wallet";
+  els.connectButton.replaceChildren(createWalletTriggerIcon(), labelText);
+  els.connectButton.setAttribute("aria-label", `${walletName} ${label}`);
+}
+
 function syncWalletButton() {
   const label = runtime.account
     ? formatAddressShort(runtime.account)
     : runtime.isConnectingWallet
       ? "Connecting..."
       : "Connect Wallet";
-  els.connectButton.textContent = label;
+  renderWalletTrigger(label);
   els.connectButton.disabled = runtime.isConnectingWallet;
   els.connectButton.setAttribute("aria-busy", runtime.isConnectingWallet ? "true" : "false");
   els.walletMenuAddress.textContent = runtime.account ? formatAddressShort(runtime.account) : "-";
@@ -2729,9 +2788,10 @@ function bindEvents() {
       clearMessage();
     },
     onChainChanged: async (chainId) => {
-      resetProvider(runtime, chainId ? Number.parseInt(chainId, 16) : null);
+      const nextChainId = parseWalletChainId(chainId);
+      if (nextChainId !== null && runtime.chainId === nextChainId) return;
+      resetProvider(runtime, nextChainId);
       await refreshPage();
-      clearMessage();
     },
   });
 

--- a/frontend/js/pages/claim.js
+++ b/frontend/js/pages/claim.js
@@ -20,6 +20,7 @@ import {
   switchConfiguredNetwork,
   bindWalletEvents,
   getAvailableWallets,
+  parseWalletChainId,
 } from "../shared/wallet.js";
 import { promptForWalletSelection } from "../shared/wallet-picker.js";
 import { fetchWalletClaimRounds, isClaimsApiConfigured } from "../shared/claims.js";
@@ -47,6 +48,7 @@ const runtime = {
   selectedWalletId: null,
   selectedWalletName: null,
   selectedWalletRdns: null,
+  selectedWalletIcon: null,
   owner: null,
   currentEpoch: 0,
   config: {
@@ -977,13 +979,69 @@ function isMetaMaskWalletSelected() {
   return Boolean(provider?.isMetaMask);
 }
 
+function createWalletInitials(name) {
+  const parts = String(name || "Wallet")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2);
+
+  if (!parts.length) return "W";
+  return parts.map((part) => part[0]?.toUpperCase() || "").join("");
+}
+
+function createWalletTriggerIcon() {
+  const iconShell = document.createElement("span");
+  iconShell.className = "wallet-trigger-icon-shell";
+  iconShell.setAttribute("aria-hidden", "true");
+
+  const fallback = document.createElement("span");
+  fallback.className = "wallet-trigger-icon-fallback";
+  fallback.textContent = createWalletInitials(runtime.selectedWalletName);
+  iconShell.append(fallback);
+
+  if (runtime.selectedWalletIcon) {
+    const image = document.createElement("img");
+    image.className = "wallet-trigger-icon";
+    image.src = runtime.selectedWalletIcon;
+    image.alt = "";
+    image.hidden = true;
+    image.addEventListener("load", () => {
+      fallback.hidden = true;
+      image.hidden = false;
+    });
+    image.addEventListener("error", () => {
+      image.remove();
+    });
+    iconShell.prepend(image);
+  }
+
+  return iconShell;
+}
+
+function renderWalletTrigger(label) {
+  if (!runtime.account) {
+    els.connectButton.textContent = label;
+    els.connectButton.removeAttribute("aria-label");
+    return;
+  }
+
+  const labelText = document.createElement("span");
+  labelText.className = "wallet-trigger-label";
+  labelText.textContent = label;
+
+  const walletName = String(runtime.selectedWalletName || "").trim() || "Wallet";
+  els.connectButton.replaceChildren(createWalletTriggerIcon(), labelText);
+  els.connectButton.setAttribute("aria-label", `${walletName} ${label}`);
+}
+
 function syncWalletButton() {
   const label = runtime.account
     ? formatAddressShort(runtime.account)
     : runtime.isConnectingWallet
       ? "Connecting..."
       : "Connect Wallet";
-  els.connectButton.textContent = label;
+  renderWalletTrigger(label);
   els.connectButton.disabled = runtime.isConnectingWallet;
   els.connectButton.setAttribute("aria-busy", runtime.isConnectingWallet ? "true" : "false");
   els.walletMenuAddress.textContent = runtime.account ? formatAddressShort(runtime.account) : "-";
@@ -1476,11 +1534,12 @@ function bindEvents() {
       clearMessage();
     },
     onChainChanged: async (chainId) => {
+      const nextChainId = parseWalletChainId(chainId);
+      if (nextChainId !== null && runtime.chainId === nextChainId) return;
       runtime.claimInFlightEpoch = null;
       hideClaimCelebration({ restoreFocus: false, immediate: true });
-      resetProvider(runtime, chainId ? Number.parseInt(chainId, 16) : null);
+      resetProvider(runtime, nextChainId);
       await refreshPage();
-      clearMessage();
     },
   });
 

--- a/frontend/js/pages/claim.js
+++ b/frontend/js/pages/claim.js
@@ -979,60 +979,15 @@ function isMetaMaskWalletSelected() {
   return Boolean(provider?.isMetaMask);
 }
 
-function createWalletInitials(name) {
-  const parts = String(name || "Wallet")
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2);
-
-  if (!parts.length) return "W";
-  return parts.map((part) => part[0]?.toUpperCase() || "").join("");
-}
-
-function createWalletTriggerIcon() {
-  const iconShell = document.createElement("span");
-  iconShell.className = "wallet-trigger-icon-shell";
-  iconShell.setAttribute("aria-hidden", "true");
-
-  const fallback = document.createElement("span");
-  fallback.className = "wallet-trigger-icon-fallback";
-  fallback.textContent = createWalletInitials(runtime.selectedWalletName);
-  iconShell.append(fallback);
-
-  if (runtime.selectedWalletIcon) {
-    const image = document.createElement("img");
-    image.className = "wallet-trigger-icon";
-    image.src = runtime.selectedWalletIcon;
-    image.alt = "";
-    image.hidden = true;
-    image.addEventListener("load", () => {
-      fallback.hidden = true;
-      image.hidden = false;
-    });
-    image.addEventListener("error", () => {
-      image.remove();
-    });
-    iconShell.prepend(image);
-  }
-
-  return iconShell;
-}
-
 function renderWalletTrigger(label) {
+  els.connectButton.textContent = label;
+
   if (!runtime.account) {
-    els.connectButton.textContent = label;
     els.connectButton.removeAttribute("aria-label");
     return;
   }
 
-  const labelText = document.createElement("span");
-  labelText.className = "wallet-trigger-label";
-  labelText.textContent = label;
-
-  const walletName = String(runtime.selectedWalletName || "").trim() || "Wallet";
-  els.connectButton.replaceChildren(createWalletTriggerIcon(), labelText);
-  els.connectButton.setAttribute("aria-label", `${walletName} ${label}`);
+  els.connectButton.setAttribute("aria-label", `Connected wallet ${label}`);
 }
 
 function syncWalletButton() {

--- a/frontend/js/shared/wallet.js
+++ b/frontend/js/shared/wallet.js
@@ -33,9 +33,10 @@ export function parseWalletChainId(rawChainId) {
 
   if (typeof rawChainId === "string" && rawChainId.trim()) {
     const normalized = rawChainId.trim().toLowerCase();
-    return normalized.startsWith("0x")
+    const chainId = normalized.startsWith("0x")
       ? Number.parseInt(normalized, 16)
       : Number(normalized);
+    return Number.isFinite(chainId) ? chainId : null;
   }
 
   return null;

--- a/frontend/js/shared/wallet.js
+++ b/frontend/js/shared/wallet.js
@@ -1,71 +1,12 @@
 import { ethers } from "./ethers.js";
-import { CHAIN_NAME_BY_ID, WALLET_SESSION_KEY, toChainIdHex } from "./constants.js";
+import { CHAIN_NAME_BY_ID, WALLET_SESSION_KEY } from "./constants.js";
+import { createWalletCore } from "../../vendor/liberdus-wallet-module/index.js";
+import { switchOrAddEthereumChain } from "../../vendor/liberdus-wallet-module/adapters/chain.js";
 
-const EIP6963_ANNOUNCE_EVENT = "eip6963:announceProvider";
-const EIP6963_REQUEST_EVENT = "eip6963:requestProvider";
-const LEGACY_WALLET_PREFIX = "legacy";
-const LEGACY_DEFAULT_WALLET_ID = `${LEGACY_WALLET_PREFIX}:default`;
-const AMBIGUOUS_WALLET_ID = Symbol("ambiguous-wallet-id");
-
-const discoveredWallets = new Map();
-const walletAliasIds = new Map();
-const walletEventSubscribers = new Set();
-
-let providerIds = new WeakMap();
-let walletIdsByUuid = new Map();
-let walletIdsByRdns = new Map();
-let discoveryInitialized = false;
-let activeInjectedProvider = null;
-let boundWalletEventProvider = null;
-let boundAccountsChanged = null;
-let boundChainChanged = null;
-let nextEip6963SortIndex = 0;
-
-function createWalletId(source, name, fallback = "wallet") {
-  return `${source}:${String(name || fallback).trim().toLowerCase().replace(/[^a-z0-9]+/g, "-") || fallback}`;
-}
-
-function normalizeWalletSession(rawSession) {
-  if (!rawSession) return null;
-
-  if (rawSession === "injected") {
-    return { walletId: LEGACY_DEFAULT_WALLET_ID };
-  }
-
-  if (rawSession.trim().startsWith("{")) {
-    try {
-      const parsed = JSON.parse(rawSession);
-      if (typeof parsed?.walletId === "string" && parsed.walletId) {
-        return { walletId: parsed.walletId };
-      }
-    } catch {
-      return null;
-    }
-  }
-
-  return typeof rawSession === "string" && rawSession ? { walletId: rawSession } : null;
-}
-
-function saveWalletSession(walletId) {
-  if (!walletId) {
-    clearWalletSession();
-    return;
-  }
-
-  window.localStorage.setItem(WALLET_SESSION_KEY, JSON.stringify({ walletId }));
-}
-
-function clearWalletSession() {
-  window.localStorage.removeItem(WALLET_SESSION_KEY);
-}
-
-function getWalletSession() {
-  return normalizeWalletSession(window.localStorage.getItem(WALLET_SESSION_KEY));
-}
-
-export function hasWalletSession() {
-  return Boolean(getWalletSession()?.walletId);
-}
+const walletCore = createWalletCore({
+  walletSessionKey: WALLET_SESSION_KEY,
+  discoveryWaitMs: 250,
+});
 
 function resolveChainName(runtime, chainId, networkName) {
   const numericChainId = Number(chainId);
@@ -81,63 +22,50 @@ function resolveChainName(runtime, chainId, networkName) {
   return CHAIN_NAME_BY_ID[numericChainId] || null;
 }
 
-function applyNetworkToRuntime(runtime, network) {
-  runtime.chainId = Number(network.chainId);
-  runtime.chainName = resolveChainName(runtime, runtime.chainId, network.name);
+export function parseWalletChainId(rawChainId) {
+  if (typeof rawChainId === "number" && Number.isFinite(rawChainId)) {
+    return rawChainId;
+  }
+
+  if (typeof rawChainId === "bigint") {
+    return Number(rawChainId);
+  }
+
+  if (typeof rawChainId === "string" && rawChainId.trim()) {
+    const normalized = rawChainId.trim().toLowerCase();
+    return normalized.startsWith("0x")
+      ? Number.parseInt(normalized, 16)
+      : Number(normalized);
+  }
+
+  return null;
 }
 
-function matchesWalletNamespaceProvider(namespaceProvider, provider) {
-  if (!namespaceProvider || !provider) return false;
-  if (namespaceProvider === provider) return true;
+async function syncRuntimeChainFromInjected(runtime) {
+  const state = walletCore.getState();
+  const stateChainId = parseWalletChainId(state.chainId);
+  if (stateChainId !== null && Number.isFinite(stateChainId)) {
+    runtime.chainId = stateChainId;
+    runtime.chainName = resolveChainName(runtime, stateChainId, state.chainName);
+    return true;
+  }
 
-  const namespaceProviders = Array.isArray(namespaceProvider.providers)
-    ? namespaceProvider.providers
-    : [];
-  const candidateProviders = Array.isArray(provider.providers)
-    ? provider.providers
-    : [];
+  const injected = getInjectedProviderForRuntime(runtime);
+  if (!injected?.request) return false;
 
-  return namespaceProviders.includes(provider) || candidateProviders.includes(namespaceProvider);
-}
-
-function isPhantomNamespaceProvider(provider) {
-  if (typeof window === "undefined") return false;
-  return matchesWalletNamespaceProvider(window.phantom?.ethereum, provider);
-}
-
-function guessLegacyWalletName(provider) {
-  if (provider?.isPhantom || isPhantomNamespaceProvider(provider)) return "Phantom";
-  if (provider?.isRabby) return "Rabby";
-  if (provider?.isCoinbaseWallet) return "Coinbase Wallet";
-  if (provider?.isBraveWallet) return "Brave Wallet";
-  if (provider?.isFrame) return "Frame";
-  if (provider?.isTally) return "Taho";
-  if (provider?.isMetaMask) return "MetaMask";
-  return "Injected Wallet";
-}
-
-function guessLegacyWalletRdns(provider) {
-  if (provider?.isPhantom || isPhantomNamespaceProvider(provider)) return "com.phantom.browser";
-  if (provider?.isRabby) return "io.rabby";
-  if (provider?.isCoinbaseWallet) return "com.coinbase.wallet";
-  if (provider?.isBraveWallet) return "com.brave.wallet";
-  if (provider?.isFrame) return "sh.frame";
-  if (provider?.isTally) return "so.tally";
-  if (provider?.isMetaMask) return "io.metamask";
-  return "";
+  try {
+    const chainId = parseWalletChainId(await injected.request({ method: "eth_chainId" }));
+    if (chainId === null || !Number.isFinite(chainId)) return false;
+    runtime.chainId = chainId;
+    runtime.chainName = resolveChainName(runtime, chainId, null);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeWalletIdentityValue(value) {
   return String(value || "").trim().toLowerCase();
-}
-
-function normalizeWalletInfo(info = {}) {
-  return {
-    uuid: normalizeWalletIdentityValue(info.uuid),
-    name: String(info.name || "").trim(),
-    icon: String(info.icon || "").trim(),
-    rdns: normalizeWalletIdentityValue(info.rdns),
-  };
 }
 
 function isBnbChainConfig(config) {
@@ -156,8 +84,7 @@ function isPhantomWallet(wallet) {
   const rdns = normalizeWalletIdentityValue(wallet.info?.rdns);
   return name.includes("phantom")
     || rdns.includes("phantom")
-    || Boolean(wallet.provider?.isPhantom)
-    || isPhantomNamespaceProvider(wallet.provider);
+    || Boolean(wallet.provider?.isPhantom);
 }
 
 function getWalletCompatibility(config, wallet) {
@@ -198,397 +125,51 @@ function assertWalletSupported(config, wallet) {
   return compatibility;
 }
 
-function mergeWalletInfo(primary = {}, secondary = {}) {
-  return {
-    uuid: String(primary.uuid || secondary.uuid || ""),
-    name: String(primary.name || secondary.name || "Injected Wallet"),
-    icon: String(primary.icon || secondary.icon || ""),
-    rdns: String(primary.rdns || secondary.rdns || ""),
-  };
+function resetProviderIfChanged(runtime, injectedProvider) {
+  if (runtime.providerSource === injectedProvider) return;
+
+  runtime.provider = null;
+  runtime.providerSource = null;
+  runtime.signer = null;
 }
 
-function mergeLinkedProviders(...providers) {
-  return [...new Set(providers.filter(Boolean))];
-}
+function syncWalletCoreStateToRuntime(runtime) {
+  const state = walletCore.getState();
+  const selectedProvider = state.selectedWalletId ? walletCore.getEip1193Provider() : null;
 
-function getWalletSourcePriority(source) {
-  return source === "eip6963" ? 0 : 1;
-}
+  runtime.account = state.account ? ethers.getAddress(state.account) : null;
+  runtime.selectedWalletId = state.selectedWalletId || null;
+  runtime.selectedWalletName = state.selectedWalletName || null;
+  runtime.selectedWalletRdns = state.selectedWalletRdns || null;
+  runtime.selectedWalletIcon = state.selectedWalletIcon || null;
+  runtime.injectedProvider = selectedProvider;
 
-function createWalletDescriptor(candidate, previous = null) {
-  const candidateSource = candidate.source || previous?.source || LEGACY_WALLET_PREFIX;
-  const candidatePriority = getWalletSourcePriority(candidateSource);
-  const previousPriority = previous?.sourcePriority ?? Number.POSITIVE_INFINITY;
-  const isFreshEip6963Announcement = previous
-    && candidateSource === "eip6963"
-    && previous.source === "eip6963";
-  const preferCandidate = !previous || candidatePriority < previousPriority || isFreshEip6963Announcement;
-
-  return {
-    id: candidate.id,
-    provider: preferCandidate ? candidate.provider : (previous?.provider || candidate.provider),
-    linkedProviders: mergeLinkedProviders(previous?.provider, candidate.provider),
-    source: preferCandidate ? candidateSource : (previous?.source || candidateSource),
-    sourcePriority: preferCandidate ? candidatePriority : (previous?.sourcePriority ?? candidatePriority),
-    sortIndex: previous
-      ? (preferCandidate ? (candidate.sortIndex ?? previous.sortIndex) : previous.sortIndex)
-      : (candidate.sortIndex ?? 0),
-    info: mergeWalletInfo(
-      preferCandidate ? candidate.info : previous?.info,
-      preferCandidate ? previous?.info : candidate.info,
-    ),
-  };
-}
-
-function getWalletSortLabel(wallet) {
-  return `${wallet.info?.name || ""}|${wallet.info?.rdns || ""}|${wallet.id || ""}`.toLowerCase();
-}
-
-function listWalletsSnapshot() {
-  return [...discoveredWallets.values()]
-    .sort((left, right) => {
-      if (left.sourcePriority !== right.sourcePriority) {
-        return left.sourcePriority - right.sourcePriority;
-      }
-      if (left.sortIndex !== right.sortIndex) {
-        return left.sortIndex - right.sortIndex;
-      }
-      return getWalletSortLabel(left).localeCompare(getWalletSortLabel(right));
-    });
-}
-
-function rebuildWalletLookups() {
-  providerIds = new WeakMap();
-  walletIdsByUuid = new Map();
-  walletIdsByRdns = new Map();
-
-  for (const wallet of discoveredWallets.values()) {
-    for (const provider of mergeLinkedProviders(wallet.provider, ...(wallet.linkedProviders || []))) {
-      providerIds.set(provider, wallet.id);
-    }
-    if (wallet.info?.uuid) {
-      walletIdsByUuid.set(wallet.info.uuid, wallet.id);
-    }
-    if (wallet.info?.rdns) {
-      const existingWalletId = walletIdsByRdns.get(wallet.info.rdns);
-      if (!existingWalletId) {
-        walletIdsByRdns.set(wallet.info.rdns, wallet.id);
-      } else if (existingWalletId !== wallet.id) {
-        walletIdsByRdns.set(wallet.info.rdns, AMBIGUOUS_WALLET_ID);
-      }
-    }
-  }
-}
-
-function resolveWalletAlias(walletId) {
-  let resolvedWalletId = String(walletId || "");
-  const visited = new Set();
-
-  while (walletAliasIds.has(resolvedWalletId) && !visited.has(resolvedWalletId)) {
-    visited.add(resolvedWalletId);
-    resolvedWalletId = walletAliasIds.get(resolvedWalletId);
+  if (state.chainId !== null && state.chainId !== undefined) {
+    runtime.chainId = Number(state.chainId);
+    runtime.chainName = resolveChainName(runtime, runtime.chainId, state.chainName);
   }
 
-  return resolvedWalletId;
-}
-
-function findWalletById(walletId) {
-  if (!walletId) return null;
-  return discoveredWallets.get(resolveWalletAlias(walletId)) || null;
-}
-
-function findWalletId(provider, info = {}, source = LEGACY_WALLET_PREFIX) {
-  const existingProviderId = providerIds.get(provider);
-  if (existingProviderId) return existingProviderId;
-
-  if (info.uuid && walletIdsByUuid.has(info.uuid)) {
-    return walletIdsByUuid.get(info.uuid);
-  }
-
-  if (info.rdns) {
-    const rdnsWalletId = walletIdsByRdns.get(info.rdns);
-    if (rdnsWalletId && rdnsWalletId !== AMBIGUOUS_WALLET_ID) {
-      const rdnsWallet = discoveredWallets.get(rdnsWalletId) || null;
-      if (source === "eip6963" && info.uuid && rdnsWallet?.source !== LEGACY_WALLET_PREFIX) {
-        return null;
-      }
-      return rdnsWalletId;
-    }
-  }
-
-  if (source === "eip6963" && info.uuid) {
-    return null;
-  }
-
-  return null;
-}
-
-function hasDiscoveredEip6963Wallets() {
-  return [...discoveredWallets.values()].some((wallet) => wallet.source === "eip6963");
-}
-
-function pruneLegacyShimWallets(latestWallet) {
-  if (!latestWallet || typeof window === "undefined") return false;
-
-  const ethereum = window?.ethereum;
-  if (!ethereum || Array.isArray(ethereum.providers)) return false;
-
-  let changed = false;
-  for (const wallet of [...discoveredWallets.values()]) {
-    if (wallet.id === latestWallet.id) continue;
-    if (wallet.source !== LEGACY_WALLET_PREFIX) continue;
-    if (wallet.provider !== ethereum) continue;
-
-    discoveredWallets.delete(wallet.id);
-    changed = true;
-  }
-
-  if (changed) {
-    rebuildWalletLookups();
-  }
-
-  return changed;
-}
-
-function unbindWalletEventProvider() {
-  if (boundWalletEventProvider?.removeListener && boundAccountsChanged && boundChainChanged) {
-    boundWalletEventProvider.removeListener("accountsChanged", boundAccountsChanged);
-    boundWalletEventProvider.removeListener("chainChanged", boundChainChanged);
-  }
-
-  boundWalletEventProvider = null;
-  boundAccountsChanged = null;
-  boundChainChanged = null;
-}
-
-async function notifyAccountsChanged() {
-  for (const subscriber of walletEventSubscribers) {
-    if (subscriber.onAccountsChanged) {
-      await subscriber.onAccountsChanged();
-    }
-  }
-}
-
-async function notifyChainChanged(chainId) {
-  for (const subscriber of walletEventSubscribers) {
-    if (subscriber.onChainChanged) {
-      await subscriber.onChainChanged(chainId);
-    }
-  }
-}
-
-function getReadOnlyInjectedProvider() {
-  const discoveredProvider = listWalletsSnapshot()[0]?.provider || null;
-  if (discoveredProvider) return discoveredProvider;
-  if (window.ethereum) return window.ethereum;
-  return null;
-}
-
-function getCurrentInjectedProvider() {
-  return activeInjectedProvider || getReadOnlyInjectedProvider();
-}
-
-function syncWalletEventProvider() {
-  const nextProvider = walletEventSubscribers.size ? getCurrentInjectedProvider() : null;
-
-  if (!nextProvider?.on) {
-    unbindWalletEventProvider();
-    return;
-  }
-
-  if (boundWalletEventProvider === nextProvider) {
-    return;
-  }
-
-  unbindWalletEventProvider();
-
-  boundAccountsChanged = async () => {
-    await notifyAccountsChanged();
-  };
-
-  boundChainChanged = async (chainId) => {
-    await notifyChainChanged(chainId);
-  };
-
-  nextProvider.on("accountsChanged", boundAccountsChanged);
-  nextProvider.on("chainChanged", boundChainChanged);
-  boundWalletEventProvider = nextProvider;
-}
-
-function registerWallet(candidate) {
-  const provider = candidate?.provider;
-  if (!provider || typeof provider.request !== "function") return null;
-
-  const normalizedInfo = normalizeWalletInfo(candidate.info);
-  const walletId = findWalletId(provider, normalizedInfo, candidate?.source || LEGACY_WALLET_PREFIX)
-    || candidate?.id
-    || createWalletId(
-      candidate?.source || LEGACY_WALLET_PREFIX,
-      normalizedInfo.name || guessLegacyWalletName(provider),
-      "wallet",
-    );
-  const previousWallet = discoveredWallets.get(walletId) || null;
-  const nextWallet = createWalletDescriptor({
-    id: walletId,
-    provider,
-    source: candidate?.source || LEGACY_WALLET_PREFIX,
-    sortIndex: candidate?.sortIndex ?? previousWallet?.sortIndex ?? 0,
-    info: normalizedInfo,
-  }, previousWallet);
-
-  discoveredWallets.set(walletId, nextWallet);
-  if (candidate?.id && candidate.id !== walletId) {
-    walletAliasIds.set(candidate.id, walletId);
-  }
-
-  rebuildWalletLookups();
-  if (activeInjectedProvider === previousWallet?.provider && previousWallet?.provider !== nextWallet.provider) {
-    activeInjectedProvider = nextWallet.provider;
-  }
-  syncWalletEventProvider();
-  return nextWallet;
-}
-
-function registerLegacyWallet(provider, index = 0) {
-  return registerWallet({
-    id: index === 0 ? LEGACY_DEFAULT_WALLET_ID : createWalletId(LEGACY_WALLET_PREFIX, `${guessLegacyWalletName(provider)}-${index + 1}`),
-    provider,
-    source: LEGACY_WALLET_PREFIX,
-    sortIndex: index,
-    info: {
-      name: guessLegacyWalletName(provider),
-      rdns: guessLegacyWalletRdns(provider),
-      icon: "",
-      uuid: "",
-    },
-  });
-}
-
-function collectLegacyWallets() {
-  if (!window.ethereum) return [];
-
-  const namespaceProviders = [...new Set([window.phantom?.ethereum].filter(Boolean))];
-  const rawProviders = Array.isArray(window.ethereum.providers) && window.ethereum.providers.length
-    ? window.ethereum.providers
-    : [];
-  const uniqueProviders = [...new Set(rawProviders.filter(Boolean))]
-    .filter((provider) => !(namespaceProviders.length && provider === window.ethereum && !namespaceProviders.includes(provider)));
-  const candidateProviders = [...new Set([...namespaceProviders, ...uniqueProviders])];
-
-  if (candidateProviders.length) {
-    return candidateProviders
-      .map((provider, index) => registerLegacyWallet(provider, index))
-      .filter(Boolean);
-  }
-
-  if (hasDiscoveredEip6963Wallets()) {
-    return [];
-  }
-
-  if (namespaceProviders.length) {
-    return [];
-  }
-
-  if (providerIds.get(window.ethereum)) {
-    return [];
-  }
-
-  const wallet = registerLegacyWallet(window.ethereum, 0);
-  return wallet ? [wallet] : [];
-}
-
-function requestWalletAnnouncements() {
-  try {
-    window.dispatchEvent(new Event(EIP6963_REQUEST_EVENT));
-  } catch {
-    // Some browsers may reject synthetic events during teardown.
-  }
-}
-
-function initWalletDiscovery() {
-  if (discoveryInitialized || typeof window === "undefined") return;
-
-  discoveryInitialized = true;
-  window.addEventListener(EIP6963_ANNOUNCE_EVENT, (event) => {
-    const detail = event?.detail;
-    if (!detail?.provider) return;
-
-    const wallet = registerWallet({
-      id: detail.info?.uuid || detail.info?.rdns || createWalletId("eip6963", detail.info?.name, "wallet"),
-      provider: detail.provider,
-      source: "eip6963",
-      sortIndex: nextEip6963SortIndex++,
-      info: detail.info || {},
-    });
-
-    if (pruneLegacyShimWallets(wallet)) {
-      syncWalletEventProvider();
-    }
-  });
-
-  collectLegacyWallets();
-  requestWalletAnnouncements();
-}
-
-function wait(ms) {
-  return new Promise((resolve) => {
-    window.setTimeout(resolve, ms);
-  });
-}
-
-async function discoverWallets(waitMs = 250) {
-  initWalletDiscovery();
-  collectLegacyWallets();
-  requestWalletAnnouncements();
-
-  if (waitMs > 0) {
-    await wait(waitMs);
-    collectLegacyWallets();
-  }
-
-  return listWalletsSnapshot();
-}
-
-function applyActiveWallet(runtime, wallet) {
-  const nextInjectedProvider = wallet?.provider || null;
-
-  activeInjectedProvider = nextInjectedProvider;
-  runtime.selectedWalletId = wallet?.id || null;
-  runtime.selectedWalletName = wallet?.info?.name || null;
-  runtime.selectedWalletRdns = wallet?.info?.rdns || null;
-  runtime.injectedProvider = nextInjectedProvider;
-
-  if (runtime.providerSource !== nextInjectedProvider) {
-    runtime.provider = null;
-    runtime.providerSource = null;
-    runtime.signer = null;
-  }
-
-  syncWalletEventProvider();
+  resetProviderIfChanged(runtime, selectedProvider || runtime.providerSource);
 }
 
 function getInjectedProviderForRuntime(runtime) {
-  const selectedWallet = runtime?.selectedWalletId ? findWalletById(runtime.selectedWalletId) : null;
-  if (selectedWallet) {
-    runtime.selectedWalletName = selectedWallet.info?.name || null;
-    runtime.selectedWalletRdns = selectedWallet.info?.rdns || null;
-    runtime.injectedProvider = selectedWallet.provider || null;
-    return runtime.injectedProvider;
+  if (runtime?.selectedWalletId) {
+    return runtime.injectedProvider || walletCore.getEip1193Provider();
   }
 
-  return runtime?.injectedProvider || getReadOnlyInjectedProvider();
+  return walletCore.getEip1193Provider();
 }
 
-async function resolveWalletById(walletId) {
-  if (!walletId) return null;
-  const cachedWallet = findWalletById(walletId);
-  if (cachedWallet) return cachedWallet;
-  const wallets = await discoverWallets();
-  return wallets.find((wallet) => wallet.id === resolveWalletAlias(walletId)) || null;
+function getRequestCapableProvider() {
+  return walletCore.getEip1193Provider();
+}
+
+export function hasWalletSession() {
+  return walletCore.hasWalletSession();
 }
 
 export async function getAvailableWallets(config = null) {
-  const wallets = await discoverWallets();
+  const wallets = await walletCore.discoverWallets();
   return wallets.map((wallet) => {
     const compatibility = getWalletCompatibility(config, wallet);
     return {
@@ -602,7 +183,9 @@ export async function getAvailableWallets(config = null) {
 }
 
 export async function ensureProvider(runtime) {
-  await discoverWallets();
+  if (!getInjectedProviderForRuntime(runtime)) {
+    await walletCore.discoverWallets();
+  }
   const injected = getInjectedProviderForRuntime(runtime);
   if (!injected) throw new Error("No compatible wallet was detected in this browser.");
 
@@ -623,62 +206,60 @@ export function resetProvider(runtime, nextChainId = null) {
     runtime.chainName = resolveChainName(runtime, runtime.chainId, null);
     return;
   }
+  runtime.chainId = null;
   runtime.chainName = null;
 }
 
 export async function connectWallet(runtime, walletId) {
-  const wallet = await resolveWalletById(walletId);
+  const wallet = await walletCore.resolveWalletById(walletId);
   if (!wallet) {
     throw new Error("The selected wallet is no longer available. Refresh the page and try again.");
   }
 
   assertWalletSupported(runtime?.config, wallet);
 
-  applyActiveWallet(runtime, wallet);
+  await walletCore.connect({ walletId: wallet.id });
+  syncWalletCoreStateToRuntime(runtime);
+  await syncRuntimeChainFromInjected(runtime);
 
   const provider = await ensureProvider(runtime);
-  await provider.send("eth_requestAccounts", []);
   runtime.signer = await provider.getSigner();
-  runtime.account = await runtime.signer.getAddress();
-  const network = await provider.getNetwork();
-  applyNetworkToRuntime(runtime, network);
-  saveWalletSession(wallet.id);
+  runtime.account = ethers.getAddress(await runtime.signer.getAddress());
   return runtime.account;
 }
 
 export async function disconnectWallet(runtime) {
-  clearWalletSession();
+  await walletCore.disconnect();
+  syncWalletCoreStateToRuntime(runtime);
   runtime.account = null;
   runtime.signer = null;
-  applyActiveWallet(runtime, null);
 
-  try {
-    const provider = await ensureProvider(runtime);
-    const network = await provider.getNetwork();
-    applyNetworkToRuntime(runtime, network);
-  } catch {
+  const hasChain = await syncRuntimeChainFromInjected(runtime);
+  if (!hasChain) {
     runtime.chainId = null;
     runtime.chainName = null;
   }
 }
 
 export async function syncWalletState(runtime) {
-  const session = getWalletSession();
-  let selectedWallet = session?.walletId ? await resolveWalletById(session.walletId) : null;
+  if (!hasWalletSession()) {
+    await walletCore.discoverWallets();
+  }
+  await walletCore.sync();
 
-  if (selectedWallet) {
+  const restoredWalletId = walletCore.getState().selectedWalletId;
+  const restoredWallet = restoredWalletId
+    ? await walletCore.resolveWalletById(restoredWalletId)
+    : null;
+  if (restoredWallet) {
     try {
-      assertWalletSupported(runtime?.config, selectedWallet);
+      assertWalletSupported(runtime?.config, restoredWallet);
     } catch {
-      selectedWallet = null;
+      await walletCore.disconnect();
     }
   }
 
-  if (session?.walletId && !selectedWallet) {
-    clearWalletSession();
-  }
-
-  applyActiveWallet(runtime, selectedWallet);
+  syncWalletCoreStateToRuntime(runtime);
 
   const injected = getInjectedProviderForRuntime(runtime);
   if (!injected) {
@@ -691,10 +272,7 @@ export async function syncWalletState(runtime) {
     return;
   }
 
-  const provider = await ensureProvider(runtime);
-  const network = await provider.getNetwork();
-
-  applyNetworkToRuntime(runtime, network);
+  await syncRuntimeChainFromInjected(runtime);
 
   if (!hasWalletSession()) {
     runtime.account = null;
@@ -702,73 +280,64 @@ export async function syncWalletState(runtime) {
     return;
   }
 
-  const accounts = await provider.send("eth_accounts", []);
-  runtime.account = accounts[0] ? ethers.getAddress(accounts[0]) : null;
+  runtime.account = walletCore.getState().account
+    ? ethers.getAddress(walletCore.getState().account)
+    : null;
+  const provider = await ensureProvider(runtime);
   runtime.signer = runtime.account ? await provider.getSigner() : null;
 
   if (!runtime.account) {
-    clearWalletSession();
+    await walletCore.disconnect();
+    syncWalletCoreStateToRuntime(runtime);
   }
-}
-
-function getRequestCapableProvider() {
-  return getCurrentInjectedProvider();
 }
 
 export async function addConfiguredNetwork(config) {
   const injected = getRequestCapableProvider();
   if (!injected) throw new Error("No compatible wallet was detected.");
-  if (!Number.isInteger(Number(config.chainId))) throw new Error("Configured chainId is required.");
-  if (!config.networkName || !config.rpcUrl || !config.nativeCurrency) {
-    throw new Error("Configured networkName, rpcUrl, and nativeCurrency are required.");
-  }
-
-  const chainIdHex = toChainIdHex(config.chainId);
-
-  await injected.request({
-    method: "wallet_addEthereumChain",
-    params: [
-      {
-        chainId: chainIdHex,
-        chainName: config.networkName,
-        rpcUrls: [config.rpcUrl],
-        nativeCurrency: config.nativeCurrency,
-      },
-    ],
+  await switchOrAddEthereumChain(injected, {
+    chainId: config?.chainId,
+    chainName: config?.networkName,
+    rpcUrls: [config?.rpcUrl],
+    nativeCurrency: config?.nativeCurrency,
   });
 }
 
 export async function switchConfiguredNetwork(config) {
   const injected = getRequestCapableProvider();
   if (!injected) throw new Error("No compatible wallet was detected.");
-  if (!Number.isInteger(Number(config.chainId))) throw new Error("Configured chainId is required.");
-
-  const chainIdHex = toChainIdHex(config.chainId);
-
-  try {
-    await injected.request({
-      method: "wallet_switchEthereumChain",
-      params: [{ chainId: chainIdHex }],
-    });
-  } catch (error) {
-    if (error?.code === 4902) {
-      await addConfiguredNetwork(config);
-      await switchConfiguredNetwork(config);
-      return;
-    }
-
-    throw error;
-  }
+  await switchOrAddEthereumChain(injected, {
+    chainId: config?.chainId,
+    chainName: config?.networkName,
+    rpcUrls: [config?.rpcUrl],
+    nativeCurrency: config?.nativeCurrency,
+  });
 }
 
 export function bindWalletEvents({ onAccountsChanged, onChainChanged }) {
-  const subscriber = { onAccountsChanged, onChainChanged };
-  walletEventSubscribers.add(subscriber);
-  initWalletDiscovery();
-  syncWalletEventProvider();
+  const scheduleEventHandler = (handler, data) => {
+    if (!handler) return;
 
-  return () => {
-    walletEventSubscribers.delete(subscriber);
-    syncWalletEventProvider();
+    const run = () => {
+      Promise.resolve(handler(data)).catch(() => {});
+    };
+
+    if (typeof window !== "undefined" && typeof window.setTimeout === "function") {
+      window.setTimeout(run, 0);
+      return;
+    }
+
+    run();
   };
+
+  return walletCore.subscribe((event, data) => {
+    if (event === "accountChanged") {
+      scheduleEventHandler(onAccountsChanged, data);
+      return;
+    }
+
+    if (event === "chainChanged") {
+      scheduleEventHandler(onChainChanged, data);
+    }
+  });
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -758,7 +758,57 @@ select {
 }
 
 .wallet-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   min-width: 164px;
+}
+
+.wallet-trigger-icon-shell,
+.wallet-trigger-label {
+  position: relative;
+  z-index: 1;
+}
+
+.wallet-trigger-icon-shell {
+  width: 26px;
+  min-width: 26px;
+  height: 26px;
+  min-height: 26px;
+  display: inline-grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 9px;
+  background: rgba(17, 25, 48, 0.14);
+  box-shadow: 0 0 0 1px rgba(17, 25, 48, 0.12) inset;
+}
+
+.wallet-trigger-icon,
+.wallet-trigger-icon-fallback {
+  width: 100%;
+  height: 100%;
+}
+
+.wallet-trigger-icon {
+  object-fit: cover;
+}
+
+.wallet-trigger-icon[hidden] {
+  display: none;
+}
+
+.wallet-trigger-icon-fallback {
+  display: grid;
+  place-items: center;
+  color: #111930;
+  font-family: var(--display);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.wallet-trigger-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .wallet-trigger.is-receiving-claim {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -764,53 +764,6 @@ select {
   min-width: 164px;
 }
 
-.wallet-trigger-icon-shell,
-.wallet-trigger-label {
-  position: relative;
-  z-index: 1;
-}
-
-.wallet-trigger-icon-shell {
-  width: 26px;
-  min-width: 26px;
-  height: 26px;
-  min-height: 26px;
-  display: inline-grid;
-  place-items: center;
-  overflow: hidden;
-  border-radius: 9px;
-  background: rgba(17, 25, 48, 0.14);
-  box-shadow: 0 0 0 1px rgba(17, 25, 48, 0.12) inset;
-}
-
-.wallet-trigger-icon,
-.wallet-trigger-icon-fallback {
-  width: 100%;
-  height: 100%;
-}
-
-.wallet-trigger-icon {
-  object-fit: cover;
-}
-
-.wallet-trigger-icon[hidden] {
-  display: none;
-}
-
-.wallet-trigger-icon-fallback {
-  display: grid;
-  place-items: center;
-  color: #111930;
-  font-family: var(--display);
-  font-size: 0.72rem;
-  font-weight: 800;
-}
-
-.wallet-trigger-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .wallet-trigger.is-receiving-claim {
   animation: walletReceivePulse 1.15s ease-out 1;
   box-shadow:


### PR DESCRIPTION
## Summary
- vendor the shared Liberdus wallet module as a submodule
- route claim/admin wallet discovery and sessions through the shared module
- display wallet logos/fallback initials next to connected wallet names
- preserve wrong-network handling, selected-provider restoration, and EIP-6963 wrapper behavior

## Tests
- npm test: 37 passing
- CI=1 npm run test:e2e: 45 passing