### PR TITLE
test: cover X recovery empty claims state

### DIFF
--- a/e2e/tests/claim/claim-flow.spec.js
+++ b/e2e/tests/claim/claim-flow.spec.js
@@ -7,7 +7,7 @@ test("@smoke claimant can claim from the wrong network after wallet switch", asy
   await startAirdropFromUpload(page, e2eClaimsFile);
 
   await mockWallet.setAccount(page, mockWallet.accounts.claimant);
-  await mockWallet.setChainId(page, toHexChainId(31337));
+  await mockWallet.setChainId(page, toHexChainId(1337));
 
   await page.goto("index.html");
   await expect(page.getByRole("button", { name: /0x7099\.\.\.79c8/i })).toBeVisible();

--- a/e2e/tests/claim/wallet-menu.spec.js
+++ b/e2e/tests/claim/wallet-menu.spec.js
@@ -26,6 +26,24 @@ test("claimant wallet menu shows the connected address, chain id, and disconnect
   await expect(page.getByText("Available claims will appear here after you connect.")).toBeVisible();
 });
 
+test("claimant wallet with no claims sees X recovery instead of the generic empty state", async ({ page, hardhatChain }) => {
+  await enableXRecovery(page, hardhatChain.backendUrl);
+
+  await page.goto("index.html");
+  await connectViaWalletPicker(page);
+
+  await expect(page.getByRole("button", { name: /0xf39f\.\.\.2266/i })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sign In With X" })).toBeVisible();
+  await expect(page.getByText("No claim was found for this wallet. Sign in with X to start follower recovery.")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Available Claims" })).toHaveCount(0);
+  await expect(page.getByText("Nothing available right now.")).toHaveCount(0);
+  await expect(page.getByText("If anything is available for this wallet, it will appear here.")).toHaveCount(0);
+
+  await openWalletMenu(page, /0xf39f\.\.\.2266/i);
+  await expect(page.locator("#walletMenu")).toBeVisible();
+  await expect(page.locator("#walletMenuChainId")).toHaveText("1337");
+});
+
 test("wallet picker merges a provider-array wallet with the same EIP-6963 wallet announcement", async ({ page }) => {
   await page.addInitScript(() => {
     const icon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Crect width='1' height='1' fill='%23f6851b'/%3E%3C/svg%3E";


### PR DESCRIPTION
Closes #12.

Stacked on #25 / `codex/issue-10-round-deadline-sync` so this can be merged after the deadline-sync PR.

## Summary
- add wallet-menu regression coverage for a connected wallet with no claims when X recovery is offered
- assert the X recovery section is shown while the generic Available Claims empty state is hidden
- preserve nearby coverage that the generic empty state still appears when X recovery is not offered
- fix the claim-flow wrong-network smoke setup to use chain `1337` as the wrong chain while local Hardhat config is `31337`

## Code review notes
- `frontend/js/pages/claim.js` already gates `availableClaimsBlock` and clears `roundList` when `isXRecoveryOffered()` and there are no visible rounds; no source change was needed
- the new regression directly covers the issue state without deploying a round first

## Validation
- `npm test` -> 37 passing Hardhat tests
- `E2E_FRONTEND_PORT=4273 npx playwright test e2e/tests/claim/claim-flow.spec.js -g "claimant can claim from the wrong network"` -> 1 passing
- `E2E_FRONTEND_PORT=4273 npx playwright test e2e/tests/claim/wallet-menu.spec.js e2e/tests/claim/claim-flow.spec.js` -> 25 passing
- `node --check e2e/tests/claim/claim-flow.spec.js e2e/tests/claim/wallet-menu.spec.js frontend/js/pages/claim.js`
- `git diff --check`

Note: Hardhat emits the existing Node v23 unsupported warning locally, but tests completed successfully.