### PR TITLE
fix: keep airdrop round deadlines in sync

### DIFF
--- a/backend/lib/airdrop-chain.js
+++ b/backend/lib/airdrop-chain.js
@@ -2,6 +2,7 @@ const { ethers } = require("ethers");
 
 const AIRDROP_ABI = [
   "event AirdropStarted(uint256 indexed epoch, bytes32 indexed merkleRoot, uint256 deadline)",
+  "event DeadlineUpdated(uint256 indexed epoch, uint256 previousDeadline, uint256 newDeadline)",
   "function epochInfo(uint256) view returns (bytes32,uint256,uint256)",
   "function owner() view returns (address)",
 ];
@@ -86,6 +87,70 @@ async function verifyAirdropStartTransaction(appConfig, txHash, expectedMerkleRo
   };
 }
 
+async function verifyDeadlineUpdateTransaction(appConfig, txHash, expectedEpoch, expectedDeadline) {
+  const provider = createAirdropProvider(appConfig);
+  const contract = createAirdropContract(appConfig, provider);
+  const normalizedTxHash = String(txHash || "").trim();
+
+  if (!ethers.isHexString(normalizedTxHash, 32)) {
+    throw new Error("Transaction hash must be a 32-byte hex string.");
+  }
+
+  const receipt = await provider.getTransactionReceipt(normalizedTxHash);
+  if (!receipt) {
+    throw new Error("Transaction receipt was not found yet.");
+  }
+
+  if (Number(receipt.status || 0) !== 1) {
+    throw new Error("Transaction did not succeed on chain.");
+  }
+
+  const normalizedContractAddress = appConfig.airdropAddress.toLowerCase();
+  const matchingLogs = receipt.logs
+    .filter((log) => String(log.address || "").toLowerCase() === normalizedContractAddress)
+    .map((log) => {
+      try {
+        return contract.interface.parseLog(log);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean)
+    .filter((parsed) => parsed.name === "DeadlineUpdated");
+
+  if (matchingLogs.length !== 1) {
+    throw new Error("Expected exactly one DeadlineUpdated event in the transaction receipt.");
+  }
+
+  const [event] = matchingLogs;
+  const epoch = Number(event.args.epoch);
+  const previousDeadline = Number(event.args.previousDeadline || 0);
+  const newDeadline = Number(event.args.newDeadline || 0);
+
+  if (Number(expectedEpoch) !== epoch) {
+    throw new Error("Epoch from the transaction did not match the request.");
+  }
+
+  if (Number(expectedDeadline) !== newDeadline) {
+    throw new Error("Deadline from the transaction did not match the request.");
+  }
+
+  const onchain = await fetchEpochMetadata(appConfig, epoch);
+  if (onchain.deadline !== newDeadline) {
+    throw new Error("On-chain epoch deadline did not match the transaction event.");
+  }
+
+  return {
+    epoch,
+    previousDeadline,
+    deadline: newDeadline,
+    merkleRoot: onchain.merkleRoot,
+    txHash: normalizedTxHash.toLowerCase(),
+    blockNumber: Number(receipt.blockNumber || 0),
+    blockHash: String(receipt.blockHash || "").trim().toLowerCase(),
+  };
+}
+
 async function fetchAirdropOwner(appConfig) {
   const provider = createAirdropProvider(appConfig);
   const contract = createAirdropContract(appConfig, provider);
@@ -98,4 +163,5 @@ module.exports = {
   fetchAirdropOwner,
   fetchEpochMetadata,
   verifyAirdropStartTransaction,
+  verifyDeadlineUpdateTransaction,
 };

--- a/backend/lib/airdrop-round-store.js
+++ b/backend/lib/airdrop-round-store.js
@@ -178,6 +178,22 @@ function createAirdropRoundStore(db) {
           updated_at = @updatedAt
       WHERE id = @id
     `),
+    updateDraftDeadline: db.prepare(`
+      UPDATE airdrop_rounds
+      SET deadline = @deadline,
+          updated_at = @updatedAt
+      WHERE id = @id
+        AND deployment_key = @deploymentKey
+        AND status = 'draft'
+    `),
+    updateDeployedDeadlineByEpoch: db.prepare(`
+      UPDATE airdrop_rounds
+      SET deadline = @deadline,
+          updated_at = @updatedAt
+      WHERE deployment_key = @deploymentKey
+        AND status = 'deployed'
+        AND epoch = @epoch
+    `),
     deleteClaimsByRoundId: db.prepare(`
       DELETE FROM airdrop_claims
       WHERE round_id = ?
@@ -392,6 +408,58 @@ function createAirdropRoundStore(db) {
     return normalizeRoundRecord(statements.getRoundByIdAndDeployment.get(existing.id, existing.deploymentKey));
   });
 
+  const updateDraftRoundDeadline = db.transaction((roundId, deploymentKey, deadline, updatedAt = null) => {
+    const normalizedDeploymentKey = normalizeDeploymentKey(deploymentKey);
+    const normalizedRoundId = Number(roundId);
+    const existing = normalizeRoundRecord(
+      statements.getRoundByIdAndDeployment.get(normalizedRoundId, normalizedDeploymentKey),
+    );
+
+    if (!existing) {
+      throw new Error("Stored airdrop round was not found.");
+    }
+
+    if (existing.status !== "draft") {
+      throw new Error("Only draft rounds can be edited before deployment.");
+    }
+
+    const timestamp = normalizeIsoDate(updatedAt, new Date().toISOString());
+    statements.updateDraftDeadline.run({
+      id: existing.id,
+      deploymentKey: existing.deploymentKey,
+      deadline: Number(deadline),
+      updatedAt: timestamp,
+    });
+
+    return normalizeRoundRecord(statements.getRoundByIdAndDeployment.get(existing.id, existing.deploymentKey));
+  });
+
+  const updateDeployedRoundDeadlineByEpoch = db.transaction((deploymentKey, epoch, deadline, updatedAt = null) => {
+    const normalizedDeploymentKey = normalizeDeploymentKey(deploymentKey);
+    const normalizedEpoch = Number(epoch);
+    const existing = normalizeRoundRecord(
+      statements.getRoundByDeploymentAndEpoch.get(normalizedDeploymentKey, normalizedEpoch),
+    );
+
+    if (!existing) {
+      throw new Error("Stored deployed round was not found for this epoch.");
+    }
+
+    if (existing.status !== "deployed") {
+      throw new Error("Only deployed rounds can be synced by epoch.");
+    }
+
+    const timestamp = normalizeIsoDate(updatedAt, new Date().toISOString());
+    statements.updateDeployedDeadlineByEpoch.run({
+      deploymentKey: normalizedDeploymentKey,
+      epoch: normalizedEpoch,
+      deadline: Number(deadline),
+      updatedAt: timestamp,
+    });
+
+    return normalizeRoundRecord(statements.getRoundByDeploymentAndEpoch.get(normalizedDeploymentKey, normalizedEpoch));
+  });
+
   return {
     saveDraftRound(round) {
       return saveDraftRound(round);
@@ -399,6 +467,14 @@ function createAirdropRoundStore(db) {
 
     finalizeRoundDeployment(roundId, deploymentKey, deployment) {
       return finalizeRoundDeployment(roundId, deploymentKey, deployment);
+    },
+
+    updateDraftRoundDeadline(roundId, deploymentKey, deadline, updatedAt = null) {
+      return updateDraftRoundDeadline(roundId, deploymentKey, deadline, updatedAt);
+    },
+
+    updateDeployedRoundDeadlineByEpoch(deploymentKey, epoch, deadline, updatedAt = null) {
+      return updateDeployedRoundDeadlineByEpoch(deploymentKey, epoch, deadline, updatedAt);
     },
 
     listRounds(deploymentKey) {
@@ -409,6 +485,12 @@ function createAirdropRoundStore(db) {
     getRoundById(roundId, deploymentKey) {
       return normalizeRoundRecord(
         statements.getRoundByIdAndDeployment.get(Number(roundId), normalizeDeploymentKey(deploymentKey)),
+      );
+    },
+
+    getRoundByEpoch(epoch, deploymentKey) {
+      return normalizeRoundRecord(
+        statements.getRoundByDeploymentAndEpoch.get(normalizeDeploymentKey(deploymentKey), Number(epoch)),
       );
     },
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,7 +9,7 @@ const { openDatabase, getDatabasePath } = require("./lib/db");
 const { loadAppConfig, requireChainConfig } = require("./lib/app-config");
 const { buildClaimRound } = require("./lib/claim-round");
 const { createAirdropRoundStore } = require("./lib/airdrop-round-store");
-const { fetchAirdropOwner, verifyAirdropStartTransaction } = require("./lib/airdrop-chain");
+const { fetchAirdropOwner, verifyAirdropStartTransaction, verifyDeadlineUpdateTransaction } = require("./lib/airdrop-chain");
 const { createAccountStore } = require("./lib/x-account-store");
 const { createRecoverySubmissionStore } = require("./lib/recovery-submission-store");
 
@@ -64,6 +64,7 @@ const RATE_LIMITS = {
   adminDraftChallenge: { limit: 20, windowMs: 10 * 60 * 1000 },
   saveRound: { limit: 20, windowMs: 10 * 60 * 1000 },
   deployRound: { limit: 20, windowMs: 10 * 60 * 1000 },
+  updateRoundDeadline: { limit: 30, windowMs: 10 * 60 * 1000 },
   health: { limit: 30, windowMs: 60 * 1000 },
 };
 
@@ -1857,6 +1858,119 @@ async function handleDeployStoredAirdropRound(request, response, roundId) {
   });
 }
 
+async function verifyAdminRoundSaveSignature(body, { expectedMerkleRoot, expectedDeadline }) {
+  const challenge = getRequiredAdminRoundSaveChallenge(body);
+  const signedWalletAddress = requireWalletAddress(body.walletAddress);
+  const signature = String(body.signature || "").trim();
+  if (!signature) {
+    throw new HttpError(400, "Admin round save request must include a wallet signature.");
+  }
+
+  if (challenge.walletAddress !== signedWalletAddress) {
+    throw new HttpError(403, "Admin round save challenge does not match the signing wallet.");
+  }
+
+  if (challenge.merkleRoot !== String(expectedMerkleRoot || "").trim().toLowerCase()) {
+    throw new HttpError(400, "Admin round save challenge does not match the Merkle root.");
+  }
+
+  if (challenge.deadline !== Number(expectedDeadline)) {
+    throw new HttpError(400, "Admin round save challenge does not match the deadline.");
+  }
+
+  if (challenge.deploymentKey !== getRequiredDeploymentKey()) {
+    throw new HttpError(400, "Admin round save challenge does not match the active deployment.");
+  }
+
+  let recoveredAddress;
+  try {
+    recoveredAddress = ethers.verifyMessage(challenge.message, signature);
+  } catch {
+    throw new HttpError(400, "Admin round save signature is invalid.");
+  }
+
+  if (ethers.getAddress(recoveredAddress) !== signedWalletAddress) {
+    throw new HttpError(403, "Admin round save signature did not match the supplied wallet.");
+  }
+
+  const chainConfig = requireChainConfig(appConfig);
+  const currentOwner = await fetchAirdropOwner(chainConfig);
+  if (ethers.getAddress(currentOwner) !== signedWalletAddress) {
+    throw new HttpError(403, "Only the current contract owner can save airdrop drafts.");
+  }
+
+  adminRoundSaveChallenges.delete(challenge.challengeId);
+  return signedWalletAddress;
+}
+
+async function handleUpdateAirdropRoundDeadline(request, response) {
+  const body = await readJsonRequest(request);
+  const deploymentKey = getRequiredDeploymentKey();
+  const deadline = Number.parseInt(String(body.deadline ?? "").trim(), 10);
+
+  if (!Number.isInteger(deadline) || deadline < 0) {
+    throw new HttpError(400, "Round deadline must be zero or a positive integer.");
+  }
+
+  const roundId = Number.parseInt(String(body.roundId || "").trim(), 10);
+  if (Number.isInteger(roundId) && roundId > 0) {
+    if (deadline <= 0) {
+      throw new HttpError(400, "Draft round deadline must be a positive integer.");
+    }
+
+    const storedRound = airdropRoundStore.getRoundById(roundId, deploymentKey);
+    if (!storedRound) {
+      throw new HttpError(404, "Stored airdrop round was not found.");
+    }
+
+    if (storedRound.status !== "draft") {
+      throw new HttpError(400, "Only draft rounds can be edited with roundId.");
+    }
+
+    await verifyAdminRoundSaveSignature(body, {
+      expectedMerkleRoot: storedRound.merkleRoot,
+      expectedDeadline: deadline,
+    });
+
+    const updatedRound = airdropRoundStore.updateDraftRoundDeadline(
+      storedRound.id,
+      deploymentKey,
+      deadline,
+      new Date().toISOString(),
+    );
+
+    writeJson(response, 200, {
+      round: serializeAirdropRoundSummary(updatedRound),
+    });
+    return;
+  }
+
+  const epoch = Number.parseInt(String(body.epoch || "").trim(), 10);
+  if (!Number.isInteger(epoch) || epoch <= 0) {
+    throw new HttpError(400, "Epoch must be a positive integer.");
+  }
+
+  const txHash = requireBytes32Hex(body.txHash || body.transactionHash, "Transaction hash");
+  const chainConfig = requireChainConfig(appConfig);
+  const verifiedUpdate = await verifyDeadlineUpdateTransaction(chainConfig, txHash, epoch, deadline);
+  const storedRound = airdropRoundStore.getRoundByEpoch(verifiedUpdate.epoch, deploymentKey);
+  if (!storedRound || storedRound.status !== "deployed") {
+    throw new HttpError(404, "Stored deployed round was not found for this epoch.");
+  }
+
+  const updatedRound = airdropRoundStore.updateDeployedRoundDeadlineByEpoch(
+    deploymentKey,
+    verifiedUpdate.epoch,
+    verifiedUpdate.deadline,
+    new Date().toISOString(),
+  );
+
+  writeJson(response, 200, {
+    round: serializeAirdropRoundSummary(updatedRound),
+    deadlineUpdate: verifiedUpdate,
+  });
+}
+
 async function handleLinkChallenge(request, response) {
   const session = getRequiredSessionFromCookie(request, response);
   requireCsrf(request, session);
@@ -2187,6 +2301,13 @@ const server = http.createServer(async (request, response) => {
       requireAllowedOrigin(request, response);
       consumeRateLimit(request, "saveRound");
       await handleSaveAirdropRound(request, response);
+      return;
+    }
+
+    if (request.method === "POST" && pathname === "/api/admin/airdrop-rounds/deadline") {
+      requireAllowedOrigin(request, response);
+      consumeRateLimit(request, "updateRoundDeadline");
+      await handleUpdateAirdropRoundDeadline(request, response);
       return;
     }
 

--- a/e2e/helpers/hardhatChain.js
+++ b/e2e/helpers/hardhatChain.js
@@ -8,7 +8,8 @@ const RPC_URL = "http://127.0.0.1:8545";
 const E2E_BACKEND_HOST = "127.0.0.1";
 const E2E_BACKEND_PORT = 8790;
 const E2E_BACKEND_ORIGIN = `http://${E2E_BACKEND_HOST}:${E2E_BACKEND_PORT}`;
-const E2E_FRONTEND_ORIGIN = "http://127.0.0.1:4173";
+const E2E_FRONTEND_PORT = Number.parseInt(process.env.E2E_FRONTEND_PORT || "4173", 10);
+const E2E_FRONTEND_ORIGIN = `http://127.0.0.1:${E2E_FRONTEND_PORT}`;
 const E2E_FRONTEND_RETURN_URL = `${E2E_FRONTEND_ORIGIN}/frontend/`;
 const E2E_DB_PATH = path.join(REPO_ROOT, "data", "e2e.sqlite");
 

--- a/e2e/tests/admin/epoch-management.spec.js
+++ b/e2e/tests/admin/epoch-management.spec.js
@@ -1,6 +1,7 @@
 const { expect, test } = require("../../fixtures/testWithMockWallet");
 const {
   connectViaWalletPicker,
+  fetchStoredRounds,
   getLocalDateTimeInputValue,
   getUtcDateTimeInputValue,
   startAirdropFromUpload,
@@ -11,6 +12,9 @@ test("admin can update an epoch deadline and the update inputs stay synchronized
   await connectViaWalletPicker(page);
   await startAirdropFromUpload(page, e2eClaimsFile);
   await page.getByRole("button", { name: "Contract", exact: true }).click();
+  const beforeRounds = await fetchStoredRounds(page);
+  const beforeRound = beforeRounds.rounds.find((round) => round.epoch === 1);
+  expect(beforeRound).toBeTruthy();
 
   const nextDeadlineUnix = await page.evaluate(() => {
     const nextDeadline = Math.floor(Date.now() / 1000) + (4 * 60 * 60);
@@ -27,6 +31,11 @@ test("admin can update an epoch deadline and the update inputs stay synchronized
   await page.getByRole("button", { name: "Update Deadline" }).click();
   await expect(page.getByText("Update deadline complete.")).toBeVisible();
   await expect(page.locator("#epochListBody")).toContainText("Active");
+
+  const afterRounds = await fetchStoredRounds(page);
+  const afterRound = afterRounds.rounds.find((round) => round.epoch === 1);
+  expect(afterRound.deadline).toBe(Number(nextDeadlineUnix));
+  expect(Date.parse(afterRound.updatedAt)).toBeGreaterThan(Date.parse(beforeRound.updatedAt));
 
   await page.getByRole("button", { name: "Lookups", exact: true }).click();
   await page.locator("#queryEpochInput").fill("1");

--- a/e2e/tests/admin/start-airdrop.spec.js
+++ b/e2e/tests/admin/start-airdrop.spec.js
@@ -2,7 +2,12 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const { expect, test } = require("../../fixtures/testWithMockWallet");
-const { connectViaWalletPicker, setFutureDeadline } = require("../helpers");
+const {
+  connectViaWalletPicker,
+  fetchStoredRounds,
+  getUtcDateTimeInputValue,
+  setFutureDeadline,
+} = require("../helpers");
 
 function writeFixtureFile(testInfo, name, content) {
   const filePath = testInfo.outputPath(name);
@@ -86,4 +91,46 @@ test("admin can build a round from every linked wallet with one shared amount", 
   await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
   await page.getByRole("button", { name: "Deploy" }).first().click();
   await expect(page.locator("#currentEpoch")).toHaveText("1");
+});
+
+test("admin can edit a saved draft deadline before deploying it", async ({ page, e2eClaimsFile }) => {
+  await page.goto("admin.html");
+  await connectViaWalletPicker(page);
+
+  await page.locator("#uploadClaimsFileInput").setInputFiles(e2eClaimsFile);
+  await setFutureDeadline(page, "#startDeadlineInput", 90);
+  await page.getByRole("button", { name: "Save Round to DB" }).click();
+  await expect(page.locator("#selectedRoundLabel")).toContainText("Draft");
+
+  const beforeRounds = await fetchStoredRounds(page);
+  const draftBefore = beforeRounds.rounds.find((round) => round.status === "draft");
+  expect(draftBefore).toBeTruthy();
+
+  await page.locator("#epochListBody tr", { hasText: "Draft" }).getByRole("button", { name: "Edit Deadline" }).click();
+
+  const nextDeadlineUnix = await page.evaluate(() => {
+    const nextDeadline = Math.floor(Date.now() / 1000) + (3 * 60 * 60);
+    return String(Math.floor(nextDeadline / 60) * 60);
+  });
+  const nextDeadlineUtc = await getUtcDateTimeInputValue(page, nextDeadlineUnix);
+  await page.locator("#updateDeadlineUtcInput").fill(nextDeadlineUtc);
+  await page.getByRole("button", { name: "Update Deadline" }).click();
+  await expect(page.getByText("Draft deadline updated.")).toBeVisible();
+
+  const afterRounds = await fetchStoredRounds(page);
+  const draftAfter = afterRounds.rounds.find((round) => round.id === draftBefore.id);
+  expect(draftAfter.deadline).toBe(Number(nextDeadlineUnix));
+  expect(Date.parse(draftAfter.updatedAt)).toBeGreaterThan(Date.parse(draftBefore.updatedAt));
+
+  await page.getByRole("button", { name: "Rounds", exact: true }).click();
+  await expect(page.locator("#epochListBody")).toContainText("Draft");
+  await page.getByRole("button", { name: "Fund Total" }).first().click();
+  await expect(page.getByText("Fund airdrop complete.")).toBeVisible();
+  await page.getByRole("button", { name: "Deploy" }).first().click();
+  await expect(page.getByText("Draft deployed as epoch 1.")).toBeVisible();
+
+  await page.getByRole("button", { name: "Lookups", exact: true }).click();
+  await page.locator("#queryEpochInput").fill("1");
+  await page.getByRole("button", { name: "Fetch Epoch Data" }).click();
+  await expect(page.locator("#epochQueryResult")).toContainText(`"deadline": "${nextDeadlineUnix}"`);
 });

--- a/e2e/tests/helpers.js
+++ b/e2e/tests/helpers.js
@@ -86,9 +86,50 @@ async function startAirdropFromUpload(page, claimsFile, { deadlineSelector = "#s
   await page.getByRole("button", { name: "Prepare" }).click();
 }
 
+async function fetchStoredRounds(page) {
+  return page.evaluate(async (storageKey) => {
+    const configResponse = await fetch("config.local.json", { cache: "no-store" });
+    if (!configResponse.ok) {
+      throw new Error("Unable to load local frontend config.");
+    }
+
+    const config = await configResponse.json();
+    let overrides = {};
+    try {
+      overrides = JSON.parse(window.localStorage.getItem(storageKey) || "{}");
+    } catch {
+      overrides = {};
+    }
+
+    const overrideXAuth = overrides.xAuth && typeof overrides.xAuth === "object" ? overrides.xAuth : {};
+    const configXAuth = config.xAuth && typeof config.xAuth === "object" ? config.xAuth : {};
+    const apiBaseUrl = String(
+      overrides.apiBaseUrl
+      || overrideXAuth.backendUrl
+      || config.apiBaseUrl
+      || configXAuth.backendUrl
+      || "",
+    ).replace(/\/+$/u, "");
+    if (!apiBaseUrl) {
+      throw new Error("Local frontend config does not include an API base URL.");
+    }
+
+    const response = await fetch(`${apiBaseUrl}/api/airdrop/rounds`, {
+      cache: "no-store",
+      credentials: "include",
+    });
+    if (!response.ok) {
+      throw new Error(`Stored rounds request failed with ${response.status}.`);
+    }
+
+    return response.json();
+  }, UI_CONFIG_STORAGE_KEY);
+}
+
 module.exports = {
   connectViaWalletPicker,
   enableXRecovery,
+  fetchStoredRounds,
   getLocalDateTimeInputValue,
   getUtcDateTimeInputValue,
   mockXAuthSession,

--- a/frontend/js/pages/admin.js
+++ b/frontend/js/pages/admin.js
@@ -36,6 +36,7 @@ import {
   isClaimsApiConfigured,
   saveAirdropRound,
   deploySavedAirdropRound,
+  updateStoredAirdropRoundDeadline,
   requestAirdropSaveChallenge,
 } from "../shared/claims.js";
 import {
@@ -124,6 +125,7 @@ const runtime = {
   hasLoadedAccountsTab: false,
   isConnectingWallet: false,
   noticeTimerId: null,
+  deadlineEditTarget: null,
 };
 
 const els = {
@@ -1086,6 +1088,51 @@ function syncDeadlineFromUtc(localInput, utcInput, unixInput) {
   applyDeadlineFields(localInput, utcInput, unixInput, unix);
 }
 
+function clearDeadlineEditTarget() {
+  runtime.deadlineEditTarget = null;
+  els.updateEpochInput.disabled = false;
+  els.updateEpochInput.placeholder = "1";
+  els.disableEpochButton.disabled = false;
+}
+
+function prepareDeadlineEdit(rowKey) {
+  const row = runtime.roundRows.find((candidate) => candidate.key === rowKey) || null;
+  if (!row || !row.canEditDeadline) {
+    throw new Error("This round does not have an editable stored deadline.");
+  }
+
+  runtime.deadlineEditTarget = {
+    rowType: row.rowType,
+    roundId: row.roundId == null ? null : Number(row.roundId),
+    epoch: Number(row.epoch || 0) || null,
+    deadline: Number(row.deadline || 0),
+  };
+
+  if (row.rowType === "draft") {
+    els.updateEpochInput.value = "";
+    els.updateEpochInput.placeholder = `Draft ${row.roundId}`;
+    els.updateEpochInput.disabled = true;
+    els.disableEpochButton.disabled = true;
+  } else {
+    els.updateEpochInput.disabled = false;
+    els.updateEpochInput.value = String(runtime.deadlineEditTarget.epoch || "");
+    els.updateEpochInput.placeholder = "1";
+    els.disableEpochButton.disabled = false;
+  }
+
+  applyDeadlineFields(
+    els.updateDeadlineInput,
+    els.updateDeadlineUtcInput,
+    els.updateDeadlineUnix,
+    row.deadline,
+  );
+  setAdminTab("contract");
+  els.updateDeadlineInput.focus();
+  logger.log(row.rowType === "draft"
+    ? "Draft deadline loaded for editing."
+    : `Epoch ${runtime.deadlineEditTarget.epoch} deadline loaded for editing.`);
+}
+
 function bindNativePicker(input) {
   if (!input) return;
 
@@ -1252,6 +1299,7 @@ function buildRoundRows() {
       key: `draft-${round.id}`,
       rowType: "draft",
       roundId: round.id,
+      epoch: null,
       label: "Draft",
       root: round.merkleRoot,
       deadline: Number(round.deadline || 0),
@@ -1261,6 +1309,7 @@ function buildRoundRows() {
       canFundTotal: true,
       canDeploy: true,
       canViewClaims: true,
+      canEditDeadline: true,
     });
   }
 
@@ -1275,6 +1324,7 @@ function buildRoundRows() {
       key: matchesStoredRound ? `round-${storedRound.id}` : `chain-${chainRow.epoch}`,
       rowType: matchesStoredRound ? "deployed" : "chain-only",
       roundId: matchesStoredRound ? storedRound.id : null,
+      epoch: Number(chainRow.epoch),
       label: `Epoch ${chainRow.epoch}`,
       root: chainRow.root,
       deadline: Number(chainRow.deadline || 0),
@@ -1284,6 +1334,7 @@ function buildRoundRows() {
       canFundTotal: matchesStoredRound,
       canDeploy: false,
       canViewClaims: Boolean(matchesStoredRound),
+      canEditDeadline: Boolean(matchesStoredRound),
     });
   }
 
@@ -1296,6 +1347,7 @@ function buildRoundRows() {
       key: `stored-${round.id}`,
       rowType: "stored-only",
       roundId: round.id,
+      epoch: Number(round.epoch || 0),
       label: formatStoredRoundLabel(round),
       root: round.merkleRoot,
       deadline: Number(round.deadline || 0),
@@ -1305,6 +1357,7 @@ function buildRoundRows() {
       canFundTotal: true,
       canDeploy: false,
       canViewClaims: true,
+      canEditDeadline: false,
     });
   }
 
@@ -1589,7 +1642,8 @@ function renderEpochList() {
             ${row.canDeploy ? `<button type="button" class="secondary table-action-button" data-round-deploy="${row.roundId}">Deploy</button>` : ""}
             ${row.canFundTotal ? `<button type="button" class="ghost table-action-button" data-round-fund="${row.roundId}">Fund Total</button>` : ""}
             ${row.canViewClaims ? `<button type="button" class="ghost table-action-button" data-round-claims="${row.roundId}">View Claims</button>` : ""}
-            ${!row.canDeploy && !row.canFundTotal && !row.canViewClaims ? '<span class="hint">No DB record</span>' : ""}
+            ${row.canEditDeadline ? `<button type="button" class="ghost table-action-button" data-round-deadline="${row.key}">Edit Deadline</button>` : ""}
+            ${!row.canDeploy && !row.canFundTotal && !row.canViewClaims && !row.canEditDeadline ? '<span class="hint">No DB record</span>' : ""}
           </td>
         </tr>
       `;
@@ -1622,6 +1676,16 @@ function renderEpochList() {
         await loadRoundClaims(Number(button.getAttribute("data-round-claims")), { scrollIntoView: true });
       } catch (error) {
         reportError(error, "Load round claims");
+      }
+    });
+  });
+
+  els.epochListBody.querySelectorAll("[data-round-deadline]").forEach((button) => {
+    button.addEventListener("click", () => {
+      try {
+        prepareDeadlineEdit(String(button.getAttribute("data-round-deadline") || ""));
+      } catch (error) {
+        reportError(error, "Edit round deadline");
       }
     });
   });
@@ -2076,6 +2140,39 @@ async function deployStoredRound(roundId) {
   }
 }
 
+async function updateDraftRoundDeadline(target, newDeadline) {
+  const storedRound = runtime.storedRounds.find((round) => round.id === Number(target.roundId)) || null;
+  if (!storedRound || storedRound.status !== "draft") {
+    throw new Error("The selected draft round could not be found.");
+  }
+
+  if (!isClaimsApiConfigured(runtime.config)) {
+    throw new Error("Backend API URL is not configured.");
+  }
+
+  const saveChallenge = await requestAirdropSaveChallenge(runtime.config, {
+    walletAddress: runtime.account,
+    merkleRoot: storedRound.merkleRoot,
+    deadline: newDeadline,
+  });
+  const saveSignature = await runtime.signer.signMessage(saveChallenge.message);
+  const persisted = await updateStoredAirdropRoundDeadline(runtime.config, {
+    roundId: storedRound.id,
+    deadline: newDeadline,
+    walletAddress: runtime.account,
+    challengeId: saveChallenge.challengeId,
+    signature: saveSignature,
+  });
+
+  await refreshPage();
+  if (persisted?.round?.id) {
+    runtime.selectedRoundId = persisted.round.id;
+    await loadRoundClaims(persisted.round.id);
+  }
+  clearDeadlineEditTarget();
+  logger.log("Draft deadline updated.", "success");
+}
+
 async function updateEpochDeadline(newDeadline) {
   const { airdrop } = getContracts({
     config: runtime.config,
@@ -2086,17 +2183,45 @@ async function updateEpochDeadline(newDeadline) {
   if (!airdrop) throw new Error("Airdrop address is not configured.");
 
   const epoch = readRequiredEpoch(els.updateEpochInput, "Epoch");
+  const epochNumber = Number(epoch);
+  const storedRound = runtime.storedRoundsByEpoch.get(epochNumber) || null;
+  const chainRow = runtime.epochRows.find((row) => Number(row.epoch) === epochNumber) || null;
+  const shouldSyncStoredRound = doesStoredRoundMatchChainRow(storedRound, chainRow);
+  let submittedTxHash = "";
   await sendTransaction(
     newDeadline === 0 ? "Disable epoch" : "Update deadline",
     () => airdrop.setEpochDeadline(epoch, newDeadline),
     {
       log: logger.log,
+      afterSubmit: async (tx) => {
+        submittedTxHash = tx.hash;
+      },
       afterSuccess: async () => {
+        if (shouldSyncStoredRound && isClaimsApiConfigured(runtime.config) && submittedTxHash) {
+          await updateStoredAirdropRoundDeadline(runtime.config, {
+            epoch: epochNumber,
+            deadline: newDeadline,
+            txHash: submittedTxHash,
+          });
+        }
         await refreshPage();
       },
       formatError: (error, label) => formatUiError(error, label, runtime),
     },
   );
+  clearDeadlineEditTarget();
+}
+
+async function updateSelectedRoundDeadline(newDeadline) {
+  const target = runtime.deadlineEditTarget;
+  if (target?.rowType === "draft") {
+    await validateFutureDeadlineAgainstChain(newDeadline);
+    await updateDraftRoundDeadline(target, newDeadline);
+    return;
+  }
+
+  await validateFutureDeadlineAgainstChain(newDeadline, { allowZero: true });
+  await updateEpochDeadline(newDeadline);
 }
 
 function bindEvents() {
@@ -2329,6 +2454,11 @@ function bindEvents() {
   els.updateDeadlineUtcInput.addEventListener("input", () => {
     syncDeadlineFromUtc(els.updateDeadlineInput, els.updateDeadlineUtcInput, els.updateDeadlineUnix);
   });
+  els.updateEpochInput.addEventListener("input", () => {
+    if (!els.updateEpochInput.disabled) {
+      clearDeadlineEditTarget();
+    }
+  });
 
   bindNativePicker(els.startDeadlineInput);
   bindNativePicker(els.startDeadlineUtcInput);
@@ -2358,8 +2488,7 @@ function bindEvents() {
     event.preventDefault();
     try {
       const deadlineUnix = Number(els.updateDeadlineUnix.value);
-      await validateFutureDeadlineAgainstChain(deadlineUnix);
-      await updateEpochDeadline(deadlineUnix);
+      await updateSelectedRoundDeadline(deadlineUnix);
     } catch (error) {
       reportError(error, "Update deadline");
     }
@@ -2367,7 +2496,7 @@ function bindEvents() {
 
   els.disableEpochButton.addEventListener("click", async () => {
     try {
-      await updateEpochDeadline(0);
+      await updateSelectedRoundDeadline(0);
     } catch (error) {
       reportError(error, "Disable epoch");
     }

--- a/frontend/js/shared/claims.js
+++ b/frontend/js/shared/claims.js
@@ -146,6 +146,22 @@ export async function deploySavedAirdropRound(config, roundId, payload) {
   });
 }
 
+export async function updateStoredAirdropRoundDeadline(config, payload) {
+  const backendBaseUrl = getBackendBaseUrl(config);
+  if (!backendBaseUrl) {
+    throw new Error("Claim backend URL is not configured.");
+  }
+
+  return fetchBackendJson(`${backendBaseUrl}/api/admin/airdrop-rounds/deadline`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
 export async function requestAirdropSaveChallenge(config, payload) {
   const backendBaseUrl = getBackendBaseUrl(config);
   if (!backendBaseUrl) {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,7 @@
 const { defineConfig } = require("@playwright/test");
 
+const frontendPort = Number.parseInt(process.env.E2E_FRONTEND_PORT || "4173", 10);
+
 module.exports = defineConfig({
   testDir: "./e2e/tests",
   timeout: 90_000,
@@ -10,7 +12,7 @@ module.exports = defineConfig({
   },
   reporter: "list",
   use: {
-    baseURL: "http://127.0.0.1:4173/frontend/",
+    baseURL: `http://127.0.0.1:${frontendPort}/frontend/`,
     headless: true,
     screenshot: "only-on-failure",
     trace: "on-first-retry",
@@ -26,8 +28,8 @@ module.exports = defineConfig({
       timeout: 120_000,
     },
     {
-      command: "node scripts/e2e/static-server.js",
-      port: 4173,
+      command: `PORT=${frontendPort} node scripts/e2e/static-server.js`,
+      port: frontendPort,
       reuseExistingServer: false,
       stdout: "pipe",
       stderr: "pipe",


### PR DESCRIPTION
Closes #10.

## Summary
- add a backend deadline sync endpoint for draft and deployed airdrop rounds
- verify deployed deadline updates against the on-chain DeadlineUpdated event before updating SQLite
- add admin UI controls to edit draft deadlines and mirror deployed epoch deadline changes
- extend e2e coverage for draft deadline edits, deployed deadline sync, and updated_at changes

## Validation
- npm test
- E2E_FRONTEND_PORT=4273 npx playwright test e2e/tests/admin/epoch-management.spec.js e2e/tests/admin/start-airdrop.spec.js
- node --check backend/server.js backend/lib/airdrop-chain.js backend/lib/airdrop-round-store.js frontend/js/shared/claims.js frontend/js/pages/admin.js e2e/tests/helpers.js e2e/tests/admin/epoch-management.spec.js e2e/tests/admin/start-airdrop.spec.js playwright.config.js e2e/helpers/hardhatChain.js
- git diff --check

Note: I used E2E_FRONTEND_PORT=4273 locally because another dev server was already occupying 4173.