### PR TITLE
Bump liberdus-wallet-module to 6da2af4

### DIFF
--- a/e2e/tests/claim/claim-flow.spec.js
+++ b/e2e/tests/claim/claim-flow.spec.js
@@ -7,7 +7,7 @@ test("@smoke claimant can claim from the wrong network after wallet switch", asy
   await startAirdropFromUpload(page, e2eClaimsFile);
 
   await mockWallet.setAccount(page, mockWallet.accounts.claimant);
-  await mockWallet.setChainId(page, toHexChainId(1337));
+  await mockWallet.setChainId(page, toHexChainId(31337));
 
   await page.goto("index.html");
   await expect(page.getByRole("button", { name: /0x7099\.\.\.79c8/i })).toBeVisible();


### PR DESCRIPTION
## Summary
Bumps `vendor/liberdus-wallet-module` to `6da2af4`, the latest shared wallet module commit.

This brings in the wallet discovery and session fixes from the module: connected wallet state now stays aligned when a late EIP-6963 announcement replaces a legacy injected provider, and read-only discovery no longer probes browser window aliases such as `self`, `top`, or `parent` as wallet namespaces.

Also updates the claim smoke test so its wrong-network scenario actually starts on a different chain from the local app config. The local airdrop config uses chain `1337`; the test previously also moved the mock wallet to `1337`, which meant the wallet was already on the correct network. With the wallet module bump, provider and chain state restore more accurately, so the UI correctly rendered `Claim` instead of `Switch Network to Claim`. The test now uses `31337` so it genuinely exercises the switch-network path.

Fixes #29.

## Why
This app gets its wallet behavior through the shared wallet module. Updating the submodule keeps the app on the fixed connection/discovery behavior, avoiding stale provider references after replacement and unnecessary default-provider probes during discovery.

The smoke test adjustment keeps CI aligned with the intended scenario: the app should show the switch-network action only when the connected wallet is truly off the configured chain.

## Validation
- `npm test`
- `npm run test:e2e:smoke`